### PR TITLE
docs: refresh CLAUDE.md after recent feature additions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,12 @@ See:
 
 ## Commands
 
-- `npm test` — full Vitest suite (196 tests, ~1s). Includes `src/scanner.test.ts`, a replay harness that asserts byte-for-byte equivalence against recorded Frida captures. Six parametrised entries: three JPG (1p-simplex, 3p-simplex, 1p-duplex — asserting JPEGs on disk + EXIF APP1 orientation, `Orientation=3` on duplex back pages only) and three PDF reusing the same captures with `action='pdf'` (asserting one composed `scan_<ts>.pdf` with correct page count and `/Rotate=180` on back pages). Treat this as a regression shield — protocol edits that change wire bytes must be mirrored in fixtures.
+- `npm test` — full Vitest suite (216 tests across 14 files, ~1s). Includes `src/scanner.test.ts`, a replay harness that asserts byte-for-byte equivalence against recorded Frida captures. Six parametrised entries: three JPG (1p-simplex, 3p-simplex, 1p-duplex — asserting JPEGs on disk + EXIF APP1 orientation, `Orientation=3` on duplex back pages only) and three PDF reusing the same captures with `action='pdf'` (asserting one composed `scan_<ts>.pdf` with correct page count and `/Rotate=180` on back pages). Treat this as a regression shield — protocol edits that change wire bytes must be mirrored in fixtures.
 - `npm test -- <name>` — filter by file name (e.g. `npm test -- pushscan`).
 - `npx vitest run <path> --reporter=verbose` — single file, verbose output.
-- `npm run dev` — start the service via `tsx` (no build step).
+- `npm run dev` — start the long-running service via `tsx` (no build step).
+- `npm run scan` — one-shot CLI mode (`src/one-shot.ts`). Same wire behaviour as the daemon, but exits after the first scan completes — useful for ad-hoc captures and integration tests.
+- `npm run printer-fingerprint` — print the printer's TLS certificate sha256 fingerprint, in the colon-hex form expected by `PRINTER_CERT_FINGERPRINT`.
 - `npm run build` — TypeScript compile to `dist/`. Usually not needed in dev.
 - `npm run lint` / `npm run lint:fix` — ESLint with typescript-eslint type-checked rules (`eslint.config.mjs`). Test files and `tools/` relax `no-unsafe-*` around fixture-heavy code.
 - `npm run format` / `npm run format:check` — Prettier (`.prettierrc.json`).
@@ -30,18 +32,24 @@ Env-var driven, Zod-validated in `src/config.ts`. Required: `PRINTER_IP`. Full t
 Noteworthy for dev:
 
 - `LOG_LEVEL=debug` — scanner state transitions + per-request detail only show at `debug`.
+- `LOG_FORMAT` (`text` / `json`) — `json` emits structured one-line records; useful when running under a log shipper.
 - `PREVIEW_ACTION` (`reject` / `jpg` / `pdf`) — what happens when the panel's Action is **Preview on Computer** (`PushScanIDIn[1]=4`). Default silently ignores the scan; `jpg` / `pdf` override to let it proceed as that format.
 - `TEMP_DIR` — per-session JPEG spill dir. Empty → `os.tmpdir()`. Override in Docker if `/tmp` is tmpfs-backed.
+- `PAPERLESS_URL` + `PAPERLESS_TOKEN` (or `PAPERLESS_TOKEN_FILE`) — when both are set, completed scans are POSTed to Paperless-ngx's `/api/documents/post_document/` endpoint. `PAPERLESS_DELETE_AFTER_UPLOAD` (default `true`) controls whether the local file is removed after a successful upload.
+- `PRINTER_CERT_FINGERPRINT` — optional sha256 pin (32 colon-separated hex bytes) for the printer's TLS cert. When set, the scan session rejects any cert whose fingerprint doesn't match. Capture with `npm run printer-fingerprint`.
+- `SHUTDOWN_TIMEOUT_MS` — how long graceful shutdown waits for in-flight scans before forcing exit (default 30000).
 
 ## Architecture (brief — full detail in `docs/HOW-IT-WORKS.md`)
 
 Each protocol layer lives in its own module and can be reasoned about independently:
 
-- **Discovery / multicast** (`src/keepalive.ts`) — UDP `239.255.255.253:2968`. Echoes the printer's beacon seq byte back in a 3-burst keepalive to register as destination `Paperless`.
+- **Discovery / multicast** (`src/keepalive.ts`, `src/network.ts`) — UDP `239.255.255.253:2968`. Echoes the printer's beacon seq byte back in a 3-burst keepalive to register as destination `Paperless`. `network.ts` resolves which local interface IP to advertise.
 - **Push-scan trigger** (`src/pushscan.ts`) — TCP port 2968, raw `net.createServer` because Epson uses non-standard header spacing (`Header : value`, whitespace before the colon). The `x-uid` response header **must** echo the request — mismatch shows "Scanning Error" on the panel even though data transfer completes. `PushScanIDIn` bytes carry the panel's Sides (byte 0: `0`=1-Sided, `1`=2-Sided) and Action bitmask (byte 1: `1`=jpg, `2`=pdf, `4`=preview).
