### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epson2paperless",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "epson2paperless",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "pdf-lib": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epson2paperless",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Epson Scan to Computer protocol emulator — delivers scans to Paperless-ngx",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Version bump only — `0.1.0 → 0.2.0` in both `package.json` and `package-lock.json`. No code changes.

After this merges I will tag `v0.2.0` from `main` and push the tag, which triggers `.github/workflows/docker.yml` → publishes `ghcr.io/mtheuma/epson2paperless:v0.2.0` + `:latest` (multi-arch). The GitHub Release notes will follow on the tag.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm test` — 216/216 pass
- [x] Script header confirms version wired through (`epson2paperless@0.2.0` in `npm run` output)
- [ ] CI green