### PR TITLE
docs(readme): re-align Compatible printers table after note edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ What you get:
 
 ## Compatible printers
 
-| Model                 | Status      | Notes                                  |
-| --------------------- | ----------- | -------------------------------------- |
-| **ET-3950**           | ✅ Verified |                                       |
-| **ET-4950 / ET-4956** | ✅ Verified | Same hardware, different colours      |
+| Model                 | Status      | Notes                            |
+| --------------------- | ----------- | -------------------------------- |
+| **ET-3950**           | ✅ Verified |                                  |
+| **ET-4950 / ET-4956** | ✅ Verified | Same hardware, different colours |
 
 Compatibility reports are welcome whether your model works or doesn't — [open an issue](https://github.com/mtheuma/epson2paperless/issues/new?template=compatibility.yml) using the compatibility template.
 


### PR DESCRIPTION
## Summary

Fixes the `format:check` failure on `main` introduced by commit fc2ba01 ("Update README.md" via GitHub web UI), which shortened the ET-4950 note from `Same hardware, different colour shells` to `Same hardware, different colours` and cleared the ET-3950 Notes cell.

The cell text changed but the surrounding column-3 padding (and the divider row) was still sized for the longer original note, so Prettier's table alignment rule was violated. Running `npx prettier --write README.md` shrinks column 3 to match the new widest content.

Pure formatting — no content change beyond whitespace.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm test` passes (216/216)
- [ ] Confirm CI on `main` goes green once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)