### PR TITLE
refactor: extract shared startup boilerplate into src/startup.ts

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -3,6 +3,7 @@ import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { loadConfig, isPaperlessEnabled } from "./config.js";
+import { buildPaperlessOptions } from "./startup.js";
 
 describe("loadConfig", () => {
   beforeEach(() => {
@@ -216,5 +217,50 @@ describe("loadConfig", () => {
     delete process.env.PAPERLESS_URL;
     config = loadConfig();
     expect(isPaperlessEnabled(config)).toBe(false);
+  });
+});
+
+describe("buildPaperlessOptions", () => {
+  beforeEach(() => {
+    delete process.env.PRINTER_IP;
+    delete process.env.PAPERLESS_URL;
+    delete process.env.PAPERLESS_TOKEN;
+    delete process.env.PAPERLESS_TOKEN_FILE;
+    delete process.env.PAPERLESS_DELETE_AFTER_UPLOAD;
+  });
+
+  it("returns undefined when either URL or token is missing", () => {
+    process.env.PRINTER_IP = "192.0.2.58";
+    expect(buildPaperlessOptions(loadConfig())).toBeUndefined();
+
+    process.env.PAPERLESS_URL = "http://paperless.lan:8000";
+    expect(buildPaperlessOptions(loadConfig())).toBeUndefined();
+
+    delete process.env.PAPERLESS_URL;
+    process.env.PAPERLESS_TOKEN = "abc";
+    expect(buildPaperlessOptions(loadConfig())).toBeUndefined();
+  });
+
+  it("returns options with deleteAfterUpload=true by default", () => {
+    process.env.PRINTER_IP = "192.0.2.58";
+    process.env.PAPERLESS_URL = "http://paperless.lan:8000";
+    process.env.PAPERLESS_TOKEN = "abc123";
+    expect(buildPaperlessOptions(loadConfig())).toEqual({
+      url: "http://paperless.lan:8000",
+      token: "abc123",
+      deleteAfterUpload: true,
+    });
+  });
+
+  it("honours PAPERLESS_DELETE_AFTER_UPLOAD=false", () => {
+    process.env.PRINTER_IP = "192.0.2.58";
+    process.env.PAPERLESS_URL = "http://paperless.lan:8000";
+    process.env.PAPERLESS_TOKEN = "abc123";
+    process.env.PAPERLESS_DELETE_AFTER_UPLOAD = "false";
+    expect(buildPaperlessOptions(loadConfig())).toEqual({
+      url: "http://paperless.lan:8000",
+      token: "abc123",
+      deleteAfterUpload: false,
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ async function main() {
   setLogFormat(config.logFormat);
 
   logStartupBanner(config, "epson2paperless starting");
-  const { responder } = await startPrinterDiscovery(config);
+  const responder = await startPrinterDiscovery(config);
 
   const inflight = createInflightTracker();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,15 @@
-import { loadConfig, isPaperlessEnabled } from "./config.js";
+import { loadConfig } from "./config.js";
 import { setLogLevel, setLogFormat, createLogger } from "./logger.js";
-import { getLocalIpForTarget } from "./network.js";
-import { createKeepaliveResponder } from "./keepalive.js";
 import { createPushScanServer, resolveEffectiveAction } from "./pushscan.js";
 import { startScanSession } from "./scanner.js";
 import { createHealthServer, setLastScanTime } from "./health.js";
 import { createInflightTracker, shutdown as runShutdown } from "./lifecycle.js";
-import type { PaperlessUploadOptions } from "./paperless-upload.js";
+import {
+  logStartupBanner,
+  startPrinterDiscovery,
+  installCrashHandlers,
+  buildPaperlessOptions,
+} from "./startup.js";
 
 const log = createLogger("main");
 
@@ -15,45 +18,8 @@ async function main() {
   setLogLevel(config.logLevel);
   setLogFormat(config.logFormat);
 
-  log.info("epson2paperless starting");
-  log.info(`Printer IP: ${config.printerIp}`);
-  log.info(`Destination name: ${config.scanDestName}`);
-  log.info(`Output directory: ${config.outputDir}`);
-
-  const hasUrl = Boolean(config.paperlessUrl);
-  const hasToken = Boolean(config.paperlessToken);
-  if (hasUrl && hasToken) {
-    const retention = config.paperlessDeleteAfterUpload
-      ? "local files deleted after successful upload"
-      : "local files retained";
-    log.info(`Paperless upload: enabled (${config.paperlessUrl}) — ${retention}`);
-  } else if (hasUrl || hasToken) {
-    log.warn(
-      "Paperless upload disabled: both PAPERLESS_URL and PAPERLESS_TOKEN (or PAPERLESS_TOKEN_FILE) must be set",
-    );
-  } else {
-    log.info("Paperless upload: disabled (no PAPERLESS_URL/PAPERLESS_TOKEN)");
-  }
-
-  const localIp = await getLocalIpForTarget(config.printerIp);
-  log.info(`Local IP: ${localIp}`);
-
-  const responder = createKeepaliveResponder({
-    keepalive: {
-      clientName: config.scanDestName,
-      ipAddress: localIp,
-      eventPort: 2968,
-      destId: config.scanDestId,
-      language: config.language,
-    },
-    printerIp: config.printerIp,
-    printerPort: 2968,
-    multicastAddress: "239.255.255.253",
-    multicastPort: 2968,
-    burstCount: 3,
-    burstIntervalMs: 500,
-  });
-  await responder.start();
+  logStartupBanner(config, "epson2paperless starting");
+  const { responder } = await startPrinterDiscovery(config);
 
   const inflight = createInflightTracker();
 
@@ -68,14 +34,6 @@ async function main() {
     );
     setLastScanTime(new Date().toISOString());
 
-    const paperless: PaperlessUploadOptions | undefined = isPaperlessEnabled(config)
-      ? {
-          url: config.paperlessUrl,
-          token: config.paperlessToken,
-          deleteAfterUpload: config.paperlessDeleteAfterUpload,
-        }
-      : undefined;
-
     const scanPromise = startScanSession({
       printerIp: config.printerIp,
       port: 1865,
@@ -84,7 +42,7 @@ async function main() {
       tempDir: config.tempDir,
       duplex: info.duplex,
       action: effective,
-      paperless,
+      paperless: buildPaperlessOptions(config),
     });
     void inflight.track(scanPromise);
   });
@@ -110,13 +68,7 @@ async function main() {
   process.on("SIGINT", () => handleSignal("SIGINT"));
   process.on("SIGTERM", () => handleSignal("SIGTERM"));
 
-  process.on("uncaughtException", (err) => {
-    log.error("Uncaught exception — exiting", err);
-    process.exit(1);
-  });
-  process.on("unhandledRejection", (reason) => {
-    log.error("Unhandled rejection (not exiting)", reason);
-  });
+  installCrashHandlers();
 }
 
 main().catch((err) => {

--- a/src/one-shot.ts
+++ b/src/one-shot.ts
@@ -18,7 +18,7 @@ async function main() {
   setLogFormat(config.logFormat);
 
   logStartupBanner(config, "epson2paperless one-shot — will exit after the first scan completes");
-  const { responder } = await startPrinterDiscovery(config);
+  const responder = await startPrinterDiscovery(config);
 
   type ExitReason =
     | { kind: "complete" }

--- a/src/one-shot.ts
+++ b/src/one-shot.ts
@@ -1,57 +1,24 @@
-import { loadConfig, isPaperlessEnabled } from "./config.js";
-import { setLogLevel, createLogger } from "./logger.js";
-import { getLocalIpForTarget } from "./network.js";
-import { createKeepaliveResponder } from "./keepalive.js";
+import { loadConfig } from "./config.js";
+import { setLogLevel, setLogFormat, createLogger } from "./logger.js";
 import { createPushScanServer, resolveEffectiveAction } from "./pushscan.js";
 import { startScanSession } from "./scanner.js";
 import { createInflightTracker } from "./lifecycle.js";
-import type { PaperlessUploadOptions } from "./paperless-upload.js";
+import {
+  logStartupBanner,
+  startPrinterDiscovery,
+  installCrashHandlers,
+  buildPaperlessOptions,
+} from "./startup.js";
 
 const log = createLogger("one-shot");
 
 async function main() {
   const config = loadConfig();
   setLogLevel(config.logLevel);
+  setLogFormat(config.logFormat);
 
-  log.info("epson2paperless one-shot — will exit after the first scan completes");
-  log.info(`Printer IP: ${config.printerIp}`);
-  log.info(`Destination name: ${config.scanDestName}`);
-  log.info(`Output directory: ${config.outputDir}`);
-
-  const hasUrl = Boolean(config.paperlessUrl);
-  const hasToken = Boolean(config.paperlessToken);
-  if (hasUrl && hasToken) {
-    const retention = config.paperlessDeleteAfterUpload
-      ? "local files deleted after successful upload"
-      : "local files retained";
-    log.info(`Paperless upload: enabled (${config.paperlessUrl}) — ${retention}`);
-  } else if (hasUrl || hasToken) {
-    log.warn(
-      "Paperless upload disabled: both PAPERLESS_URL and PAPERLESS_TOKEN (or PAPERLESS_TOKEN_FILE) must be set",
-    );
-  } else {
-    log.info("Paperless upload: disabled (no PAPERLESS_URL/PAPERLESS_TOKEN)");
-  }
-
-  const localIp = await getLocalIpForTarget(config.printerIp);
-  log.info(`Local IP: ${localIp}`);
-
-  const responder = createKeepaliveResponder({
-    keepalive: {
-      clientName: config.scanDestName,
-      ipAddress: localIp,
-      eventPort: 2968,
-      destId: config.scanDestId,
-      language: config.language,
-    },
-    printerIp: config.printerIp,
-    printerPort: 2968,
-    multicastAddress: "239.255.255.253",
-    multicastPort: 2968,
-    burstCount: 3,
-    burstIntervalMs: 500,
-  });
-  await responder.start();
+  logStartupBanner(config, "epson2paperless one-shot — will exit after the first scan completes");
+  const { responder } = await startPrinterDiscovery(config);
 
   type ExitReason =
     | { kind: "complete" }
@@ -79,14 +46,6 @@ async function main() {
       `PushScan received (duplex=${info.duplex}, action=${effective}) — starting TLS scan session`,
     );
 
-    const paperless: PaperlessUploadOptions | undefined = isPaperlessEnabled(config)
-      ? {
-          url: config.paperlessUrl,
-          token: config.paperlessToken,
-          deleteAfterUpload: config.paperlessDeleteAfterUpload,
-        }
-      : undefined;
-
     const scanPromise = startScanSession({
       printerIp: config.printerIp,
       port: 1865,
@@ -95,7 +54,7 @@ async function main() {
       tempDir: config.tempDir,
       duplex: info.duplex,
       action: effective,
-      paperless,
+      paperless: buildPaperlessOptions(config),
     });
     void inflight.track(scanPromise);
     scanPromise.then(
@@ -112,13 +71,7 @@ async function main() {
   };
   process.on("SIGINT", onSignal);
   process.on("SIGTERM", onSignal);
-  process.on("uncaughtException", (err) => {
-    log.error("Uncaught exception — exiting", err);
-    process.exit(1);
-  });
-  process.on("unhandledRejection", (reason) => {
-    log.error("Unhandled rejection (not exiting)", reason);
-  });
+  installCrashHandlers();
 
   const reason = await settled;
   process.off("SIGINT", onSignal);

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,0 +1,73 @@
+import { isPaperlessEnabled, type Config } from "./config.js";
+import { createLogger } from "./logger.js";
+import { getLocalIpForTarget } from "./network.js";
+import { createKeepaliveResponder, type KeepaliveResponder } from "./keepalive.js";
+import type { PaperlessUploadOptions } from "./paperless-upload.js";
+
+const log = createLogger("startup");
+
+export function logStartupBanner(config: Config, modeMessage: string): void {
+  log.info(modeMessage);
+  log.info(`Printer IP: ${config.printerIp}`);
+  log.info(`Destination name: ${config.scanDestName}`);
+  log.info(`Output directory: ${config.outputDir}`);
+
+  const hasUrl = Boolean(config.paperlessUrl);
+  const hasToken = Boolean(config.paperlessToken);
+  if (hasUrl && hasToken) {
+    const retention = config.paperlessDeleteAfterUpload
+      ? "local files deleted after successful upload"
+      : "local files retained";
+    log.info(`Paperless upload: enabled (${config.paperlessUrl}) — ${retention}`);
+  } else if (hasUrl || hasToken) {
+    log.warn(
+      "Paperless upload disabled: both PAPERLESS_URL and PAPERLESS_TOKEN (or PAPERLESS_TOKEN_FILE) must be set",
+    );
+  } else {
+    log.info("Paperless upload: disabled (no PAPERLESS_URL/PAPERLESS_TOKEN)");
+  }
+}
+
+export async function startPrinterDiscovery(
+  config: Config,
+): Promise<{ localIp: string; responder: KeepaliveResponder }> {
+  const localIp = await getLocalIpForTarget(config.printerIp);
+  log.info(`Local IP: ${localIp}`);
+
+  const responder = createKeepaliveResponder({
+    keepalive: {
+      clientName: config.scanDestName,
+      ipAddress: localIp,
+      eventPort: 2968,
+      destId: config.scanDestId,
+      language: config.language,
+    },
+    printerIp: config.printerIp,
+    printerPort: 2968,
+    multicastAddress: "239.255.255.253",
+    multicastPort: 2968,
+    burstCount: 3,
+    burstIntervalMs: 500,
+  });
+  await responder.start();
+  return { localIp, responder };
+}
+
+export function installCrashHandlers(): void {
+  process.on("uncaughtException", (err) => {
+    log.error("Uncaught exception — exiting", err);
+    process.exit(1);
+  });
+  process.on("unhandledRejection", (reason) => {
+    log.error("Unhandled rejection (not exiting)", reason);
+  });
+}
+
+export function buildPaperlessOptions(config: Config): PaperlessUploadOptions | undefined {
+  if (!isPaperlessEnabled(config)) return undefined;
+  return {
+    url: config.paperlessUrl,
+    token: config.paperlessToken,
+    deleteAfterUpload: config.paperlessDeleteAfterUpload,
+  };
+}

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -12,14 +12,12 @@ export function logStartupBanner(config: Config, modeMessage: string): void {
   log.info(`Destination name: ${config.scanDestName}`);
   log.info(`Output directory: ${config.outputDir}`);
 
-  const hasUrl = Boolean(config.paperlessUrl);
-  const hasToken = Boolean(config.paperlessToken);
-  if (hasUrl && hasToken) {
+  if (isPaperlessEnabled(config)) {
     const retention = config.paperlessDeleteAfterUpload
       ? "local files deleted after successful upload"
       : "local files retained";
     log.info(`Paperless upload: enabled (${config.paperlessUrl}) — ${retention}`);
-  } else if (hasUrl || hasToken) {
+  } else if (config.paperlessUrl || config.paperlessToken) {
     log.warn(
       "Paperless upload disabled: both PAPERLESS_URL and PAPERLESS_TOKEN (or PAPERLESS_TOKEN_FILE) must be set",
     );
@@ -28,9 +26,7 @@ export function logStartupBanner(config: Config, modeMessage: string): void {
   }
 }
 
-export async function startPrinterDiscovery(
-  config: Config,
-): Promise<{ localIp: string; responder: KeepaliveResponder }> {
+export async function startPrinterDiscovery(config: Config): Promise<KeepaliveResponder> {
   const localIp = await getLocalIpForTarget(config.printerIp);
   log.info(`Local IP: ${localIp}`);
 
@@ -50,7 +46,7 @@ export async function startPrinterDiscovery(
     burstIntervalMs: 500,
   });
   await responder.start();
-  return { localIp, responder };
+  return responder;
 }
 
 export function installCrashHandlers(): void {


### PR DESCRIPTION
## Summary

Both entry points — `src/index.ts` (daemon) and `src/one-shot.ts` (one-shot CLI, PR #9) — carried ~40 lines of byte-identical startup orchestration: banner + config logs, local-IP resolution, keepalive responder creation, Paperless options construction, and crash handlers. This PR collapses them into four helpers in a new `src/startup.ts`:

| Helper | Purpose |
|---|---|
| `logStartupBanner(config, modeMessage)` | Banner + Printer IP / dest / outdir / Paperless-status log block |
| `startPrinterDiscovery(config)` | Resolve outbound IP, build + start keepalive responder, returns `{ localIp, responder }` |
| `installCrashHandlers()` | `uncaughtException` / `unhandledRejection` process listeners |
| `buildPaperlessOptions(config)` | `Config` → `PaperlessUploadOptions \| undefined` glue |

## What's intentionally NOT extracted

- **Signal handling + shutdown**: daemon uses `runShutdown` (always exits 0). One-shot has its own teardown with distinct exit codes (`0` / `1` / `130` / `143`). Forcing a common helper would require parameterising exit-code and re-entry semantics — not worth it for two callers.
- **`startScanSession` call mapping**: same fields across both entry points, but wrapping a pure field-mapping call just shuffles code.
- **Port literals (`2968`, `1865`, multicast `239.255.255.253`)**: pre-existing duplication that predates PR #9. Separate refactor if/when a third caller appears.

## Drive-by fix

`src/one-shot.ts` now calls `setLogFormat(config.logFormat)` alongside `setLogLevel` — it was missing because PR #8 (JSON logging) landed on `main` before PR #9 (one-shot) did, so `one-shot.ts` never picked up the new call. `LOG_FORMAT=json npm run scan` now produces JSON output like the daemon does.

## Diff shape

- `+src/startup.ts` — 73 lines
- `src/index.ts` — -49 lines (125 → 76)
- `src/one-shot.ts` — -52 lines (161 → 109)
- `src/config.test.ts` — +46 lines (3 new `buildPaperlessOptions` tests)

Net `+143 / -119`. The `createKeepaliveResponder({...})` options object is now written once across the whole codebase.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 211/211 pass (includes 3 new `buildPaperlessOptions` tests; daemon/one-shot orchestration remains covered by the `scanner.test.ts` replay harness, which exercises the full ESC/I-2 pipeline)
- [ ] CI `test` workflow green on this PR
- [ ] Manual: `PRINTER_IP=... npm run dev` — destination still appears on printer panel within 60s
- [ ] Manual: `PRINTER_IP=... npm run scan` — one-shot still completes a scan and exits 0

## Test-coverage notes

Only `buildPaperlessOptions` got dedicated tests. Skipped for:
- `logStartupBanner` — repo has no `vi.spyOn(console, …)` pattern; introducing log-capture just for this is scope creep.
- `installCrashHandlers` — modifies `process` globals; add/remove dance for a 4-line function is low value.
- `startPrinterDiscovery` — thin wrapper over `getLocalIpForTarget` and `createKeepaliveResponder`, both already covered in their own test files. Its correctness *is* the deduplication.