### PR TITLE
chore(compose): add container_name for clean logs/exec output

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,7 @@
 services:
   epson2paperless:
     image: ghcr.io/mtheuma/epson2paperless:latest
+    container_name: epson2paperless
     restart: unless-stopped
     network_mode: host
     init: true


### PR DESCRIPTION
## Summary

One-line follow-up to the Stage 3 deployment: add \`container_name: epson2paperless\` to the tracked \`compose.yaml\` so the running container is named \`epson2paperless\` instead of Docker Compose's default \`<stack>-<service>-<replica>\` form (e.g. \`epson2paperless-epson2paperless-1\`).

Noticed during the first real Portainer deploy on the Synology NAS — the default name makes \`docker logs\`, \`docker exec\`, and the Portainer container list much less friendly.

Functionally: \`container_name\` disables Compose's scaling of the service, which we don't use (single-replica service). No runtime behaviour change.

## Test plan

- [ ] CI \`test\` workflow green on this PR (no src/ changes; should pass unchanged at 197 tests)
- [ ] \`docker compose config\` parses cleanly (verified locally)
- [ ] \`prettier --check\` clean (verified locally)
- [ ] After merge: any fresh \`docker compose up -d\` from a clone produces a container named \`epson2paperless\` rather than the stack-service-replica form