### PR TITLE
docs: add compatibility issue template + fix Settings menu wording

### DIFF
--- a/.github/ISSUE_TEMPLATE/compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility.yml
@@ -1,0 +1,70 @@
+name: Compatibility report
+description: Report whether your Epson printer works (or doesn't) with epson2paperless.
+title: "Compatibility: <model>"
+labels: ["compatibility"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing a compatibility report — both successes and failures
+        help the [Compatible printers](../../#compatible-printers) table grow.
+
+  - type: input
+    id: model
+    attributes:
+      label: Printer model
+      description: e.g. `ET-4950`. Found on the front of the printer.
+      placeholder: ET-XXXX
+    validations:
+      required: true
+
+  - type: input
+    id: firmware
+    attributes:
+      label: Firmware version
+      description: Settings → Firmware Update → check now.
+      placeholder: e.g. CG21B6
+    validations:
+      required: true
+
+  - type: dropdown
+    id: result
+    attributes:
+      label: Result
+      options:
+        - Works
+        - Partially works
+        - Doesn't work
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: tested
+    attributes:
+      label: What did you test?
+      description: Tick everything you actually tried.
+      options:
+        - label: ADF, 1-Sided, JPG
+        - label: ADF, 1-Sided, PDF
+        - label: ADF, 2-Sided, JPG
+        - label: ADF, 2-Sided, PDF
+        - label: Flatbed, JPG
+        - label: Flatbed, PDF
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: |
+        For "Partially works" / "Doesn't work" — what failed, what the panel showed, any error logs
+        (run with `LOG_LEVEL=debug` for state transitions). For "Works" — anything quirky worth knowing.
+      placeholder: |
+        e.g. ADF simplex worked, but duplex back pages were not flipped 180°.
+        Panel showed "Scanning Error" after ~30s.
+
+  - type: input
+    id: version
+    attributes:
+      label: epson2paperless version
+      description: e.g. `v0.2.0` or a commit SHA.
+      placeholder: v0.2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ The project's scope is the wire protocol between an Epson EcoTank printer's "Sca
 
 Open a GitHub issue with:
 
-- Printer model and firmware version (panel → Setup → Firmware Update → check now will show the version).
+- Printer model and firmware version (Settings → Firmware Update → check now will show the version on the ET-4950 — adjust for your model).
 - What you tried, what you expected, and what actually happened.
 - Relevant logs. Re-running with `LOG_LEVEL=debug` shows scanner state transitions and per-request detail; please include the section spanning from "ready" through the failure.
 - For protocol-level issues, a `tshark` / Wireshark capture of port 2968 traffic is enormously helpful.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ What you get:
 | --------------------- | ----------- | -------------------------------------- |
 | **ET-4950 / ET-4956** | ✅ Verified | Same hardware, different colour shells |
 
-Compatibility reports are welcome whether your model works or doesn't — open an [issue](https://github.com/mtheuma/epson2paperless/issues) with the `compatibility` label, including the printer model, firmware version, and a short note on what worked or failed. The table grows from those reports.
+Compatibility reports are welcome whether your model works or doesn't — [open an issue](https://github.com/mtheuma/epson2paperless/issues/new?template=compatibility.yml) using the compatibility template. The table grows from those reports.
 
 When the list outgrows a single readable table, it'll move to its own file under `docs/`.
 


### PR DESCRIPTION
## Summary

- **New file:** `.github/ISSUE_TEMPLATE/compatibility.yml` — structured GitHub issue form for compatibility reports. Required fields: printer model, firmware version, result (works / partially / doesn't). Optional: tested-features checkboxes, notes, epson2paperless version. Auto-applies the `compatibility` label and pre-fills the title `Compatibility: <model>`.
- **README:** the Compatible printers section's "open an issue" link now goes directly to the template (`?template=compatibility.yml`).
- **CONTRIBUTING:** drops "panel" from the firmware breadcrumb and corrects "Setup" → "Settings" (the actual menu name on the ET-4950).

The issue form also surfaces in GitHub's "New issue" picker, so people landing on `/issues/new` without going through the README still find the right form.

## Follow-up (not this PR)

- Make sure the `compatibility` label exists on the repo (Settings → Labels).

## Test plan

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [ ] CI green
- [ ] After merge, `https://github.com/mtheuma/epson2paperless/issues/new?template=compatibility.yml` opens the form
- [ ] "New issue" picker shows "Compatibility report" as an option
- [ ] Title pre-fills as `Compatibility: <model>`, label `compatibility` is auto-applied