### PR TITLE
chore: address CodeQL findings (workflow permissions + logger format string)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -32,12 +32,14 @@ describe("logger", () => {
       expect(arg).toMatch(/^\d{4}-\d{2}-\d{2}T\S+Z \[INFO\] \[mod\] hello$/);
     });
 
-    it("passes data as a second console argument", () => {
+    it("passes data as a separate console argument with explicit '%s' format", () => {
       const log = createLogger("mod");
       log.info("scan done", { pages: 3 });
-      expect(logSpy).toHaveBeenCalledWith(expect.stringMatching(/\[INFO\] \[mod\] scan done$/), {
-        pages: 3,
-      });
+      expect(logSpy).toHaveBeenCalledWith(
+        "%s",
+        expect.stringMatching(/\[INFO\] \[mod\] scan done$/),
+        { pages: 3 },
+      );
     });
   });
 

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -32,7 +32,7 @@ describe("logger", () => {
       expect(arg).toMatch(/^\d{4}-\d{2}-\d{2}T\S+Z \[INFO\] \[mod\] hello$/);
     });
 
-    it("passes data as a separate console argument with explicit '%s' format", () => {
+    it("passes data as a separate console argument (not concatenated into the message)", () => {
       const log = createLogger("mod");
       log.info("scan done", { pages: 3 });
       expect(logSpy).toHaveBeenCalledWith(

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -56,8 +56,7 @@ function log(level: LogLevel, module: string, message: string, data?: unknown): 
 
   const prefix = `${timestamp} [${level.toUpperCase()}] [${module}]`;
   if (data !== undefined) {
-    // Pass "%s" explicitly so console.* doesn't treat the (potentially
-    // user-derived) message as a format string — CodeQL js/tainted-format-string.
+    // message is caller-supplied and may contain %-tokens; pin the format to "%s".
     sink("%s", `${prefix} ${message}`, data);
   } else {
     sink(`${prefix} ${message}`);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -56,7 +56,9 @@ function log(level: LogLevel, module: string, message: string, data?: unknown): 
 
   const prefix = `${timestamp} [${level.toUpperCase()}] [${module}]`;
   if (data !== undefined) {
-    sink(`${prefix} ${message}`, data);
+    // Pass "%s" explicitly so console.* doesn't treat the (potentially
+    // user-derived) message as a format string — CodeQL js/tainted-format-string.
+    sink("%s", `${prefix} ${message}`, data);
   } else {
     sink(`${prefix} ${message}`);
   }


### PR DESCRIPTION
## Summary

Addresses two open CodeQL alerts on `main`:

- **`actions/missing-workflow-permissions` (medium)** — `.github/workflows/test.yml` had no top-level `permissions:` block, defaulting to whatever the repo grants. Added `contents: read` (the only scope the job needs — checkout + npm).
- **`js/tainted-format-string` (high)** — `src/logger.ts:59` passed `\`${prefix} \${message}\`` as the first arg to `console.*` alongside a data arg, so a `%s`/`%d` in the message would be reinterpreted as a format specifier. Pass an explicit `"%s"` as the format string instead. Output is byte-identical (Node's util.format consumes the message via `%s` and appends the data arg with the usual inspector). Logger test updated to assert the new three-argument call shape.

The third CodeQL finding (`js/disabling-certificate-validation` on `src/scanner.ts:211`) was dismissed in the UI as "Won't fix" — intentional design with `PRINTER_CERT_FINGERPRINT` opt-in pinning as the documented mitigation (see `SECURITY.md`).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 216/216 pass (logger test updated to match new signature)
- [ ] CodeQL re-runs and closes alerts #1 + #2 automatically once merged