### PR TITLE
docs: surface GHCR image URL; drop "→ check now" from firmware-version instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility.yml
@@ -22,7 +22,7 @@ body:
     id: firmware
     attributes:
       label: Firmware version
-      description: Settings → Firmware Update → check now.
+      description: Shown under Settings → Firmware Update.
       placeholder: e.g. CG21B6
     validations:
       required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ The project's scope is the wire protocol between an Epson EcoTank printer's "Sca
 
 Open a GitHub issue with:
 
-- Printer model and firmware version (Settings → Firmware Update → check now will show the version on the ET-4950 — adjust for your model).
+- Printer model and firmware version (shown under Settings → Firmware Update on the ET-4950 — adjust for your model).
 - What you tried, what you expected, and what actually happened.
 - Relevant logs. Re-running with `LOG_LEVEL=debug` shows scanner state transitions and per-request detail; please include the section spanning from "ready" through the failure.
 - For protocol-level issues, a `tshark` / Wireshark capture of port 2968 traffic is enormously helpful.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ When the list outgrows a single readable table, it'll move to its own file under
 
 ### Docker (recommended)
 
-A multi-arch image (`linux/amd64`, `linux/arm64`) is published to GitHub Container Registry on every `main` push (`:main`) and every `v*` git tag (`:vX.Y.Z` + `:latest`).
+Image: **`ghcr.io/mtheuma/epson2paperless`** — multi-arch (`linux/amd64`, `linux/arm64`). Published to GHCR on every `main` push (`:main`) and every `v*` git tag (`:vX.Y.Z` + `:latest`).
 
 1. Edit `compose.yaml` — set `PRINTER_IP` to your printer's IPv4 address and `./output` to wherever you want scans written.
 2. `docker compose up -d`.


### PR DESCRIPTION
## Summary

Two unrelated doc tweaks bundled into one PR.

### README — Docker section

The Docker (recommended) section previously mentioned GHCR but never showed the image path itself, so a reader had to open `compose.yaml` to find it. The first line of the section now leads with the image URL:

> Image: **`ghcr.io/mtheuma/epson2paperless`** — multi-arch (`linux/amd64`, `linux/arm64`). Published to GHCR on every `main` push (`:main`) and every `v*` git tag (`:vX.Y.Z` + `:latest`).

### Firmware-version wording (follow-up to #20)

The firmware version is shown directly on the **Settings → Firmware Update** screen on the ET-4950 — no need to trigger an update check. Updates the wording in two spots that incorrectly said `→ check now`:

- `.github/ISSUE_TEMPLATE/compatibility.yml` — the `Firmware version` field's description.
- `CONTRIBUTING.md` — the bug-report checklist's first bullet.

## Test plan

- [x] `npm run format:check` passes
- [ ] CI green