### PR TITLE
feat: default PAPERLESS_DELETE_AFTER_UPLOAD=true + tighten Event Mgr line

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you'd rather have scans POSTed straight into Paperless-ngx's API than dropped
 | `PAPERLESS_URL`                 | yes                        | —       | Base URL of your Paperless-ngx, e.g. `http://paperless:8000`. The service appends `/api/documents/post_document/` — just give it the host. |
 | `PAPERLESS_TOKEN`               | yes                        | —       | API token. Create via Paperless-ngx admin → Users → your user → API token.                                                                 |
 | `PAPERLESS_TOKEN_FILE`          |                            | —       | Alternative to `PAPERLESS_TOKEN` — read the token from a file. For Docker secrets / Kubernetes. Takes precedence if both are set.          |
-| `PAPERLESS_DELETE_AFTER_UPLOAD` |                            | `false` | Delete the local file after a successful upload.                                                                                           |
+| `PAPERLESS_DELETE_AFTER_UPLOAD` |                            | `true`  | Delete the local file after a successful upload. Set to `false` to keep a local copy.                                                      |
 
 When both URL and token are set, every scan is uploaded to Paperless-ngx **after** the local file is written. The local file stays by default — the upload is additive. If the upload fails (network blip, Paperless-ngx down), the scan is still safe in `OUTPUT_DIR` and you can re-upload manually or fall back to the consume-folder path.
 
@@ -99,7 +99,7 @@ The printer broadcasts a discovery beacon roughly once a minute; wait at least 6
 
 - Confirm the PC is on the same subnet as the printer. Try `ping <printer-ip>`.
 - Check your firewall — UDP port `2968` needs to be allowed for multicast traffic from the printer.
-- Make sure no other Epson software (e.g. Epson Event Manager) is running on the same PC — it can fight over the same port.
+- Make sure Epson Event Manager isn't running on the same PC — it binds the same port. Other Epson software (drivers, ScanSmart) is fine.
 
 **Service hangs after a scan.**
 Rare edge case. Restart the service with `Ctrl-C` and relaunch.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -123,13 +123,22 @@ describe("loadConfig", () => {
     expect(() => loadConfig()).toThrow();
   });
 
-  it("picks up PAPERLESS_URL + PAPERLESS_TOKEN from env", () => {
+  it("picks up PAPERLESS_URL + PAPERLESS_TOKEN from env (defaults to delete-after-upload=true)", () => {
     process.env.PRINTER_IP = "192.0.2.58";
     process.env.PAPERLESS_URL = "http://paperless.lan:8000";
     process.env.PAPERLESS_TOKEN = "abc123";
     const config = loadConfig();
     expect(config.paperlessUrl).toBe("http://paperless.lan:8000");
     expect(config.paperlessToken).toBe("abc123");
+    expect(config.paperlessDeleteAfterUpload).toBe(true);
+  });
+
+  it("PAPERLESS_DELETE_AFTER_UPLOAD=false explicitly opts out of deletion", () => {
+    process.env.PRINTER_IP = "192.0.2.58";
+    process.env.PAPERLESS_URL = "http://paperless.lan:8000";
+    process.env.PAPERLESS_TOKEN = "abc123";
+    process.env.PAPERLESS_DELETE_AFTER_UPLOAD = "false";
+    const config = loadConfig();
     expect(config.paperlessDeleteAfterUpload).toBe(false);
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,7 @@ const configSchema = z.object({
   shutdownTimeoutMs: z.coerce.number().int().min(100).default(30000),
   paperlessUrl: z.string().url("PAPERLESS_URL must be a valid URL").optional(),
   paperlessToken: z.string().optional(),
-  paperlessDeleteAfterUpload: z.boolean().default(false),
+  paperlessDeleteAfterUpload: z.boolean().default(true),
 });
 
 export type Config = z.infer<typeof configSchema>;
@@ -54,7 +54,11 @@ export function loadConfig(): Config {
     shutdownTimeoutMs: process.env.SHUTDOWN_TIMEOUT_MS || undefined,
     paperlessUrl: process.env.PAPERLESS_URL || undefined,
     paperlessToken,
-    paperlessDeleteAfterUpload: process.env.PAPERLESS_DELETE_AFTER_UPLOAD === "true",
+    // undefined → Zod default (true) applies. Explicit "true" / "false" override it.
+    paperlessDeleteAfterUpload:
+      process.env.PAPERLESS_DELETE_AFTER_UPLOAD === undefined
+        ? undefined
+        : process.env.PAPERLESS_DELETE_AFTER_UPLOAD === "true",
   };
 
   return configSchema.parse(raw);

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,10 @@ async function main() {
   const hasUrl = Boolean(config.paperlessUrl);
   const hasToken = Boolean(config.paperlessToken);
   if (hasUrl && hasToken) {
-    log.info(`Paperless upload: enabled (${config.paperlessUrl})`);
+    const retention = config.paperlessDeleteAfterUpload
+      ? "local files deleted after successful upload"
+      : "local files retained";
+    log.info(`Paperless upload: enabled (${config.paperlessUrl}) — ${retention}`);
   } else if (hasUrl || hasToken) {
     log.warn(
       "Paperless upload disabled: both PAPERLESS_URL and PAPERLESS_TOKEN (or PAPERLESS_TOKEN_FILE) must be set",


### PR DESCRIPTION
Flip `PAPERLESS_DELETE_AFTER_UPLOAD` default `false` → `true` — if Paperless is configured, it's the authoritative store; retaining local files by default forces manual cleanup. Opt-out: `PAPERLESS_DELETE_AFTER_UPLOAD=false`.

Also surfaces retention state in the startup log, adds an opt-out test (197 tests), and corrects the troubleshooting line that wrongly implied all Epson software conflicts (only Event Manager does).