### PR TITLE
feat: Paperless-ngx direct upload (additive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ Point `OUTPUT_DIR` at Paperless-ngx's consume directory (typically `./consume` o
 PRINTER_IP=192.0.2.58 OUTPUT_DIR=/srv/paperless/consume npm run dev
 ```
 
+### Direct upload (alternative to consume folder)
+
+If you'd rather have scans POSTed straight into Paperless-ngx's API than dropped into its consume folder, set:
+
+| Var | Required for direct upload | Default | What it does |
+|---|---|---|---|
+| `PAPERLESS_URL` | yes | — | Base URL of your Paperless-ngx, e.g. `http://paperless:8000`. The service appends `/api/documents/post_document/` — just give it the host. |
+| `PAPERLESS_TOKEN` | yes | — | API token. Create via Paperless-ngx admin → Users → your user → API token. |
+| `PAPERLESS_TOKEN_FILE` | | — | Alternative to `PAPERLESS_TOKEN` — read the token from a file. For Docker secrets / Kubernetes. Takes precedence if both are set. |
+| `PAPERLESS_DELETE_AFTER_UPLOAD` | | `false` | Delete the local file after a successful upload. |
+
+When both URL and token are set, every scan is uploaded to Paperless-ngx **after** the local file is written. The local file stays by default — the upload is additive. If the upload fails (network blip, Paperless-ngx down), the scan is still safe in `OUTPUT_DIR` and you can re-upload manually or fall back to the consume-folder path.
+
+Multi-page ADF scans in JPG mode upload one document per page. Pick **PDF** on the printer panel if you'd rather have them grouped into a single Paperless-ngx document.
+
 ## Troubleshooting
 
 **Destination doesn't appear on the printer panel.**

--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ PRINTER_IP=192.0.2.58 OUTPUT_DIR=/srv/paperless/consume npm run dev
 
 If you'd rather have scans POSTed straight into Paperless-ngx's API than dropped into its consume folder, set:
 
-| Var | Required for direct upload | Default | What it does |
-|---|---|---|---|
-| `PAPERLESS_URL` | yes | — | Base URL of your Paperless-ngx, e.g. `http://paperless:8000`. The service appends `/api/documents/post_document/` — just give it the host. |
-| `PAPERLESS_TOKEN` | yes | — | API token. Create via Paperless-ngx admin → Users → your user → API token. |
-| `PAPERLESS_TOKEN_FILE` | | — | Alternative to `PAPERLESS_TOKEN` — read the token from a file. For Docker secrets / Kubernetes. Takes precedence if both are set. |
-| `PAPERLESS_DELETE_AFTER_UPLOAD` | | `false` | Delete the local file after a successful upload. |
+| Var                             | Required for direct upload | Default | What it does                                                                                                                               |
+| ------------------------------- | -------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `PAPERLESS_URL`                 | yes                        | —       | Base URL of your Paperless-ngx, e.g. `http://paperless:8000`. The service appends `/api/documents/post_document/` — just give it the host. |
+| `PAPERLESS_TOKEN`               | yes                        | —       | API token. Create via Paperless-ngx admin → Users → your user → API token.                                                                 |
+| `PAPERLESS_TOKEN_FILE`          |                            | —       | Alternative to `PAPERLESS_TOKEN` — read the token from a file. For Docker secrets / Kubernetes. Takes precedence if both are set.          |
+| `PAPERLESS_DELETE_AFTER_UPLOAD` |                            | `false` | Delete the local file after a successful upload.                                                                                           |
 
 When both URL and token are set, every scan is uploaded to Paperless-ngx **after** the local file is written. The local file stays by default — the upload is additive. If the upload fails (network blip, Paperless-ngx down), the scan is still safe in `OUTPUT_DIR` and you can re-upload manually or fall back to the consume-folder path.
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { loadConfig } from "./config.js";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { loadConfig, isPaperlessEnabled } from "./config.js";
 
 describe("loadConfig", () => {
   beforeEach(() => {
@@ -14,6 +17,10 @@ describe("loadConfig", () => {
     delete process.env.PREVIEW_ACTION;
     delete process.env.TEMP_DIR;
     delete process.env.SHUTDOWN_TIMEOUT_MS;
+    delete process.env.PAPERLESS_URL;
+    delete process.env.PAPERLESS_TOKEN;
+    delete process.env.PAPERLESS_TOKEN_FILE;
+    delete process.env.PAPERLESS_DELETE_AFTER_UPLOAD;
   });
 
   it("throws if PRINTER_IP is missing", () => {
@@ -114,5 +121,76 @@ describe("loadConfig", () => {
     process.env.PRINTER_IP = "192.0.2.58";
     process.env.SHUTDOWN_TIMEOUT_MS = "not-a-number";
     expect(() => loadConfig()).toThrow();
+  });
+
+  it("picks up PAPERLESS_URL + PAPERLESS_TOKEN from env", () => {
+    process.env.PRINTER_IP = "192.0.2.58";
+    process.env.PAPERLESS_URL = "http://paperless.lan:8000";
+    process.env.PAPERLESS_TOKEN = "abc123";
+    const config = loadConfig();
+    expect(config.paperlessUrl).toBe("http://paperless.lan:8000");
+    expect(config.paperlessToken).toBe("abc123");
+    expect(config.paperlessDeleteAfterUpload).toBe(false);
+  });
+
+  it("reads PAPERLESS_TOKEN_FILE from disk and trims whitespace", () => {
+    process.env.PRINTER_IP = "192.0.2.58";
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "paperless-test-"));
+    const tokenFile = path.join(tmp, "token");
+    try {
+      writeFileSync(tokenFile, "  file-token-xyz  \n");
+      process.env.PAPERLESS_URL = "http://paperless.lan:8000";
+      process.env.PAPERLESS_TOKEN_FILE = tokenFile;
+      const config = loadConfig();
+      expect(config.paperlessToken).toBe("file-token-xyz");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("PAPERLESS_TOKEN_FILE takes precedence over PAPERLESS_TOKEN when both set", () => {
+    process.env.PRINTER_IP = "192.0.2.58";
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "paperless-test-"));
+    const tokenFile = path.join(tmp, "token");
+    try {
+      writeFileSync(tokenFile, "from-file");
+      process.env.PAPERLESS_URL = "http://paperless.lan:8000";
+      process.env.PAPERLESS_TOKEN = "from-env";
+      process.env.PAPERLESS_TOKEN_FILE = tokenFile;
+      const config = loadConfig();
+      expect(config.paperlessToken).toBe("from-file");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("throws at startup when PAPERLESS_TOKEN_FILE points at a nonexistent path", () => {
+    process.env.PRINTER_IP = "192.0.2.58";
+    process.env.PAPERLESS_URL = "http://paperless.lan:8000";
+    process.env.PAPERLESS_TOKEN_FILE = "/definitely/does/not/exist";
+    expect(() => loadConfig()).toThrow(/PAPERLESS_TOKEN_FILE/);
+  });
+
+  it("isPaperlessEnabled returns false when URL or token is missing", () => {
+    process.env.PRINTER_IP = "192.0.2.58";
+
+    // No vars set — both undefined
+    let config = loadConfig();
+    expect(isPaperlessEnabled(config)).toBe(false);
+
+    // URL only
+    process.env.PAPERLESS_URL = "http://paperless.lan:8000";
+    config = loadConfig();
+    expect(isPaperlessEnabled(config)).toBe(false);
+
+    // URL + token — enabled
+    process.env.PAPERLESS_TOKEN = "abc";
+    config = loadConfig();
+    expect(isPaperlessEnabled(config)).toBe(true);
+
+    // Token only (url cleared)
+    delete process.env.PAPERLESS_URL;
+    config = loadConfig();
+    expect(isPaperlessEnabled(config)).toBe(false);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { z } from "zod";
 
 const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}$/;
@@ -17,11 +18,28 @@ const configSchema = z.object({
   previewAction: z.enum(["reject", "jpg", "pdf"]).default("reject"),
   tempDir: z.string().default(""),
   shutdownTimeoutMs: z.coerce.number().int().min(100).default(30000),
+  paperlessUrl: z.string().url("PAPERLESS_URL must be a valid URL").optional(),
+  paperlessToken: z.string().optional(),
+  paperlessDeleteAfterUpload: z.boolean().default(false),
 });
 
 export type Config = z.infer<typeof configSchema>;
 
 export function loadConfig(): Config {
+  // Resolve PAPERLESS_TOKEN — PAPERLESS_TOKEN_FILE takes precedence when both
+  // are set. A missing / unreadable _TOKEN_FILE is a startup error.
+  let paperlessToken: string | undefined;
+  if (process.env.PAPERLESS_TOKEN_FILE) {
+    try {
+      paperlessToken = readFileSync(process.env.PAPERLESS_TOKEN_FILE, "utf8").trim();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`PAPERLESS_TOKEN_FILE is set but cannot be read: ${msg}`);
+    }
+  } else if (process.env.PAPERLESS_TOKEN) {
+    paperlessToken = process.env.PAPERLESS_TOKEN;
+  }
+
   const raw = {
     printerIp: process.env.PRINTER_IP,
     scanDestName: process.env.SCAN_DEST_NAME || undefined,
@@ -34,7 +52,14 @@ export function loadConfig(): Config {
     previewAction: process.env.PREVIEW_ACTION || undefined,
     tempDir: process.env.TEMP_DIR || undefined,
     shutdownTimeoutMs: process.env.SHUTDOWN_TIMEOUT_MS || undefined,
+    paperlessUrl: process.env.PAPERLESS_URL || undefined,
+    paperlessToken,
+    paperlessDeleteAfterUpload: process.env.PAPERLESS_DELETE_AFTER_UPLOAD === "true",
   };
 
   return configSchema.parse(raw);
+}
+
+export function isPaperlessEnabled(config: Config): boolean {
+  return Boolean(config.paperlessUrl && config.paperlessToken);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { loadConfig } from "./config.js";
+import { loadConfig, isPaperlessEnabled } from "./config.js";
 import { setLogLevel, createLogger } from "./logger.js";
 import { getLocalIpForTarget } from "./network.js";
 import { createKeepaliveResponder } from "./keepalive.js";
@@ -6,6 +6,7 @@ import { createPushScanServer, resolveEffectiveAction } from "./pushscan.js";
 import { startScanSession } from "./scanner.js";
 import { createHealthServer, setLastScanTime } from "./health.js";
 import { createInflightTracker, shutdown as runShutdown } from "./lifecycle.js";
+import type { PaperlessUploadOptions } from "./paperless-upload.js";
 
 const log = createLogger("main");
 
@@ -17,6 +18,18 @@ async function main() {
   log.info(`Printer IP: ${config.printerIp}`);
   log.info(`Destination name: ${config.scanDestName}`);
   log.info(`Output directory: ${config.outputDir}`);
+
+  const hasUrl = Boolean(config.paperlessUrl);
+  const hasToken = Boolean(config.paperlessToken);
+  if (hasUrl && hasToken) {
+    log.info(`Paperless upload: enabled (${config.paperlessUrl})`);
+  } else if (hasUrl || hasToken) {
+    log.warn(
+      "Paperless upload disabled: both PAPERLESS_URL and PAPERLESS_TOKEN (or PAPERLESS_TOKEN_FILE) must be set",
+    );
+  } else {
+    log.info("Paperless upload: disabled (no PAPERLESS_URL/PAPERLESS_TOKEN)");
+  }
 
   const localIp = await getLocalIpForTarget(config.printerIp);
   log.info(`Local IP: ${localIp}`);
@@ -51,6 +64,14 @@ async function main() {
     );
     setLastScanTime(new Date().toISOString());
 
+    const paperless: PaperlessUploadOptions | undefined = isPaperlessEnabled(config)
+      ? {
+          url: config.paperlessUrl!,
+          token: config.paperlessToken!,
+          deleteAfterUpload: config.paperlessDeleteAfterUpload,
+        }
+      : undefined;
+
     const scanPromise = startScanSession({
       printerIp: config.printerIp,
       port: 1865,
@@ -59,6 +80,7 @@ async function main() {
       tempDir: config.tempDir,
       duplex: info.duplex,
       action: effective,
+      paperless,
     });
     void inflight.track(scanPromise);
   });

--- a/src/paperless-upload.test.ts
+++ b/src/paperless-upload.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { uploadAllToPaperless } from "./paperless-upload.js";
+
+function makeFiles(names: string[]): { dir: string; paths: string[] } {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "paperless-upload-test-"));
+  const paths = names.map((n) => {
+    const p = path.join(dir, n);
+    writeFileSync(p, Buffer.from([0xff, 0xd8, 0xff, 0xd9])); // minimal JPEG
+    return p;
+  });
+  return { dir, paths };
+}
+
+describe("uploadAllToPaperless", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uploads a single file with correct URL, headers, and form field", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("task-uuid-123", { status: 201 }));
+    const { dir, paths } = makeFiles(["scan_2026-04-23.jpg"]);
+    try {
+      await uploadAllToPaperless(paths, {
+        url: "http://paperless.lan:8000",
+        token: "abc123",
+        deleteAfterUpload: false,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("http://paperless.lan:8000/api/documents/post_document/");
+      expect(init.method).toBe("POST");
+      expect(init.headers).toEqual({ Authorization: "Token abc123" });
+      const formData = init.body as FormData;
+      expect(formData.get("document")).toBeInstanceOf(Blob);
+      expect(existsSync(paths[0])).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("deletes the local file after upload when deleteAfterUpload is true", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("ok", { status: 201 }));
+    const { dir, paths } = makeFiles(["scan.pdf"]);
+    try {
+      await uploadAllToPaperless(paths, {
+        url: "http://paperless.lan:8000",
+        token: "abc123",
+        deleteAfterUpload: true,
+      });
+      expect(existsSync(paths[0])).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uploads N files in parallel", async () => {
+    let concurrentCalls = 0;
+    let maxConcurrent = 0;
+    fetchMock.mockImplementation(async () => {
+      concurrentCalls++;
+      maxConcurrent = Math.max(maxConcurrent, concurrentCalls);
+      await new Promise((r) => setTimeout(r, 20));
+      concurrentCalls--;
+      return new Response("ok", { status: 201 });
+    });
+    const { dir, paths } = makeFiles(["a.jpg", "b.jpg", "c.jpg"]);
+    try {
+      await uploadAllToPaperless(paths, {
+        url: "http://paperless.lan:8000",
+        token: "t",
+        deleteAfterUpload: false,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(maxConcurrent).toBe(3);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not throw when an upload returns a non-2xx response", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("Unauthorized", { status: 401 }));
+    const { dir, paths } = makeFiles(["scan.jpg"]);
+    try {
+      await expect(
+        uploadAllToPaperless(paths, {
+          url: "http://paperless.lan:8000",
+          token: "bad",
+          deleteAfterUpload: true,
+        }),
+      ).resolves.toBeUndefined();
+      expect(existsSync(paths[0])).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("with partial failure, only successful uploads are deleted", async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response("ok", { status: 201 })) // a → success
+      .mockResolvedValueOnce(new Response("server down", { status: 500 })) // b → fail
+      .mockResolvedValueOnce(new Response("ok", { status: 201 })); // c → success
+    const { dir, paths } = makeFiles(["a.jpg", "b.jpg", "c.jpg"]);
+    try {
+      await uploadAllToPaperless(paths, {
+        url: "http://paperless.lan:8000",
+        token: "t",
+        deleteAfterUpload: true,
+      });
+      expect(existsSync(paths[0])).toBe(false);
+      expect(existsSync(paths[1])).toBe(true);
+      expect(existsSync(paths[2])).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not throw when fetch itself rejects (network error)", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("fetch failed"));
+    const { dir, paths } = makeFiles(["scan.jpg"]);
+    try {
+      await expect(
+        uploadAllToPaperless(paths, {
+          url: "http://paperless.lan:8000",
+          token: "t",
+          deleteAfterUpload: true,
+        }),
+      ).resolves.toBeUndefined();
+      expect(existsSync(paths[0])).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not leak the auth token into logs", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      fetchMock.mockRejectedValueOnce(new TypeError("fetch failed"));
+      const { dir, paths } = makeFiles(["scan.jpg"]);
+      try {
+        await uploadAllToPaperless(paths, {
+          url: "http://paperless.lan:8000",
+          token: "secret-token-xyz",
+          deleteAfterUpload: false,
+        });
+        const allLogArgs = [
+          ...logSpy.mock.calls.flat(),
+          ...errSpy.mock.calls.flat(),
+        ]
+          .map((arg) => (typeof arg === "string" ? arg : JSON.stringify(arg)))
+          .join("\n");
+        expect(allLogArgs).not.toContain("secret-token-xyz");
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    } finally {
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+
+  it("handles various URL shapes correctly (trailing slash, sub-path)", async () => {
+    fetchMock.mockResolvedValue(new Response("ok", { status: 201 }));
+    const { dir, paths } = makeFiles(["scan.jpg"]);
+    try {
+      await uploadAllToPaperless(paths, {
+        url: "http://paperless.lan:8000",
+        token: "t",
+        deleteAfterUpload: false,
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        "http://paperless.lan:8000/api/documents/post_document/",
+      );
+
+      fetchMock.mockClear();
+      await uploadAllToPaperless(paths, {
+        url: "http://paperless.lan:8000/",
+        token: "t",
+        deleteAfterUpload: false,
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        "http://paperless.lan:8000/api/documents/post_document/",
+      );
+
+      fetchMock.mockClear();
+      await uploadAllToPaperless(paths, {
+        url: "http://host.lan/paperless",
+        token: "t",
+        deleteAfterUpload: false,
+      });
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        "http://host.lan/paperless/api/documents/post_document/",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/paperless-upload.test.ts
+++ b/src/paperless-upload.test.ts
@@ -15,10 +15,10 @@ function makeFiles(names: string[]): { dir: string; paths: string[] } {
 }
 
 describe("uploadAllToPaperless", () => {
-  let fetchMock: ReturnType<typeof vi.fn>;
+  let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
 
   beforeEach(() => {
-    fetchMock = vi.fn();
+    fetchMock = vi.fn<typeof fetch>();
     vi.stubGlobal("fetch", fetchMock);
   });
 

--- a/src/paperless-upload.test.ts
+++ b/src/paperless-upload.test.ts
@@ -154,10 +154,7 @@ describe("uploadAllToPaperless", () => {
           token: "secret-token-xyz",
           deleteAfterUpload: false,
         });
-        const allLogArgs = [
-          ...logSpy.mock.calls.flat(),
-          ...errSpy.mock.calls.flat(),
-        ]
+        const allLogArgs = [...logSpy.mock.calls.flat(), ...errSpy.mock.calls.flat()]
           .map((arg) => (typeof arg === "string" ? arg : JSON.stringify(arg)))
           .join("\n");
         expect(allLogArgs).not.toContain("secret-token-xyz");

--- a/src/paperless-upload.ts
+++ b/src/paperless-upload.ts
@@ -1,0 +1,79 @@
+import { readFileSync, unlinkSync } from "node:fs";
+import { basename, extname } from "node:path";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("paperless");
+
+const UPLOAD_PATH = "/api/documents/post_document/";
+
+export interface PaperlessUploadOptions {
+  /** Base URL of the Paperless-ngx instance, e.g. "http://paperless:8000". */
+  url: string;
+  /**
+   * API token. Sent as `Authorization: Token <value>`. Never logged —
+   * if a future debug-tracing layer is added to fetch calls elsewhere,
+   * that code path must redact this header explicitly.
+   */
+  token: string;
+  /** When true, unlink a file after a successful upload of that file. */
+  deleteAfterUpload: boolean;
+}
+
+function contentTypeFor(filePath: string): string {
+  const ext = extname(filePath).toLowerCase();
+  if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
+  if (ext === ".pdf") return "application/pdf";
+  return "application/octet-stream";
+}
+
+function buildUploadUrl(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  return trimmed + UPLOAD_PATH;
+}
+
+async function uploadOne(
+  filePath: string,
+  opts: PaperlessUploadOptions,
+): Promise<void> {
+  const bytes = readFileSync(filePath);
+  const blob = new Blob([bytes], { type: contentTypeFor(filePath) });
+  const form = new FormData();
+  form.append("document", blob, basename(filePath));
+
+  const response = await fetch(buildUploadUrl(opts.url), {
+    method: "POST",
+    headers: { Authorization: `Token ${opts.token}` },
+    body: form,
+  });
+
+  const body = await response.text();
+  if (response.status === 200 || response.status === 201) {
+    log.info(`Paperless upload complete: ${basename(filePath)} → ${body.trim()}`);
+    if (opts.deleteAfterUpload) {
+      unlinkSync(filePath);
+      log.debug(`Deleted local file after upload: ${filePath}`);
+    }
+    return;
+  }
+
+  // Intentional: do not throw. The scan is complete because the local
+  // file was written before this function was called.
+  log.error(
+    `Paperless upload failed for ${basename(filePath)}: ${response.status} ${response.statusText} — ${body.slice(0, 500)}`,
+  );
+}
+
+export async function uploadAllToPaperless(
+  filePaths: string[],
+  opts: PaperlessUploadOptions,
+): Promise<void> {
+  log.info(`Uploading ${filePaths.length} file(s) to Paperless-ngx`);
+  await Promise.allSettled(
+    filePaths.map((p) =>
+      uploadOne(p, opts).catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.error(`Paperless upload failed for ${basename(p)}: ${msg}`);
+      }),
+    ),
+  );
+}

--- a/src/paperless-upload.ts
+++ b/src/paperless-upload.ts
@@ -31,10 +31,7 @@ function buildUploadUrl(baseUrl: string): string {
   return trimmed + UPLOAD_PATH;
 }
 
-async function uploadOne(
-  filePath: string,
-  opts: PaperlessUploadOptions,
-): Promise<void> {
+async function uploadOne(filePath: string, opts: PaperlessUploadOptions): Promise<void> {
   const bytes = readFileSync(filePath);
   const blob = new Blob([bytes], { type: contentTypeFor(filePath) });
   const form = new FormData();

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -29,6 +29,7 @@ import {
 } from "./output.js";
 import { setJpegOrientation } from "./exif.js";
 import { composePdfFromJpegs } from "./pdf.js";
+import { uploadAllToPaperless, type PaperlessUploadOptions } from "./paperless-upload.js";
 
 const log = createLogger("scanner");
 
@@ -48,6 +49,12 @@ export interface ScanSession {
   duplex: boolean;
   /** Effective output format, already resolved against PREVIEW_ACTION. */
   action: "jpg" | "pdf";
+  /**
+   * Optional Paperless-ngx upload config. When present, each output file
+   * is POSTed to Paperless-ngx after being written locally. Absent means
+   * no upload — current default behaviour preserved.
+   */
+  paperless?: PaperlessUploadOptions;
 }
 
 /**
@@ -952,6 +959,9 @@ export function startScanSession(
               "jpg",
             );
             log.info(`Scan complete — wrote ${saved.length} JPG file(s); first: ${saved[0]}`);
+            if (session.paperless) {
+              await uploadAllToPaperless(saved, session.paperless);
+            }
           } else {
             // PDF branch
             try {
@@ -961,6 +971,9 @@ export function startScanSession(
               const pdfName = generateFilename(sessionTs, "pdf");
               const savedPath = writeOutputFile(session.outputDir, pdfName, pdfBuf);
               log.info(`Scan complete — saved PDF to ${savedPath}`);
+              if (session.paperless) {
+                await uploadAllToPaperless([savedPath], session.paperless);
+              }
             } catch (err) {
               const msg = err instanceof Error ? err.message : String(err);
               log.error(`PDF composition failed: ${msg}. Falling back to JPG output.`);
@@ -971,6 +984,9 @@ export function startScanSession(
                 "jpg",
               );
               log.info(`Saved ${saved.length} JPG file(s) as fallback`);
+              if (session.paperless) {
+                await uploadAllToPaperless(saved, session.paperless);
+              }
             }
           }
         } finally {


### PR DESCRIPTION
## Summary

When `PAPERLESS_URL` and `PAPERLESS_TOKEN` are configured, every scan is POSTed to Paperless-ngx's `/api/documents/post_document/` endpoint **after** the local file is written. Purely additive — when the env vars aren't set, behaviour is unchanged.

- Multi-page ADF JPG → N parallel uploads, one Paperless document per page.
- ADF/flatbed PDF → one Paperless document.
- Upload failures log at ERROR and never throw; the local file is always there as a fallback.
- Optional `PAPERLESS_DELETE_AFTER_UPLOAD=true` removes the local file after a 2xx.
- `PAPERLESS_TOKEN_FILE` supports the Docker-secrets pattern (takes precedence over `PAPERLESS_TOKEN`).

## Implementation

- New `src/paperless-upload.ts` module — Node 22 stdlib `fetch` + `FormData`, **zero new runtime deps**.
- `src/scanner.ts` `finalizeScan` calls the upload at the end of the JPG, PDF, and PDF-fallback branches.
- `src/config.ts` adds the four new env vars + `isPaperlessEnabled` helper.
- `src/index.ts` startup logs the Paperless state explicitly (enabled / disabled / half-set WARN).
- `README.md` gets a "Direct upload (alternative to consume folder)" subsection under "Pair with Paperless-ngx".

## Test plan

Unit suite (automated, in CI):

- [x] `npm test` — 196 passing (was 183; +5 config, +8 paperless-upload).
- [x] `npm run lint` — clean.
- [x] Replay fixtures in `src/scanner.test.ts` still pass byte-for-byte (no protocol changes).
- [x] Smoke-tested all three startup branches: no config → "disabled (no PAPERLESS_URL/PAPERLESS_TOKEN)"; URL only → WARN "both PAPERLESS_URL and PAPERLESS_TOKEN must be set"; full config → "enabled (\<URL>)".

Hardware verification matrix (manual, post-merge):

- [ ] **H5** — 2-page ADF JPG, Paperless enabled → 2 separate Paperless documents; both local JPGs retained.
- [ ] **H6** — 2-page ADF PDF, Paperless enabled → 1 Paperless 2-page document; local PDF retained.
- [ ] **H7** — Flatbed JPG with `PAPERLESS_DELETE_AFTER_UPLOAD=true` → 1 Paperless document; local JPG removed after upload.

Spec: `.reference/superpowers/specs/2026-04-23-paperless-direct-upload-design.md`
Plan: `.reference/superpowers/plans/2026-04-23-paperless-direct-upload.md`