-- **Scan session** (`src/scanner.ts` + `src/esci.ts` + `src/protocol.ts`) — TLS port 1865, cert verification off. Inside TLS, Epson's "IS" framing wraps ESC/I-2 commands. The scanner runs a deterministic state machine per scan; see `docs/HOW-IT-WORKS.md` for the diagram. Per-page JPEGs spill to a session temp dir; at end-of-scan, `action='jpg'` promotes them to `scan_<ts>{,_NN}.jpg`, `action='pdf'` composes a single PDF via `src/pdf.ts` (JPG-promote fallback on compose failure).
+- **Scan session** (`src/scanner.ts` + `src/esci.ts` + `src/protocol.ts`) — TLS port 1865. Cert verification is off by default; setting `PRINTER_CERT_FINGERPRINT` switches on sha256 pinning. Inside TLS, Epson's "IS" framing wraps ESC/I-2 commands. The scanner runs a deterministic state machine per scan; see `docs/HOW-IT-WORKS.md` for the diagram. Per-page JPEGs spill to a session temp dir; at end-of-scan, `src/output.ts` promotes/composes the result — `action='jpg'` → `scan_<ts>{,_NN}.jpg`, `action='pdf'` → one composed `scan_<ts>.pdf` via `src/pdf.ts` (JPG-promote fallback on compose failure).
 - **EXIF / PDF helpers** (`src/exif.ts`, `src/pdf.ts`) — minimal 36-byte APP1 insertion for JPG back-page orientation; pdf-lib composition with per-page sizing and `/Rotate=180` on back pages.
-- **Health check** (`src/health.ts`) — plain HTTP on port 3000 (configurable).
+- **Paperless upload** (`src/paperless-upload.ts`) — when `PAPERLESS_URL` + `PAPERLESS_TOKEN` are configured, finished scans are POSTed multipart to Paperless-ngx's `post_document` endpoint. Optional cleanup of the local file after a successful upload.
+- **Process layer** (`src/index.ts`, `src/one-shot.ts`, `src/startup.ts`, `src/lifecycle.ts`, `src/logger.ts`) — `index.ts` is the long-running daemon; `one-shot.ts` is the `npm run scan` CLI variant. Both share startup boilerplate (banner, discovery, crash handlers, Paperless option assembly) from `startup.ts`. `lifecycle.ts` provides an in-flight scan tracker and graceful shutdown driver bounded by `SHUTDOWN_TIMEOUT_MS`. `logger.ts` is a tiny structured logger with a `LOG_FORMAT=json` mode.
+- **Health check** (`src/health.ts`) — plain HTTP on port 3000 (configurable). Note: binds to all interfaces, so it's LAN-reachable — see README.
 
 The `PARA` payload from `buildParaPayload(duplex)` is hardcoded and byte-matched to the driver capture: 936 bytes simplex (`#ADF…`, announced `0x3A8`) / 940 bytes duplex (`#ADFDPLX…`, `0x3AC`). Don't edit without re-capturing fixtures — the replay test will fail.
 
@@ -54,7 +62,8 @@ The `PARA` payload from `buildParaPayload(duplex)` is hardcoded and byte-matched
 
 - `main` = deployable. `dev` = integration.
 - Work on `dev` or short-lived branches off `dev`; PR to `main` via `gh pr create --base main --head dev`.
-- CI (`.github/workflows/test.yml`) runs `npm install && npm test` on every push and PR targeting `main`. Uses `npm install` (not `npm ci`) because the lockfile is generated on Windows and lacks Linux-only optional native deps — don't swap to `npm ci` without regenerating the lockfile on Linux.
+- CI (`.github/workflows/test.yml`) runs `npm install` and then the same lint + format:check + test trio that the local pre-push hook enforces, on every push to `dev`/`main` and every PR targeting `main`. Uses `npm install` (not `npm ci`) because the lockfile is generated on Windows and lacks Linux-only optional native deps — don't swap to `npm ci` without regenerating the lockfile on Linux.
+- A separate `.github/workflows/docker.yml` builds and publishes a multi-arch image to GHCR on pushes to `main` and on `v*` tags. `Dockerfile` + `compose.yaml` at the repo root are the deploy artifacts.
 - Server-side branch protection on `main`: PR required, CI status check required, linear history required.
 
 ### Local pre-push hook


### PR DESCRIPTION
## Summary

Catches `CLAUDE.md` up to work that landed since it was last touched. No source or behaviour changes — docs only.

- Commands: test count 196 → 216 (14 files); add `npm run scan` (one-shot CLI mode, PR #9) and `npm run printer-fingerprint` (PR #12).
- Configuration: new noteworthy env vars — `LOG_FORMAT` (PR #8), `PAPERLESS_URL` / `PAPERLESS_TOKEN` / `PAPERLESS_TOKEN_FILE` / `PAPERLESS_DELETE_AFTER_UPLOAD` (PR #2, #5), `PRINTER_CERT_FINGERPRINT` (PR #12), `SHUTDOWN_TIMEOUT_MS`.
- Architecture brief: covers `src/paperless-upload.ts`, `src/network.ts`, `src/output.ts`, and the process layer (`src/index.ts`, `src/one-shot.ts`, `src/startup.ts`, `src/lifecycle.ts`, `src/logger.ts`). TLS bullet now reflects opt-in fingerprint pinning instead of claiming cert verification is unconditionally off. Health bullet notes the LAN-reachable bind (matches the README restructure in PR #11).
- Development workflow: CI description matches the actual install + lint + format:check + test gate that the local pre-push hook mirrors. Adds a bullet for `.github/workflows/docker.yml` + `Dockerfile` + `compose.yaml` (PR #6).

## Test plan

- [x] `npm run format:check` passes locally
- [ ] CI green (lint + format:check + test trio)
- [ ] Spot-check rendered Markdown on the PR view