### PR TITLE
docs: open contributions, add Ko-fi support link, fix HOW-IT-WORKS drift

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,51 @@
 # Contributing
 
-Thanks for your interest in `epson2paperless`.
+Thanks for your interest in `epson2paperless`. Contributions — bug reports, feature ideas, pull requests — are welcome.
 
-This is a personal project built primarily for my own scanner setup. External contributions (pull requests, bug reports in issues) are not being actively reviewed right now. I may open this up later as the project stabilizes.
+The project's scope is the wire protocol between an Epson EcoTank printer's "Scan to Computer" panel button and a folder on your machine. Anything inside that scope is fair game; reports from EcoTank models other than the ET-4950 are particularly valuable.
 
-You're welcome to fork and adapt the code under the MIT license. If you hit a bug or have a question that seems worth discussing publicly, opening an issue is fine.
+## Reporting bugs
+
+Open a GitHub issue with:
+
+- Printer model and firmware version (panel → Setup → Firmware Update → check now will show the version).
+- What you tried, what you expected, and what actually happened.
+- Relevant logs. Re-running with `LOG_LEVEL=debug` shows scanner state transitions and per-request detail; please include the section spanning from "ready" through the failure.
+- For protocol-level issues, a `tshark` / Wireshark capture of port 2968 traffic is enormously helpful.
+
+## Proposing changes
+
+For non-trivial work, please open an issue to discuss before writing the PR. It saves time on both sides if the direction needs adjusting.
+
+Smaller things — typos, doc fixes, an obvious bug with a one-line fix — go straight to a PR.
+
+## Development setup
+
+Requires Node.js ≥ 24.15.0.
+
+```bash
+git clone https://github.com/mtheuma/epson2paperless.git
+cd epson2paperless
+npm install
+PRINTER_IP=192.0.2.58 npm run dev    # long-running daemon
+PRINTER_IP=192.0.2.58 npm run scan   # one-shot mode
+npm test                             # 216 tests, ~1s
+```
+
+`docs/HOW-IT-WORKS.md` is the deep-dive on the protocol, the scanner state machine, and the reverse-engineering methodology — start there if you're touching anything below the file-output layer.
+
+## Pull requests
+
+- Branch off `main`. PR back to `main`.
+- Commit-message style: `type: short summary` — `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`. The body explains the _why_ when it isn't obvious from the diff.
+- The CI gate is `npm run lint`, `npm run format:check`, and `npm test` — all three must pass. Activate the local pre-push hook with `git config core.hooksPath .githooks` to catch issues before pushing.
+- If your PR addresses an open issue, link it in the description.
+- Protocol changes that affect wire bytes need matching updates to the Frida-capture fixtures in `tools/frida-capture/captures/` — the byte-for-byte replay test in `src/scanner.test.ts` will fail otherwise. See `tools/frida-capture/README.md` for the re-capture workflow.
+
+## Code of conduct
+
+Be civil. I'm a one-person reviewer doing this in spare time, and clear, kind communication is what makes that sustainable.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the MIT license — the same terms as the rest of the repository.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ Normal. If two scans land in the same second, the service appends `_1`, `_2` to 
 
 - **[docs/HOW-IT-WORKS.md](docs/HOW-IT-WORKS.md)** — full technical walkthrough: the wire protocol, the scanner state machine, and the reverse-engineering methodology used to derive them.
 
+## Support
+
+If `epson2paperless` saved you an afternoon of fighting with a printer and you'd like to say thanks, you can:
+
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/A0A41CAGWG)
+
+Also genuinely valuable: opening an issue with what worked / didn't on your EcoTank model — the more data points, the better the README's "compatible models" claim gets.
+
 ## License & trademarks
 
 MIT. See [`LICENSE`](LICENSE) for the full text.

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -316,9 +316,9 @@ Because the protocol was built from these captures, the replay test is both a re
 | `src/pdf.ts`       | PDF composition from per-page JPEGs using pdf-lib                          |
 | `src/output.ts`    | Output filename generation and temp-file promotion                         |
 | `src/health.ts`    | HTTP health-check endpoint on port 3000                                    |
-| `src/logger.ts`    | Structured logger (wraps pino)                                             |
+| `src/logger.ts`    | Hand-rolled structured logger; text or JSON output via `LOG_FORMAT`        |
 | `src/lifecycle.ts` | Graceful shutdown coordination                                             |
-| `src/network.ts`   | Network interface enumeration helpers                                      |
+| `src/network.ts`   | Resolves the local IP that can reach the printer (UDP `connect()` trick)   |
 
 Test files mirror the module they cover (`src/scanner.test.ts`, `src/keepalive.test.ts`, etc.). The replay test harness support code lives in `src/test-support/`.
 
@@ -335,7 +335,7 @@ Reverse-engineering artifacts:
 
 ## Testing
 
-The test suite uses Vitest and runs with `npm test` (approximately 150 tests, completing in under two seconds).
+The test suite uses Vitest and runs with `npm test` (216 tests across 14 files, completing in roughly a second).
 
 **The replay harness** (`src/scanner.test.ts`) is the most important test file. It instantiates the real `startScanSession` function with a fake TLS socket factory. The fake socket replays the RECV side of a Frida capture (the bytes the printer sent), advancing one IS packet at a time, and records every byte the state machine sends. After the session completes, the test asserts byte-for-byte equality against the SEND side of the capture. On-disk output files are also asserted — JPEG files for JPG-mode runs (including EXIF orientation verification), and a composed PDF for PDF-mode runs (including page count and `/Rotate` metadata on back pages).
 
@@ -354,7 +354,7 @@ The test suite uses Vitest and runs with `npm test` (approximately 150 tests, co
 
 The test fixture for `src/pdf.test.ts` is `test-fixtures/sample-page.jpg`, a small JPEG extracted from the 1p-simplex Frida capture by `tools/extract-test-jpeg.ts`.
 
-CI runs `npm install && npm test` on every push and every pull request targeting `main` (see `.github/workflows/test.yml`). The workflow uses `npm install` rather than `npm ci` because the lockfile is generated on Windows and lacks Linux-only optional native dependencies; running `npm ci` on Linux would fail with a missing-dependency error.
+CI runs `npm install` followed by the same lint + format:check + test trio that the local pre-push hook enforces, on every push to `dev` / `main` and every pull request targeting `main` (see `.github/workflows/test.yml`). The workflow uses `npm install` rather than `npm ci` because the lockfile is generated on Windows and lacks Linux-only optional native dependencies; running `npm ci` on Linux would fail with a missing-dependency error.
 
 To run a single test file with verbose output:
 


### PR DESCRIPTION
## Summary

Three doc-only changes, one commit each — review per-commit if you'd like.

- **README:** new `## Support` section between *Further reading* and *License & trademarks*, with the Ko-fi button and a nudge to open issues with EcoTank-model results.
- **HOW-IT-WORKS:** corrects four outdated/incorrect claims I noticed while reviewing — `src/logger.ts` is hand-rolled (no pino dep), `src/network.ts` is a single `getLocalIpForTarget` helper (not interface enumeration), test count `150` → `216`, and the CI description matches the actual install + lint + format:check + test gate.
- **CONTRIBUTING:** replaces the "not actively reviewing" stance with a lean contributor guide — bug reports, proposing changes, dev setup, the PR gate, and a one-line code of conduct. Standard sections, kept short for a solo-maintainer repo.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm test` — 216/216 pass
- [ ] CI green
- [ ] Ko-fi button renders and links to https://ko-fi.com/A0A41CAGWG on the rendered README