### PR TITLE
refactor: KISS/DRY/YAGNI sweep 1 + CI gate for dev-targeted PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [dev, main]
   pull_request:
-    branches: [main]
+    branches: [dev, main]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ Configuration is via environment variables. Only `PRINTER_IP` is required.
 | -------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `SCAN_DEST_ID`             | `0x02`  | Destination ID byte sent in keepalive packets.                                                                                 |
 | `LANGUAGE`                 | `en`    | 2-letter locale sent to the printer; no observed user-visible effect.                                                          |
-| `KEEPALIVE_INTERVAL`       | `500`   | ms between keepalive responses.                                                                                                |
 | `PRINTER_CERT_FINGERPRINT` | —       | Optional SHA-256 fingerprint of the printer's TLS cert (e.g. `AB:CD:…`). When set, scans abort if the peer cert doesn't match. |
 | `SHUTDOWN_TIMEOUT_MS`      | `30000` | ms to wait for an in-flight scan to finish on `SIGINT`/`SIGTERM` before forcing shutdown.                                      |
 

--- a/docs/superpowers/plans/2026-05-04-v0.3.0-implementation.md
+++ b/docs/superpowers/plans/2026-05-04-v0.3.0-implementation.md
@@ -29,12 +29,14 @@ This phase lands first because subsequent PRs target `dev`, and the workflow cur
 ### Task A.1: Add `dev` to `pull_request.branches`
 
 **Files:**
+
 - Modify: `.github/workflows/test.yml:7`
 
 - [ ] **Step 1: Open the workflow file and verify current shape**
 
 Run: `cat .github/workflows/test.yml | head -10`
 Expected: line 4-7 reads
+
 ```yaml
 on:
   push:
@@ -46,6 +48,7 @@ on:
 - [ ] **Step 2: Edit the workflow**
 
 Change line 7 from `branches: [main]` to `branches: [dev, main]`. After the edit, lines 4-7 read:
+
 ```yaml
 on:
   push:
@@ -68,7 +71,7 @@ git push -u origin feature/v0.3.0-wf3620-autodetect
 gh pr create --base dev --head feature/v0.3.0-wf3620-autodetect --title "ci: run test workflow on PRs targeting dev" --body "Adds dev to the test workflow's pull_request.branches so milestone PRs to dev get the same lint/format/test gate as PRs to main. Required prep for the rest of v0.3.0."
 ```
 
-**Note on CI for PR1 itself:** the workflow currently filters PRs to `main` only, so PR1 (which targets `dev`) will *not* trigger the `test` workflow on the PR. CI fires after merge via the `push: branches: [dev, main]` trigger. Verify locally that lint/format/test are green (`npm run lint && npm run format:check && npm test`) — that's the gate for this PR. PR2 onwards will get the proper PR-level CI gate.
+**Note on CI for PR1 itself:** the workflow currently filters PRs to `main` only, so PR1 (which targets `dev`) will _not_ trigger the `test` workflow on the PR. CI fires after merge via the `push: branches: [dev, main]` trigger. Verify locally that lint/format/test are green (`npm run lint && npm run format:check && npm test`) — that's the gate for this PR. PR2 onwards will get the proper PR-level CI gate.
 
 - [ ] **Step 5: Merge PR1 once CI is green, recreate the local branch from new dev tip**
 
@@ -93,6 +96,7 @@ Eight independent items. Each is a separate commit; the whole phase is one PR wi
 ### Task B.1: Remove `KEEPALIVE_INTERVAL` from config + tests + README
 
 **Files:**
+
 - Modify: `src/config.ts` (drop `keepaliveInterval` schema field + raw-env wiring)
 - Modify: `src/config.test.ts` (drop the two cases referencing `keepaliveInterval`)
 - Modify: `README.md:102` (drop the row)
@@ -105,11 +109,13 @@ Expected: all loadConfig tests pass.
 - [ ] **Step 2: Remove the schema field**
 
 In `src/config.ts:15`, delete the line:
+
 ```ts
     keepaliveInterval: z.coerce.number().int().min(100).default(500),
 ```
 
 In `src/config.ts:79`, delete the line:
+
 ```ts
     keepaliveInterval: process.env.KEEPALIVE_INTERVAL || undefined,
 ```
@@ -117,23 +123,27 @@ In `src/config.ts:79`, delete the line:
 - [ ] **Step 3: Drop the test cases that reference `keepaliveInterval`**
 
 In `src/config.test.ts:14`, delete the line:
+
 ```ts
-    delete process.env.KEEPALIVE_INTERVAL;
+delete process.env.KEEPALIVE_INTERVAL;
 ```
 
 In `src/config.test.ts:43`, delete:
+
 ```ts
-    expect(config.keepaliveInterval).toBe(500);
+expect(config.keepaliveInterval).toBe(500);
 ```
 
 In `src/config.test.ts:55`, delete:
+
 ```ts
-    process.env.KEEPALIVE_INTERVAL = "1000";
+process.env.KEEPALIVE_INTERVAL = "1000";
 ```
 
 In `src/config.test.ts:64`, delete:
+
 ```ts
-    expect(config.keepaliveInterval).toBe(1000);
+expect(config.keepaliveInterval).toBe(1000);
 ```
 
 - [ ] **Step 4: Drop the README row**
@@ -158,6 +168,7 @@ git commit -m "refactor(config): drop unused KEEPALIVE_INTERVAL env var"
 ### Task B.2: Replace `pageJpegPaths` with a counter
 
 **Files:**
+
 - Modify: `src/scanner-legacy.ts:149, 598-602, 696-704`
 
 - [ ] **Step 1: Verify current behaviour by replay tests**
@@ -168,12 +179,15 @@ Expected: all replay tests green.
 - [ ] **Step 2: Replace declaration**
 
 In `src/scanner-legacy.ts:149`, change:
+
 ```ts
-    const pageJpegPaths: string[] = [];
+const pageJpegPaths: string[] = [];
 ```
+
 to:
+
 ```ts
-    let pageCount = 0;
+let pageCount = 0;
 ```
 
 - [ ] **Step 3: Replace the `length` reads**
@@ -181,38 +195,47 @@ to:
 Two sites use `pageJpegPaths.length` to test "completed pages so far":
 
 In `src/scanner-legacy.ts:598-599`:
+
 ```ts
           if (session.source === "adf-duplex" && pageJpegPaths.length % 2 === 1) {
             backPageIndices.push(pageJpegPaths.length + 1);
 ```
+
 becomes:
+
 ```ts
           if (session.source === "adf-duplex" && pageCount % 2 === 1) {
             backPageIndices.push(pageCount + 1);
 ```
 
 In `src/scanner-legacy.ts:696`:
+
 ```ts
-        const pageNum = pageJpegPaths.length + 1;
+const pageNum = pageJpegPaths.length + 1;
 ```
+
 becomes:
+
 ```ts
-        const pageNum = pageCount + 1;
+const pageNum = pageCount + 1;
 ```
 
 - [ ] **Step 4: Replace the push**
 
 In `src/scanner-legacy.ts:702-704` the path is computed and `push`ed for `length` only:
+
 ```ts
-        const jpgPath = path.join(sessionTempDir, `page_${String(pageNum).padStart(2, "0")}.jpg`);
-        fs.writeFileSync(jpgPath, jpg);
-        pageJpegPaths.push(jpgPath);
+const jpgPath = path.join(sessionTempDir, `page_${String(pageNum).padStart(2, "0")}.jpg`);
+fs.writeFileSync(jpgPath, jpg);
+pageJpegPaths.push(jpgPath);
 ```
+
 becomes:
+
 ```ts
-        const jpgPath = path.join(sessionTempDir, `page_${String(pageNum).padStart(2, "0")}.jpg`);
-        fs.writeFileSync(jpgPath, jpg);
-        pageCount++;
+const jpgPath = path.join(sessionTempDir, `page_${String(pageNum).padStart(2, "0")}.jpg`);
+fs.writeFileSync(jpgPath, jpg);
+pageCount++;
 ```
 
 - [ ] **Step 5: Run replay tests + lint**
@@ -236,12 +259,14 @@ finalizeSession discovers final paths via readdirSync(sessionTempDir)."
 ### Task B.3: Drop `PUSHSCAN_RESPONSE` export and rewrite the tautology test
 
 **Files:**
+
 - Modify: `src/pushscan.ts:36-40` (drop the const + comment)
 - Modify: `src/pushscan.test.ts:5, 14-36, 51-52` (rewrite tests to call `buildPushScanResponse("1")` inline; drop the `expect(buildPushScanResponse("1")).toBe(PUSHSCAN_RESPONSE)` tautology)
 
 - [ ] **Step 1: Drop the export from pushscan.ts**
 
 In `src/pushscan.ts`, delete lines 37-40:
+
 ```ts
 // Legacy fixed-x-uid response — kept for tests that assert the exact byte
 // layout of the default. The live server builds its response per-request
@@ -252,6 +277,7 @@ export const PUSHSCAN_RESPONSE = buildPushScanResponse("1");
 - [ ] **Step 2: Update pushscan.test.ts imports**
 
 In `src/pushscan.test.ts:4-12`, change:
+
 ```ts
 import {
   PUSHSCAN_RESPONSE,
@@ -259,7 +285,9 @@ import {
   ...
 } from "./pushscan.js";
 ```
+
 to drop `PUSHSCAN_RESPONSE`:
+
 ```ts
 import {
   buildPushScanResponse,
@@ -270,6 +298,7 @@ import {
 - [ ] **Step 3: Rewrite the `describe("PUSHSCAN_RESPONSE", …)` block**
 
 In `src/pushscan.test.ts:14-36`, replace the entire block with one that calls `buildPushScanResponse("1")` inline:
+
 ```ts
 describe("buildPushScanResponse default x-uid (xuid=1)", () => {
   const response = buildPushScanResponse("1");
@@ -301,10 +330,11 @@ describe("buildPushScanResponse default x-uid (xuid=1)", () => {
 - [ ] **Step 4: Drop the tautology test**
 
 In `src/pushscan.test.ts:51-53`, delete:
+
 ```ts
-  it("produces PUSHSCAN_RESPONSE when called with the legacy default '1'", () => {
-    expect(buildPushScanResponse("1")).toBe(PUSHSCAN_RESPONSE);
-  });
+it("produces PUSHSCAN_RESPONSE when called with the legacy default '1'", () => {
+  expect(buildPushScanResponse("1")).toBe(PUSHSCAN_RESPONSE);
+});
 ```
 
 - [ ] **Step 5: Run lint + tests**
@@ -328,6 +358,7 @@ buildPushScanResponse('1') call; drop the tautology assertion."
 ### Task B.4: Tighten `output.ts:promoteTempPagesToOutput` page filter and drop the duplicate regex parse
 
 **Files:**
+
 - Modify: `src/output.ts:92-134`
 - Modify: `src/pdf.ts:38` (also calls `sortedPageFiles`; signature change forces a `.name` access)
 - Modify: `src/output.test.ts` (any tests asserting on `sortedPageFiles` returning strings)
@@ -337,6 +368,7 @@ buildPushScanResponse('1') call; drop the tautology assertion."
 Today `sortedPageFiles` builds `{ name, page }[]` internally and discards `page` on return. The only caller (`promoteTempPagesToOutput`) re-parses it via regex. Extend the return shape:
 
 In `src/output.ts:92-102`, change:
+
 ```ts
 export function sortedPageFiles(names: string[], ext?: string): string[] {
   const extPattern = ext ? ext.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : "[^.]+";
@@ -350,7 +382,9 @@ export function sortedPageFiles(names: string[], ext?: string): string[] {
   return matched.map((e) => e.name);
 }
 ```
+
 to:
+
 ```ts
 export interface PageEntry {
   name: string;
@@ -373,6 +407,7 @@ export function sortedPageFiles(names: string[], ext?: string): PageEntry[] {
 - [ ] **Step 2: Update `promoteTempPagesToOutput` to use the parsed entries and pass the extension filter**
 
 In `src/output.ts:114-134`, change:
+
 ```ts
 export function promoteTempPagesToOutput(
   tempDir: string,
@@ -396,7 +431,9 @@ export function promoteTempPagesToOutput(
   return paths;
 }
 ```
+
 to:
+
 ```ts
 export function promoteTempPagesToOutput(
   tempDir: string,
@@ -425,14 +462,17 @@ export function promoteTempPagesToOutput(
 `pdf.ts:38` is the second caller of `sortedPageFiles`. Today it iterates `entries` and passes each entry directly to `path.join(tempDir, entry)`. With the new shape this is a type error.
 
 In `src/pdf.ts:38`, change:
+
 ```ts
-  const buffers = await Promise.all(entries.map((entry) => fs.readFile(path.join(tempDir, entry))));
+const buffers = await Promise.all(entries.map((entry) => fs.readFile(path.join(tempDir, entry))));
 ```
+
 to:
+
 ```ts
-  const buffers = await Promise.all(
-    entries.map((entry) => fs.readFile(path.join(tempDir, entry.name))),
-  );
+const buffers = await Promise.all(
+  entries.map((entry) => fs.readFile(path.join(tempDir, entry.name))),
+);
 ```
 
 The `for (let i = 0; i < entries.length; i++)` loop a few lines down indexes `entries[i]` to obtain the page number; verify that loop body. If it reads `entries[i]` as a string anywhere (e.g. for a filename), change those reads to `entries[i].name`.
@@ -468,6 +508,7 @@ to read entry.name."
 ### Task B.5: Simplify `paperless-upload.ts:uploadAllToPaperless`
 
 **Files:**
+
 - Modify: `src/paperless-upload.ts:63-76`
 
 - [ ] **Step 1: Verify current behaviour**
@@ -477,6 +518,7 @@ The current code wraps each `uploadOne` in `.catch()` (so it never rejects), the
 - [ ] **Step 2: Replace with a clearer shape**
 
 In `src/paperless-upload.ts:63-76`, change:
+
 ```ts
 export async function uploadAllToPaperless(
   filePaths: string[],
@@ -493,7 +535,9 @@ export async function uploadAllToPaperless(
   );
 }
 ```
+
 to:
+
 ```ts
 export async function uploadAllToPaperless(
   filePaths: string[],
@@ -537,11 +581,13 @@ is 'log every failure, never abort completed scans'."
 ### Task B.6: Consolidate the three Paperless upload sites in `output-tail.ts`
 
 **Files:**
+
 - Modify: `src/output-tail.ts:26-57`
 
 - [ ] **Step 1: Refactor `finalizeSession` to compute `savedPaths` once, then upload once**
 
 In `src/output-tail.ts:26-57`, replace the body of `finalizeSession` with:
+
 ```ts
 export async function finalizeSession(args: FinalizeSessionArgs): Promise<void> {
   const { sessionTempDir, outputDir, sessionTs, action, backPageIndices, paperless } = args;
@@ -595,15 +641,17 @@ decision. No behavioural change."
 ### Task B.7: Drop `synthesiseImageStream` export and fix the orphaned doc comment
 
 **Files:**
+
 - Modify: `src/test-support/legacy-replay.ts:18-26, 52`
 
 - [ ] **Step 1: Drop the export keyword and reattach the doc comment**
 
-In `src/test-support/legacy-replay.ts:18-26` is a doc comment that *should* attach to `synthesiseImageStream` (line 52) but currently sits above `driveFixture`. Move it.
+In `src/test-support/legacy-replay.ts:18-26` is a doc comment that _should_ attach to `synthesiseImageStream` (line 52) but currently sits above `driveFixture`. Move it.
 
 In `src/test-support/legacy-replay.ts:18-31, 52`:
 
 Replace the block at lines 18-31 (the orphaned + driveFixture comments):
+
 ```ts
 /**
  * Synthesise an IS-0xa200 image stream of `totalBytes` total bytes from
@@ -620,7 +668,9 @@ Replace the block at lines 18-31 (the orphaned + driveFixture comments):
  * previous reply), then await the session promise.
  */
 ```
+
 with just the driveFixture comment:
+
 ```ts
 /**
  * Drive a fixture replay: connect the fake socket, feed all printer→host events in
@@ -630,10 +680,13 @@ with just the driveFixture comment:
 ```
 
 In `src/test-support/legacy-replay.ts:52`, change:
+
 ```ts
 export function synthesiseImageStream(totalBytes: number, chunkSize: number): Buffer[] {
 ```
+
 to:
+
 ```ts
 /**
  * Synthesise an IS-0xa200 image stream of `totalBytes` total bytes from
@@ -674,6 +727,7 @@ moved it to the right declaration."
 ### Task B.8: Fix `docs/notes/...` references in tracked source comments
 
 **Files:**
+
 - Modify: `src/esci.ts:71-72`
 - Modify: `src/scanner.ts:598, 818`
 - Modify: `src/pushscan.ts:23`
@@ -683,11 +737,14 @@ moved it to the right declaration."
 - [ ] **Step 1: Replace `esci.ts` references**
 
 In `src/esci.ts:71-72`, change:
+
 ```ts
  * See docs/notes/2026-04-20-multi-page-duplex-analysis.md (ADF variants)
  * and docs/notes/2026-04-21-flatbed-protocol-analysis.md (flatbed diff).
 ```
+
 to:
+
 ```ts
  * See `docs/HOW-IT-WORKS.md` for the protocol layering and per-source
  * variant rationale.
@@ -696,33 +753,42 @@ to:
 - [ ] **Step 2: Replace `scanner.ts:598` reference**
 
 In `src/scanner.ts:598`, change:
+
 ```ts
-      // See docs/notes/2026-04-21-flatbed-protocol-analysis.md.
+// See docs/notes/2026-04-21-flatbed-protocol-analysis.md.
 ```
+
 to:
+
 ```ts
-      // See `docs/HOW-IT-WORKS.md` (ESC/I-2 INIT_POLL section).
+// See `docs/HOW-IT-WORKS.md` (ESC/I-2 INIT_POLL section).
 ```
 
 - [ ] **Step 3: Replace `scanner.ts:818` reference**
 
 In `src/scanner.ts:818`, change:
+
 ```ts
-      // See docs/notes/2026-04-21-flatbed-protocol-analysis.md.
+// See docs/notes/2026-04-21-flatbed-protocol-analysis.md.
 ```
+
 to:
+
 ```ts
-      // See `docs/HOW-IT-WORKS.md` (ESC/I-2 IMG loop / page boundary section).
+// See `docs/HOW-IT-WORKS.md` (ESC/I-2 IMG loop / page boundary section).
 ```
 
 - [ ] **Step 4: Replace `pushscan.ts:23` reference**
 
 In `src/pushscan.ts:22-23`, change:
+
 ```ts
 // even though the scan itself completes. See
 // docs/notes/2026-04-19-panel-error-investigation.md.
 ```
+
 to:
+
 ```ts
 // even though the scan itself completes. See
 // `docs/HOW-IT-WORKS.md` (push-scan trigger section).
@@ -808,6 +874,7 @@ One config-level change. TDD: tests first.
 ### Task C.1: Add `superRefine` rejecting `auto + fingerprint` and tests
 
 **Files:**
+
 - Modify: `src/config.test.ts` (new tests)
 - Modify: `src/config.ts` (new superRefine clause)
 
@@ -816,32 +883,32 @@ One config-level change. TDD: tests first.
 In `src/config.test.ts`, locate the `describe("loadConfig", …)` block. Near the existing test at line 250 (`"rejects PRINTER_CERT_FINGERPRINT with PRINTER_PROTOCOL=legacy"`), add three new tests:
 
 ```ts
-  it("rejects PRINTER_CERT_FINGERPRINT with PRINTER_PROTOCOL=auto", () => {
-    process.env.PRINTER_IP = "10.0.0.1";
-    process.env.PRINTER_PROTOCOL = "auto";
-    process.env.PRINTER_CERT_FINGERPRINT =
-      "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89";
-    expect(() => loadConfig()).toThrow(/PRINTER_PROTOCOL=esci2/);
-  });
+it("rejects PRINTER_CERT_FINGERPRINT with PRINTER_PROTOCOL=auto", () => {
+  process.env.PRINTER_IP = "10.0.0.1";
+  process.env.PRINTER_PROTOCOL = "auto";
+  process.env.PRINTER_CERT_FINGERPRINT =
+    "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89";
+  expect(() => loadConfig()).toThrow(/PRINTER_PROTOCOL=esci2/);
+});
 
-  it("accepts PRINTER_PROTOCOL=auto without a fingerprint", () => {
-    process.env.PRINTER_IP = "10.0.0.1";
-    process.env.PRINTER_PROTOCOL = "auto";
-    expect(loadConfig().printerProtocol).toBe("auto");
-    expect(loadConfig().printerCertFingerprint).toBeUndefined();
-  });
+it("accepts PRINTER_PROTOCOL=auto without a fingerprint", () => {
+  process.env.PRINTER_IP = "10.0.0.1";
+  process.env.PRINTER_PROTOCOL = "auto";
+  expect(loadConfig().printerProtocol).toBe("auto");
+  expect(loadConfig().printerCertFingerprint).toBeUndefined();
+});
 
-  it("accepts PRINTER_CERT_FINGERPRINT with PRINTER_PROTOCOL=esci2", () => {
-    process.env.PRINTER_IP = "10.0.0.1";
-    process.env.PRINTER_PROTOCOL = "esci2";
-    process.env.PRINTER_CERT_FINGERPRINT =
-      "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89";
-    const config = loadConfig();
-    expect(config.printerProtocol).toBe("esci2");
-    expect(config.printerCertFingerprint).toBe(
-      "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89",
-    );
-  });
+it("accepts PRINTER_CERT_FINGERPRINT with PRINTER_PROTOCOL=esci2", () => {
+  process.env.PRINTER_IP = "10.0.0.1";
+  process.env.PRINTER_PROTOCOL = "esci2";
+  process.env.PRINTER_CERT_FINGERPRINT =
+    "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89";
+  const config = loadConfig();
+  expect(config.printerProtocol).toBe("esci2");
+  expect(config.printerCertFingerprint).toBe(
+    "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89",
+  );
+});
 ```
 
 - [ ] **Step 2: Run them — they should fail (the auto+fingerprint test) or pass spuriously**
@@ -933,6 +1000,7 @@ The biggest semantic change of v0.3.0. Re-read spec §3.3 (the failure-mode clas
 ### Task D.1: Add `errorReason + failOnce` machinery to `scanner.ts` and migrate the cert + temp-dir paths
 
 **Files:**
+
 - Modify: `src/scanner.ts:127-308` (Promise constructor + close handler + failOnce + cert path + temp-dir path)
 - Modify: `src/scanner.test.ts` (add two new failing tests)
 
@@ -941,47 +1009,47 @@ The biggest semantic change of v0.3.0. Re-read spec §3.3 (the failure-mode clas
 In `src/scanner.test.ts`, near the existing fixture tests, add:
 
 ```ts
-  describe("startScanSession failure-mode matrix", () => {
-    it("rejects when the printer cert fingerprint does not match the pin", async () => {
-      const fake = new FakeTlsSocket();
-      fake.setPeerCertificate("AA:BB:CC"); // FakeTlsSocket.setPeerCertificate takes a string
-      const scanPromise = startScanSession(
-        {
-          printerIp: "1.2.3.4",
-          port: 1865,
-          destId: 0x02,
-          outputDir: "/tmp/out-doesnotmatter",
-          tempDir: "/tmp",
-          duplex: false,
-          action: "jpg",
-          paperless: undefined,
-          printerCertFingerprint: "DE:AD:BE:EF",
-        },
-        fake.asFactory(),
-      );
-      fake.simulateConnect();
-      await expect(scanPromise).rejects.toThrow(/fingerprint mismatch/i);
-    });
-
-    it("rejects when the session temp dir cannot be created", async () => {
-      const fake = new FakeTlsSocket();
-      // tempDir points at a path that mkdtempSync cannot resolve.
-      const scanPromise = startScanSession(
-        {
-          printerIp: "1.2.3.4",
-          port: 1865,
-          destId: 0x02,
-          outputDir: "/tmp/out-doesnotmatter",
-          tempDir: "/this/path/definitely/does/not/exist",
-          duplex: false,
-          action: "jpg",
-          paperless: undefined,
-        },
-        fake.asFactory(),
-      );
-      await expect(scanPromise).rejects.toThrow(/temp dir/i);
-    });
+describe("startScanSession failure-mode matrix", () => {
+  it("rejects when the printer cert fingerprint does not match the pin", async () => {
+    const fake = new FakeTlsSocket();
+    fake.setPeerCertificate("AA:BB:CC"); // FakeTlsSocket.setPeerCertificate takes a string
+    const scanPromise = startScanSession(
+      {
+        printerIp: "1.2.3.4",
+        port: 1865,
+        destId: 0x02,
+        outputDir: "/tmp/out-doesnotmatter",
+        tempDir: "/tmp",
+        duplex: false,
+        action: "jpg",
+        paperless: undefined,
+        printerCertFingerprint: "DE:AD:BE:EF",
+      },
+      fake.asFactory(),
+    );
+    fake.simulateConnect();
+    await expect(scanPromise).rejects.toThrow(/fingerprint mismatch/i);
   });
+
+  it("rejects when the session temp dir cannot be created", async () => {
+    const fake = new FakeTlsSocket();
+    // tempDir points at a path that mkdtempSync cannot resolve.
+    const scanPromise = startScanSession(
+      {
+        printerIp: "1.2.3.4",
+        port: 1865,
+        destId: 0x02,
+        outputDir: "/tmp/out-doesnotmatter",
+        tempDir: "/this/path/definitely/does/not/exist",
+        duplex: false,
+        action: "jpg",
+        paperless: undefined,
+      },
+      fake.asFactory(),
+    );
+    await expect(scanPromise).rejects.toThrow(/temp dir/i);
+  });
+});
 ```
 
 (Adjust the import for `FakeTlsSocket` — likely `import { FakeTlsSocket } from "./test-support/fake-tls-socket.js";`. Check the existing imports in `scanner.test.ts` for the pattern.)
@@ -996,50 +1064,58 @@ Expected: both tests FAIL — the cert mismatch resolves silently today; the tem
 In `src/scanner.ts:131-308`, change the constructor to expose `reject`:
 
 Before (line 131):
+
 ```ts
   return new Promise<void>((resolve) => {
 ```
+
 After:
+
 ```ts
   return new Promise<void>((resolve, reject) => {
     let errorReason: Error | null = null;
 ```
 
 Below `resolveOnce` (which sits around line 133-137), add `rejectOnce`:
+
 ```ts
-    const rejectOnce = (err: Error): void => {
-      if (resolved) return;
-      resolved = true;
-      reject(err);
-    };
-    const failOnce = (err: Error): void => {
-      if (errorReason) return; // first-error wins
-      errorReason = err;
-      transitionToError(); // existing helper triggers the close cascade
-    };
+const rejectOnce = (err: Error): void => {
+  if (resolved) return;
+  resolved = true;
+  reject(err);
+};
+const failOnce = (err: Error): void => {
+  if (errorReason) return; // first-error wins
+  errorReason = err;
+  transitionToError(); // existing helper triggers the close cascade
+};
 ```
 
 In the `socket.on("close", () => { … })` handler at line 304-308, change:
+
 ```ts
-    socket.on("close", () => {
-      clearTimeoutTimer();
-      log.info("TLS connection closed");
-      resolveOnce();
-    });
+socket.on("close", () => {
+  clearTimeoutTimer();
+  log.info("TLS connection closed");
+  resolveOnce();
+});
 ```
+
 to:
+
 ```ts
-    socket.on("close", () => {
-      clearTimeoutTimer();
-      log.info("TLS connection closed");
-      if (errorReason) rejectOnce(errorReason);
-      else resolveOnce();
-    });
+socket.on("close", () => {
+  clearTimeoutTimer();
+  log.info("TLS connection closed");
+  if (errorReason) rejectOnce(errorReason);
+  else resolveOnce();
+});
 ```
 
 - [ ] **Step 4: Migrate the temp-dir-failure path (direct reject)**
 
 In `src/scanner.ts:152-156`, change:
+
 ```ts
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -1048,7 +1124,9 @@ In `src/scanner.ts:152-156`, change:
       return; // never start the TLS session
     }
 ```
+
 to:
+
 ```ts
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -1061,55 +1139,58 @@ to:
 - [ ] **Step 5: Migrate the cert-fingerprint mismatch path**
 
 In `src/scanner.ts:212-232` (the cert-fingerprint check inside the TLS connect callback), change the early-return block from:
+
 ```ts
-        if (session.printerCertFingerprint) {
-          const peer = socket.getPeerCertificate();
-          const actual = peer?.fingerprint256;
-          if (actual !== session.printerCertFingerprint) {
-            log.error(
-              `Printer cert fingerprint mismatch — expected ${session.printerCertFingerprint}, ` +
-                `got ${actual ?? "(none)"} — aborting scan`,
-            );
-            state = "ERROR";
-            clearTimeoutTimer();
-            try {
-              fs.rmSync(sessionTempDir, { recursive: true, force: true });
-            } catch {
-              /* ignore — cleanup best-effort */
-            }
-            socket.destroy();
-            // Don't call transitionToError() — it sends an UNLOCK packet, but
-            // we never sent the LOCK (we're aborting at handshake). The
-            // socket's "close" handler resolves the outer promise.
-            return;
-          }
-          log.debug(`Printer cert fingerprint verified: ${actual}`);
-        }
+if (session.printerCertFingerprint) {
+  const peer = socket.getPeerCertificate();
+  const actual = peer?.fingerprint256;
+  if (actual !== session.printerCertFingerprint) {
+    log.error(
+      `Printer cert fingerprint mismatch — expected ${session.printerCertFingerprint}, ` +
+        `got ${actual ?? "(none)"} — aborting scan`,
+    );
+    state = "ERROR";
+    clearTimeoutTimer();
+    try {
+      fs.rmSync(sessionTempDir, { recursive: true, force: true });
+    } catch {
+      /* ignore — cleanup best-effort */
+    }
+    socket.destroy();
+    // Don't call transitionToError() — it sends an UNLOCK packet, but
+    // we never sent the LOCK (we're aborting at handshake). The
+    // socket's "close" handler resolves the outer promise.
+    return;
+  }
+  log.debug(`Printer cert fingerprint verified: ${actual}`);
+}
 ```
+
 to:
+
 ```ts
-        if (session.printerCertFingerprint) {
-          const peer = socket.getPeerCertificate();
-          const actual = peer?.fingerprint256;
-          if (actual !== session.printerCertFingerprint) {
-            const msg =
-              `Printer cert fingerprint mismatch — expected ${session.printerCertFingerprint}, ` +
-              `got ${actual ?? "(none)"}`;
-            log.error(`${msg} — aborting scan`);
-            errorReason = new Error(msg);
-            state = "ERROR";
-            clearTimeoutTimer();
-            try {
-              fs.rmSync(sessionTempDir, { recursive: true, force: true });
-            } catch {
-              /* ignore — cleanup best-effort */
-            }
-            socket.destroy();
-            // Close handler reads errorReason and rejects.
-            return;
-          }
-          log.debug(`Printer cert fingerprint verified: ${actual}`);
-        }
+if (session.printerCertFingerprint) {
+  const peer = socket.getPeerCertificate();
+  const actual = peer?.fingerprint256;
+  if (actual !== session.printerCertFingerprint) {
+    const msg =
+      `Printer cert fingerprint mismatch — expected ${session.printerCertFingerprint}, ` +
+      `got ${actual ?? "(none)"}`;
+    log.error(`${msg} — aborting scan`);
+    errorReason = new Error(msg);
+    state = "ERROR";
+    clearTimeoutTimer();
+    try {
+      fs.rmSync(sessionTempDir, { recursive: true, force: true });
+    } catch {
+      /* ignore — cleanup best-effort */
+    }
+    socket.destroy();
+    // Close handler reads errorReason and rejects.
+    return;
+  }
+  log.debug(`Printer cert fingerprint verified: ${actual}`);
+}
 ```
 
 - [ ] **Step 6: Re-run the two new tests**
@@ -1142,6 +1223,7 @@ finalize failure) follow in subsequent commits."
 ### Task D.2: Migrate the `transitionToError` sites (timeout, socket error, async cancel/fatal, ensure failures)
 
 **Files:**
+
 - Modify: `src/scanner.ts` (timeout, socket error, async events, ensure-failure sites)
 - Modify: `src/scanner.test.ts` (5 new failure-mode tests)
 
@@ -1150,126 +1232,126 @@ finalize failure) follow in subsequent commits."
 Add inside the `describe("startScanSession failure-mode matrix", …)` block:
 
 ```ts
-    it("rejects on timeout (no response in TIMEOUT_MS)", async () => {
-      // CRITICAL: install fake timers BEFORE startScanSession runs. The scanner
-      // schedules a setTimeout(TIMEOUT_MS) inside the connect callback fired by
-      // simulateConnect(); if useFakeTimers is called after, the real timer is
-      // already armed and advancing fake timers won't fire it.
-      vi.useFakeTimers();
-      try {
-        const fake = new FakeTlsSocket();
-        const scanPromise = startScanSession(
-          {
-            printerIp: "1.2.3.4",
-            port: 1865,
-            destId: 0x02,
-            outputDir: "/tmp",
-            tempDir: "/tmp",
-            duplex: false,
-            action: "jpg",
-            paperless: undefined,
-          },
-          fake.asFactory(),
-        );
-        fake.simulateConnect();
-        // TIMEOUT_MS is 30_000 in scanner.ts (line 113); 60_000 overshoots safely.
-        await vi.advanceTimersByTimeAsync(60_000);
-        await expect(scanPromise).rejects.toThrow(/timeout/i);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
+it("rejects on timeout (no response in TIMEOUT_MS)", async () => {
+  // CRITICAL: install fake timers BEFORE startScanSession runs. The scanner
+  // schedules a setTimeout(TIMEOUT_MS) inside the connect callback fired by
+  // simulateConnect(); if useFakeTimers is called after, the real timer is
+  // already armed and advancing fake timers won't fire it.
+  vi.useFakeTimers();
+  try {
+    const fake = new FakeTlsSocket();
+    const scanPromise = startScanSession(
+      {
+        printerIp: "1.2.3.4",
+        port: 1865,
+        destId: 0x02,
+        outputDir: "/tmp",
+        tempDir: "/tmp",
+        duplex: false,
+        action: "jpg",
+        paperless: undefined,
+      },
+      fake.asFactory(),
+    );
+    fake.simulateConnect();
+    // TIMEOUT_MS is 30_000 in scanner.ts (line 113); 60_000 overshoots safely.
+    await vi.advanceTimersByTimeAsync(60_000);
+    await expect(scanPromise).rejects.toThrow(/timeout/i);
+  } finally {
+    vi.useRealTimers();
+  }
+});
 
-    it("rejects on socket error mid-session", async () => {
-      const fake = new FakeTlsSocket();
-      const scanPromise = startScanSession(
-        {
-          printerIp: "1.2.3.4",
-          port: 1865,
-          destId: 0x02,
-          outputDir: "/tmp",
-          tempDir: "/tmp",
-          duplex: false,
-          action: "jpg",
-          paperless: undefined,
-        },
-        fake.asFactory(),
-      );
-      fake.simulateConnect();
-      fake.emit("error", Object.assign(new Error("ECONNREFUSED"), { code: "ECONNREFUSED" }));
-      await expect(scanPromise).rejects.toThrow(/ECONNREFUSED/);
-    });
+it("rejects on socket error mid-session", async () => {
+  const fake = new FakeTlsSocket();
+  const scanPromise = startScanSession(
+    {
+      printerIp: "1.2.3.4",
+      port: 1865,
+      destId: 0x02,
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      duplex: false,
+      action: "jpg",
+      paperless: undefined,
+    },
+    fake.asFactory(),
+  );
+  fake.simulateConnect();
+  fake.emit("error", Object.assign(new Error("ECONNREFUSED"), { code: "ECONNREFUSED" }));
+  await expect(scanPromise).rejects.toThrow(/ECONNREFUSED/);
+});
 
-    it("rejects on async ScanCancel event mid-session", async () => {
-      const fake = new FakeTlsSocket();
-      const scanPromise = startScanSession(
-        {
-          printerIp: "1.2.3.4",
-          port: 1865,
-          destId: 0x02,
-          outputDir: "/tmp",
-          tempDir: "/tmp",
-          duplex: false,
-          action: "jpg",
-          paperless: undefined,
-        },
-        fake.asFactory(),
-      );
-      fake.simulateConnect();
-      // Feed a synthesised IS-0x9000 packet with payload [0x03] (ScanCancel).
-      // Use buildIsPacket(0x9000, Buffer.from([0x03])) from src/protocol.ts.
-      const cancelPacket = buildIsPacket(0x9000, Buffer.from([0x03]));
-      fake.feed(cancelPacket);
-      await expect(scanPromise).rejects.toThrow(/ScanCancel/);
-    });
+it("rejects on async ScanCancel event mid-session", async () => {
+  const fake = new FakeTlsSocket();
+  const scanPromise = startScanSession(
+    {
+      printerIp: "1.2.3.4",
+      port: 1865,
+      destId: 0x02,
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      duplex: false,
+      action: "jpg",
+      paperless: undefined,
+    },
+    fake.asFactory(),
+  );
+  fake.simulateConnect();
+  // Feed a synthesised IS-0x9000 packet with payload [0x03] (ScanCancel).
+  // Use buildIsPacket(0x9000, Buffer.from([0x03])) from src/protocol.ts.
+  const cancelPacket = buildIsPacket(0x9000, Buffer.from([0x03]));
+  fake.feed(cancelPacket);
+  await expect(scanPromise).rejects.toThrow(/ScanCancel/);
+});
 
-    it("rejects on async fatal event mid-session", async () => {
-      const fake = new FakeTlsSocket();
-      const scanPromise = startScanSession(
-        {
-          printerIp: "1.2.3.4",
-          port: 1865,
-          destId: 0x02,
-          outputDir: "/tmp",
-          tempDir: "/tmp",
-          duplex: false,
-          action: "jpg",
-          paperless: undefined,
-        },
-        fake.asFactory(),
-      );
-      fake.simulateConnect();
-      // ASYNC_FATAL in scanner.ts:124 contains 0x02 (Disconnect), 0x80 (Timeout),
-      // 0xa0 (ServerError). Use 0x02. (0x05 is "unknown" and falls through to
-      // log.warn with no rejection.)
-      const fatalPacket = buildIsPacket(0x9000, Buffer.from([0x02]));
-      fake.feed(fatalPacket);
-      await expect(scanPromise).rejects.toThrow(/fatal/i);
-    });
+it("rejects on async fatal event mid-session", async () => {
+  const fake = new FakeTlsSocket();
+  const scanPromise = startScanSession(
+    {
+      printerIp: "1.2.3.4",
+      port: 1865,
+      destId: 0x02,
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      duplex: false,
+      action: "jpg",
+      paperless: undefined,
+    },
+    fake.asFactory(),
+  );
+  fake.simulateConnect();
+  // ASYNC_FATAL in scanner.ts:124 contains 0x02 (Disconnect), 0x80 (Timeout),
+  // 0xa0 (ServerError). Use 0x02. (0x05 is "unknown" and falls through to
+  // log.warn with no rejection.)
+  const fatalPacket = buildIsPacket(0x9000, Buffer.from([0x02]));
+  fake.feed(fatalPacket);
+  await expect(scanPromise).rejects.toThrow(/fatal/i);
+});
 
-    it("rejects on per-state assertion failure (unexpected packet type)", async () => {
-      const fake = new FakeTlsSocket();
-      const scanPromise = startScanSession(
-        {
-          printerIp: "1.2.3.4",
-          port: 1865,
-          destId: 0x02,
-          outputDir: "/tmp",
-          tempDir: "/tmp",
-          duplex: false,
-          action: "jpg",
-          paperless: undefined,
-        },
-        fake.asFactory(),
-      );
-      fake.simulateConnect();
-      // Feed a packet whose type doesn't match the WELCOME state's expectation.
-      // Confirm by reading src/scanner.ts:onWelcome — it expects type 0xa000.
-      // Feed type 0xa999 instead to force ensure(... === 0xa000, ...) to fail.
-      const wrongTypePacket = buildIsPacket(0xa999, Buffer.alloc(0));
-      fake.feed(wrongTypePacket);
-      await expect(scanPromise).rejects.toThrow(/protocol error/i);
-    });
+it("rejects on per-state assertion failure (unexpected packet type)", async () => {
+  const fake = new FakeTlsSocket();
+  const scanPromise = startScanSession(
+    {
+      printerIp: "1.2.3.4",
+      port: 1865,
+      destId: 0x02,
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      duplex: false,
+      action: "jpg",
+      paperless: undefined,
+    },
+    fake.asFactory(),
+  );
+  fake.simulateConnect();
+  // Feed a packet whose type doesn't match the WELCOME state's expectation.
+  // Confirm by reading src/scanner.ts:onWelcome — it expects type 0xa000.
+  // Feed type 0xa999 instead to force ensure(... === 0xa000, ...) to fail.
+  const wrongTypePacket = buildIsPacket(0xa999, Buffer.alloc(0));
+  fake.feed(wrongTypePacket);
+  await expect(scanPromise).rejects.toThrow(/protocol error/i);
+});
 ```
 
 - [ ] **Step 2: Run them, all should fail**
@@ -1280,71 +1362,78 @@ Expected: 5 of these new tests FAIL (resolve silently or never settle); the 2 fr
 - [ ] **Step 3: Migrate the timeout site**
 
 In `src/scanner.ts:185-190` (resetTimeout), change:
+
 ```ts
-    const resetTimeout = () => {
-      if (timeoutTimer) clearTimeout(timeoutTimer);
-      timeoutTimer = setTimeout(() => {
-        log.error(`Timeout in state ${state} — no response in ${TIMEOUT_MS}ms`);
-        transitionToError();
-      }, TIMEOUT_MS);
-    };
+const resetTimeout = () => {
+  if (timeoutTimer) clearTimeout(timeoutTimer);
+  timeoutTimer = setTimeout(() => {
+    log.error(`Timeout in state ${state} — no response in ${TIMEOUT_MS}ms`);
+    transitionToError();
+  }, TIMEOUT_MS);
+};
 ```
+
 to:
+
 ```ts
-    const resetTimeout = () => {
-      if (timeoutTimer) clearTimeout(timeoutTimer);
-      timeoutTimer = setTimeout(() => {
-        const msg = `Timeout in state ${state} — no response in ${TIMEOUT_MS}ms`;
-        log.error(msg);
-        failOnce(new Error(msg));
-      }, TIMEOUT_MS);
-    };
+const resetTimeout = () => {
+  if (timeoutTimer) clearTimeout(timeoutTimer);
+  timeoutTimer = setTimeout(() => {
+    const msg = `Timeout in state ${state} — no response in ${TIMEOUT_MS}ms`;
+    log.error(msg);
+    failOnce(new Error(msg));
+  }, TIMEOUT_MS);
+};
 ```
 
 - [ ] **Step 4: Migrate the socket-error site**
 
 In `src/scanner.ts:285-302` (the `socket.on("error", …)` handler), change:
+
 ```ts
-    socket.on("error", (err: NodeJS.ErrnoException) => {
-      if (state === "DONE" && err.code === "ECONNRESET") {
-        log.debug("Benign post-unlock ECONNRESET (scan already saved)");
-        clearTimeoutTimer();
-        return;
-      }
-      if (state === "ERROR") {
-        log.debug(`Post-destroy error ignored: ${err.message}`);
-        return;
-      }
-      log.error(`TLS connection error in state ${state}`, err);
-      clearTimeoutTimer();
-      if (state !== "DONE") {
-        transitionToError();
-      }
-    });
+socket.on("error", (err: NodeJS.ErrnoException) => {
+  if (state === "DONE" && err.code === "ECONNRESET") {
+    log.debug("Benign post-unlock ECONNRESET (scan already saved)");
+    clearTimeoutTimer();
+    return;
+  }
+  if (state === "ERROR") {
+    log.debug(`Post-destroy error ignored: ${err.message}`);
+    return;
+  }
+  log.error(`TLS connection error in state ${state}`, err);
+  clearTimeoutTimer();
+  if (state !== "DONE") {
+    transitionToError();
+  }
+});
 ```
+
 to:
+
 ```ts
-    socket.on("error", (err: NodeJS.ErrnoException) => {
-      if (state === "DONE" && err.code === "ECONNRESET") {
-        log.debug("Benign post-unlock ECONNRESET (scan already saved)");
-        clearTimeoutTimer();
-        return;
-      }
-      if (state === "ERROR") {
-        log.debug(`Post-destroy error ignored: ${err.message}`);
-        return;
-      }
-      log.error(`TLS connection error in state ${state}`, err);
-      clearTimeoutTimer();
-      if (state !== "DONE") {
-        failOnce(new Error(`TLS connection error in state ${state}: ${err.message}`));
-      }
-    });
+socket.on("error", (err: NodeJS.ErrnoException) => {
+  if (state === "DONE" && err.code === "ECONNRESET") {
+    log.debug("Benign post-unlock ECONNRESET (scan already saved)");
+    clearTimeoutTimer();
+    return;
+  }
+  if (state === "ERROR") {
+    log.debug(`Post-destroy error ignored: ${err.message}`);
+    return;
+  }
+  log.error(`TLS connection error in state ${state}`, err);
+  clearTimeoutTimer();
+  if (state !== "DONE") {
+    failOnce(new Error(`TLS connection error in state ${state}: ${err.message}`));
+  }
+});
 ```
 
 - [ ] **Step 5: Migrate the async-cancel and async-fatal sites**
 
 In `src/scanner.ts:359-364` (handleAsyncEvent), change:
+
 ```ts
       } else if (ASYNC_CANCEL.has(dispatch)) {
         log.warn(`Async event: ScanCancel (0x${dispatch.toString(16)}) — aborting`);
@@ -1353,7 +1442,9 @@ In `src/scanner.ts:359-364` (handleAsyncEvent), change:
         log.error(`Async event: fatal (0x${dispatch.toString(16)}) — aborting`);
         transitionToError();
 ```
+
 to:
+
 ```ts
       } else if (ASYNC_CANCEL.has(dispatch)) {
         log.warn(`Async event: ScanCancel (0x${dispatch.toString(16)}) — aborting`);
@@ -1365,29 +1456,32 @@ to:
 
 - [ ] **Step 6: Migrate the `ensure(...)` failure site**
 
-In `src/scanner.ts:442-448` (the `ensure` helper) — confirm the current shape with a Read first. The helper likely calls `transitionToError()` on `false`. Change it to call `failOnce(new Error(message))` instead, *then* return `false`:
+In `src/scanner.ts:442-448` (the `ensure` helper) — confirm the current shape with a Read first. The helper likely calls `transitionToError()` on `false`. Change it to call `failOnce(new Error(message))` instead, _then_ return `false`:
 
 Before (approximate; verify by Read):
+
 ```ts
-    function ensure(condition: boolean, message: string): boolean {
-      if (!condition) {
-        log.error(message);
-        transitionToError();
-        return false;
-      }
-      return true;
-    }
+function ensure(condition: boolean, message: string): boolean {
+  if (!condition) {
+    log.error(message);
+    transitionToError();
+    return false;
+  }
+  return true;
+}
 ```
+
 After:
+
 ```ts
-    function ensure(condition: boolean, message: string): boolean {
-      if (!condition) {
-        log.error(message);
-        failOnce(new Error(`Protocol error in state ${state}: ${message}`));
-        return false;
-      }
-      return true;
-    }
+function ensure(condition: boolean, message: string): boolean {
+  if (!condition) {
+    log.error(message);
+    failOnce(new Error(`Protocol error in state ${state}: ${message}`));
+    return false;
+  }
+  return true;
+}
 ```
 
 - [ ] **Step 7: Run all the failure-mode tests**
@@ -1414,6 +1508,7 @@ error message. Adds five failure-mode tests."
 ### Task D.3: Migrate completion-path failures (zero-image, finalize), pin post-scan-save fallback unchanged
 
 **Files:**
+
 - Modify: `src/scanner.ts:978-999` (zero-image + finalize tail)
 - Modify: `src/scanner.test.ts` (3 new tests)
 
@@ -1423,7 +1518,7 @@ Three failure-mode rows are migrated by code change without a dedicated TDD unit
 
 - **Zero-image completion** (`scanner.ts:978-981`). Reaching this site requires a synthesised wire trace that ends in UNLOCK without any IS-0xa000 IMG_DATA — non-trivial fixture surgery for a single state.
 - **`finalizeSession` failure** (`scanner.ts:992`). Reaching this requires mocking `finalizeSession` to throw, which means restructuring the import for vi.mock-ability.
-- **Post-scan-save fallback resolves** (`scanner.ts:258-262`). Triggering this requires injecting a NAK/error response during POSTSCAN_* while keeping imageChunks non-empty — the most fixture-fragile of the three.
+- **Post-scan-save fallback resolves** (`scanner.ts:258-262`). Triggering this requires injecting a NAK/error response during POSTSCAN\_\* while keeping imageChunks non-empty — the most fixture-fragile of the three.
 
 These are accepted as a v0.3.0 coverage gap, mitigated by:
 
@@ -1437,27 +1532,30 @@ These are accepted as a v0.3.0 coverage gap, mitigated by:
 - [ ] **Step 2: Migrate the zero-image-completion site**
 
 In `src/scanner.ts:977-981`, change:
+
 ```ts
-      socket.end();
-      if (imageChunks.length === 0) {
-        log.error("Scan completed with zero image chunks");
-        return;
-      }
+socket.end();
+if (imageChunks.length === 0) {
+  log.error("Scan completed with zero image chunks");
+  return;
+}
 ```
+
 to:
+
 ```ts
-      if (imageChunks.length === 0) {
-        log.error("Scan completed with zero image chunks");
-        // rejectOnce BEFORE socket.end(): on a real TLS socket end() is async, but
-        // FakeTlsSocket.end() emits "close" synchronously — the close handler
-        // would call resolveOnce() before we ever set errorReason. Reject up
-        // front; socket.end() afterwards just cleans up the socket (resolveOnce
-        // in the close handler will be a no-op via the `resolved` guard).
-        rejectOnce(new Error("Scan completed with zero image chunks"));
-        socket.end();
-        return;
-      }
-      socket.end();
+if (imageChunks.length === 0) {
+  log.error("Scan completed with zero image chunks");
+  // rejectOnce BEFORE socket.end(): on a real TLS socket end() is async, but
+  // FakeTlsSocket.end() emits "close" synchronously — the close handler
+  // would call resolveOnce() before we ever set errorReason. Reject up
+  // front; socket.end() afterwards just cleans up the socket (resolveOnce
+  // in the close handler will be a no-op via the `resolved` guard).
+  rejectOnce(new Error("Scan completed with zero image chunks"));
+  socket.end();
+  return;
+}
+socket.end();
 ```
 
 - [ ] **Step 3: Migrate the finalizeSession-failure site**
@@ -1465,6 +1563,7 @@ to:
 In `src/scanner.ts:990-998`, change the `.catch()` body to populate `errorReason`:
 
 Before:
+
 ```ts
         finalizeSession({...})
           .catch((err: unknown) => {
@@ -1475,7 +1574,9 @@ Before:
             resolveOnce();
           });
 ```
+
 After:
+
 ```ts
         finalizeSession({...})
           .catch((err: unknown) => {
@@ -1494,28 +1595,31 @@ After:
 
 - [ ] **Step 4: Verify post-scan-save fallback path is untouched**
 
-In `src/scanner.ts:249-274` (transitionToError), confirm the `inPostScan && imageChunks.length > 0` branch still calls `finalizeScan()` *without* setting `errorReason`. If `errorReason` is null at that point, the close handler resolves — which is the desired "images survived a glitch" success behaviour.
+In `src/scanner.ts:249-274` (transitionToError), confirm the `inPostScan && imageChunks.length > 0` branch still calls `finalizeScan()` _without_ setting `errorReason`. If `errorReason` is null at that point, the close handler resolves — which is the desired "images survived a glitch" success behaviour.
 
-If you find that earlier sites (e.g., the per-state `ensure(...)`) populated `errorReason` *before* reaching this branch, the resolve-anyway requirement will be violated. Mitigate: in the `inPostScan && imageChunks.length > 0` branch, *clear* `errorReason` before calling `finalizeScan()`:
+If you find that earlier sites (e.g., the per-state `ensure(...)`) populated `errorReason` _before_ reaching this branch, the resolve-anyway requirement will be violated. Mitigate: in the `inPostScan && imageChunks.length > 0` branch, _clear_ `errorReason` before calling `finalizeScan()`:
 
 In `src/scanner.ts:258-262`, change:
+
 ```ts
-      if (inPostScan && imageChunks.length > 0) {
-        log.warn(`Error during post-scan cleanup in ${priorState} — saving captured image anyway`);
-        finalizeScan();
-        return;
-      }
+if (inPostScan && imageChunks.length > 0) {
+  log.warn(`Error during post-scan cleanup in ${priorState} — saving captured image anyway`);
+  finalizeScan();
+  return;
+}
 ```
+
 to:
+
 ```ts
-      if (inPostScan && imageChunks.length > 0) {
-        log.warn(`Error during post-scan cleanup in ${priorState} — saving captured image anyway`);
-        // Cleanup-state error after the IMG loop succeeded is treated as success;
-        // clear any error captured during cleanup so the close handler resolves.
-        errorReason = null;
-        finalizeScan();
-        return;
-      }
+if (inPostScan && imageChunks.length > 0) {
+  log.warn(`Error during post-scan cleanup in ${priorState} — saving captured image anyway`);
+  // Cleanup-state error after the IMG loop succeeded is treated as success;
+  // clear any error captured during cleanup so the close handler resolves.
+  errorReason = null;
+  finalizeScan();
+  return;
+}
 ```
 
 - [ ] **Step 5: Run replay tests**
@@ -1546,16 +1650,18 @@ paths."
 ### Task D.4: Symmetric `errorReason + failOnce` shape in `scanner-legacy.ts` + matrix tests
 
 **Files:**
+
 - Modify: `src/scanner-legacy.ts:130-201` (the existing `fail()` already rejects; align its shape with scanner.ts)
 - Modify: `src/scanner-legacy.test.ts` (add failure-mode tests where fixtures permit)
 
 - [ ] **Step 1: Read `scanner-legacy.ts:183-201` to understand existing shape**
 
-The legacy path already rejects via `fail()`. The work here is alignment — give it the same `failOnce(err: Error)` *and* `errorReason` variable so v0.4.0's engine extraction lifts a single shape.
+The legacy path already rejects via `fail()`. The work here is alignment — give it the same `failOnce(err: Error)` _and_ `errorReason` variable so v0.4.0's engine extraction lifts a single shape.
 
 In `src/scanner-legacy.ts:140-201`, refactor:
 
 Before:
+
 ```ts
     let resolved = false;
     ...
@@ -1570,7 +1676,9 @@ Before:
       reject(new Error(reason));
     }
 ```
+
 After (preserve all the existing cleanup code; just add `errorReason` + introduce `failOnce` while keeping `fail` as a thin wrapper for the existing call sites):
+
 ```ts
     let resolved = false;
     let errorReason: Error | null = null;
@@ -1607,51 +1715,51 @@ After (preserve all the existing cleanup code; just add `errorReason` + introduc
 Below the existing describe block, add:
 
 ```ts
-  describe("startScanSessionLegacy failure-mode matrix", () => {
-    it("rejects on socket error mid-session", async () => {
-      const fake = new FakeTcpSocket();
-      const scanPromise = startScanSessionLegacy(
-        {
-          printerIp: "1.2.3.4",
-          port: 1865,
-          outputDir,
-          tempDir,
-          source: "adf-simplex",
-          format: "jpg",
-          jpegQuality: 90,
-        },
-        fake.asFactory(),
-      );
-      fake.simulateConnect();
-      fake.emit("error", new Error("ECONNREFUSED"));
-      await expect(scanPromise).rejects.toThrow(/socket error|ECONNREFUSED/i);
-    });
-
-    it("rejects on protocol violation (welcome with wrong packet type)", async () => {
-      const fake = new FakeTcpSocket();
-      const scanPromise = startScanSessionLegacy(
-        {
-          printerIp: "1.2.3.4",
-          port: 1865,
-          outputDir,
-          tempDir,
-          duplex: false,
-          forcedSource: "adf-simplex", // forcedSource short-circuits STATUS_2; matches old test shape
-          format: "jpg",
-          jpegQuality: 90,
-        },
-        fake.asFactory(),
-      );
-      fake.simulateConnect();
-      // WELCOME state expects a valid IS packet of type 0x8000 (scanner-legacy.ts:247).
-      // Feed type 0xa000 instead — fail() rejects immediately with
-      //   "expected welcome (0x8000), got 0xa000".
-      // (Raw garbage that doesn't form a valid IS header would just buffer until
-      //  the 60s timeout, not reject.)
-      fake.feed(buildIsPacket(0xa000, Buffer.alloc(0)));
-      await expect(scanPromise).rejects.toThrow(/expected welcome \(0x8000\)/);
-    });
+describe("startScanSessionLegacy failure-mode matrix", () => {
+  it("rejects on socket error mid-session", async () => {
+    const fake = new FakeTcpSocket();
+    const scanPromise = startScanSessionLegacy(
+      {
+        printerIp: "1.2.3.4",
+        port: 1865,
+        outputDir,
+        tempDir,
+        source: "adf-simplex",
+        format: "jpg",
+        jpegQuality: 90,
+      },
+      fake.asFactory(),
+    );
+    fake.simulateConnect();
+    fake.emit("error", new Error("ECONNREFUSED"));
+    await expect(scanPromise).rejects.toThrow(/socket error|ECONNREFUSED/i);
   });
+
+  it("rejects on protocol violation (welcome with wrong packet type)", async () => {
+    const fake = new FakeTcpSocket();
+    const scanPromise = startScanSessionLegacy(
+      {
+        printerIp: "1.2.3.4",
+        port: 1865,
+        outputDir,
+        tempDir,
+        duplex: false,
+        forcedSource: "adf-simplex", // forcedSource short-circuits STATUS_2; matches old test shape
+        format: "jpg",
+        jpegQuality: 90,
+      },
+      fake.asFactory(),
+    );
+    fake.simulateConnect();
+    // WELCOME state expects a valid IS packet of type 0x8000 (scanner-legacy.ts:247).
+    // Feed type 0xa000 instead — fail() rejects immediately with
+    //   "expected welcome (0x8000), got 0xa000".
+    // (Raw garbage that doesn't form a valid IS header would just buffer until
+    //  the 60s timeout, not reject.)
+    fake.feed(buildIsPacket(0xa000, Buffer.alloc(0)));
+    await expect(scanPromise).rejects.toThrow(/expected welcome \(0x8000\)/);
+  });
+});
 ```
 
 - [ ] **Step 3: Run the new tests**
@@ -1726,6 +1834,7 @@ The largest single PR of v0.3.0. Per the spec, this is one combined PR with inte
 ### Task E.1: Add `legacyDetectSource` Result-type helper + unit tests
 
 **Files:**
+
 - Modify: `src/esci-legacy.ts` (new export)
 - Create: `src/esci-legacy.test.ts` (new file with the unit tests)
 
@@ -1774,9 +1883,7 @@ Expected: all 6 tests FAIL — `legacyDetectSource` is not exported.
 At the bottom of `src/esci-legacy.ts`, add:
 
 ```ts
-export type DetectSourceResult =
-  | { ok: true; source: Source }
-  | { ok: false; byte: number };
+export type DetectSourceResult = { ok: true; source: Source } | { ok: false; byte: number };
 
 /**
  * Map the legacy FS F status byte (byte 0 of the 16-byte STATUS_2 reply)
@@ -1824,6 +1931,7 @@ fail() for end-to-end rejection."
 ### Task E.2: API change — `startScanSessionLegacy(duplex)` and dispatch plumbing
 
 **Files:**
+
 - Modify: `src/scanner-legacy.ts:53-62` (`LegacyScanSession` interface)
 - Modify: `src/scanner-legacy.ts:130-138` (constructor + temp-dir + fields)
 - Modify: `src/startup.ts:115-133` (`dispatchScanSession` legacy branch)
@@ -1832,6 +1940,7 @@ fail() for end-to-end rejection."
 - [ ] **Step 1: Update `LegacyScanSession`**
 
 In `src/scanner-legacy.ts:53-62`, change:
+
 ```ts
 export interface LegacyScanSession {
   printerIp: string;
@@ -1844,7 +1953,9 @@ export interface LegacyScanSession {
   paperless?: PaperlessUploadOptions;
 }
 ```
+
 to:
+
 ```ts
 export interface LegacyScanSession {
   printerIp: string;
@@ -1871,43 +1982,46 @@ export interface LegacyScanSession {
 - [ ] **Step 2: Update `dispatchScanSession`'s legacy branch**
 
 In `src/startup.ts:115-133`, change:
+
 ```ts
-  // Legacy. PushScan carries duplex+action but no explicit flatbed-vs-ADF byte.
-  // v1 mapping: duplex → adf-duplex, otherwise adf-simplex; LEGACY_FORCE_SOURCE
-  // overrides for users who need flatbed scanning from the panel.
-  let source: Source;
-  if (args.config.legacyForceSource) {
-    source = args.config.legacyForceSource;
-  } else {
-    source = args.duplex ? "adf-duplex" : "adf-simplex";
-  }
-  return startScanSessionLegacy({
-    printerIp: args.config.printerIp,
-    port: 1865,
-    outputDir: args.config.outputDir,
-    tempDir: args.config.tempDir,
-    source,
-    format: args.action,
-    jpegQuality: args.config.jpegQuality,
-    paperless: args.paperless,
-  });
+// Legacy. PushScan carries duplex+action but no explicit flatbed-vs-ADF byte.
+// v1 mapping: duplex → adf-duplex, otherwise adf-simplex; LEGACY_FORCE_SOURCE
+// overrides for users who need flatbed scanning from the panel.
+let source: Source;
+if (args.config.legacyForceSource) {
+  source = args.config.legacyForceSource;
+} else {
+  source = args.duplex ? "adf-duplex" : "adf-simplex";
+}
+return startScanSessionLegacy({
+  printerIp: args.config.printerIp,
+  port: 1865,
+  outputDir: args.config.outputDir,
+  tempDir: args.config.tempDir,
+  source,
+  format: args.action,
+  jpegQuality: args.config.jpegQuality,
+  paperless: args.paperless,
+});
 ```
+
 to:
+
 ```ts
-  // Legacy. Source is autodetected from the FS F status byte (see scanner-legacy.ts
-  // STATUS_2). LEGACY_FORCE_SOURCE overrides the autodetection for users hitting
-  // edge cases the autodetect doesn't cover (yet).
-  return startScanSessionLegacy({
-    printerIp: args.config.printerIp,
-    port: 1865,
-    outputDir: args.config.outputDir,
-    tempDir: args.config.tempDir,
-    duplex: args.duplex,
-    forcedSource: args.config.legacyForceSource ?? null,
-    format: args.action,
-    jpegQuality: args.config.jpegQuality,
-    paperless: args.paperless,
-  });
+// Legacy. Source is autodetected from the FS F status byte (see scanner-legacy.ts
+// STATUS_2). LEGACY_FORCE_SOURCE overrides the autodetection for users hitting
+// edge cases the autodetect doesn't cover (yet).
+return startScanSessionLegacy({
+  printerIp: args.config.printerIp,
+  port: 1865,
+  outputDir: args.config.outputDir,
+  tempDir: args.config.tempDir,
+  duplex: args.duplex,
+  forcedSource: args.config.legacyForceSource ?? null,
+  format: args.action,
+  jpegQuality: args.config.jpegQuality,
+  paperless: args.paperless,
+});
 ```
 
 (May also need to drop the `Source` import from `startup.ts` if it's now unused — TypeScript will tell you.)
@@ -1921,7 +2035,7 @@ For each test currently passing `source: "adf-simplex"`, change to `duplex: fals
 For each test passing `source: "adf-duplex"`, change to `duplex: true, forcedSource: "adf-duplex"`.
 For each test passing `source: "flatbed"`, change to `duplex: false, forcedSource: "flatbed"`.
 
-This keeps the tests green during the transition — they're now exercising the *forced-source* path, which still bypasses the FS F detection. The detection logic itself is wired in E.3.
+This keeps the tests green during the transition — they're now exercising the _forced-source_ path, which still bypasses the FS F detection. The detection logic itself is wired in E.3.
 
 - [ ] **Step 4: Compile-check**
 
@@ -1933,6 +2047,7 @@ Expected: zero errors. If you see "Property 'source' is missing", you missed a c
 ```bash
 npm test
 ```
+
 Expected: all green; the replay tests still pass byte-equivalent because `forcedSource` short-circuits STATUS_2 to the same source the test was configuring before.
 
 - [ ] **Step 6: Commit**
@@ -1954,6 +2069,7 @@ logic lands in the next commit."
 ### Task E.3: Wire detection rule into `STATUS_2` + downstream rewrite
 
 **Files:**
+
 - Modify: `src/scanner-legacy.ts:330-362` (STATUS_2)
 - Modify: `src/scanner-legacy.ts:130-200` (session-scope fields, add `detectedSource`)
 - Modify: `src/scanner-legacy.ts` (every `session.source` read after STATUS_2) — `:401, 422, 460, 520, 538, 598, 625, 628, 687, 699` and possibly more
@@ -1961,15 +2077,17 @@ logic lands in the next commit."
 - [ ] **Step 1: Add `detectedSource` to session scope**
 
 In `src/scanner-legacy.ts` near line 145-150, add:
+
 ```ts
-    // Set in STATUS_2 from the FS F byte (or short-circuited by session.forcedSource).
-    // Replaces session.source for all downstream reads.
-    let detectedSource: Source = session.forcedSource ?? "adf-simplex"; // safe default; overwritten in STATUS_2
+// Set in STATUS_2 from the FS F byte (or short-circuited by session.forcedSource).
+// Replaces session.source for all downstream reads.
+let detectedSource: Source = session.forcedSource ?? "adf-simplex"; // safe default; overwritten in STATUS_2
 ```
 
 - [ ] **Step 2: Wire the detection helper into STATUS_2**
 
 In `src/scanner-legacy.ts:330-362`, replace the entire STATUS_2 case body with:
+
 ```ts
         case "STATUS_2": {
           // Status after source-set probe.
@@ -2028,6 +2146,7 @@ In `src/scanner-legacy.ts:330-362`, replace the entire STATUS_2 case body with:
 ```
 
 Add the `legacyDetectSource` import to the top of the file:
+
 ```ts
 import {
   ...
@@ -2041,6 +2160,7 @@ import {
 Run: `grep -n "session\.source" src/scanner-legacy.ts`
 
 For each hit, replace `session.source` with `detectedSource`. Sites (approximate; verify with grep):
+
 - `~398-401` (`RESET_INIT` → `sendCmd(Buffer.from([SOURCE_BYTE[session.source]]), 1)`)
 - `~422` (`STATUS_READY` → `if (session.source !== "flatbed")`)
 - `~447, 450` (`ADF_IDENTITY_B`)
@@ -2052,12 +2172,15 @@ For each hit, replace `session.source` with `detectedSource`. Sites (approximate
 - `~687, 699` (`onPageComplete`)
 
 Each `session.source` becomes `detectedSource`. Example for line 401:
+
 ```ts
-          sendCmd(Buffer.from([SOURCE_BYTE[session.source]]), 1);
+sendCmd(Buffer.from([SOURCE_BYTE[session.source]]), 1);
 ```
+
 becomes:
+
 ```ts
-          sendCmd(Buffer.from([SOURCE_BYTE[detectedSource]]), 1);
+sendCmd(Buffer.from([SOURCE_BYTE[detectedSource]]), 1);
 ```
 
 Final check after editing:
@@ -2073,6 +2196,7 @@ The interface no longer has `source` (E.2 removed it), so any straggler reads wi
 ```bash
 npm test
 ```
+
 Expected: all replay tests still pass byte-equivalent. The detection logic now picks `detectedSource` from the wire bytes; the test fixtures' wire bytes drive that to the same value the test was previously forcing.
 
 If any fixture fails: re-read the fixture's STATUS_2 reply (search for the FS F status byte in the raw events) and verify `legacyDetectSource(byte, duplex)` produces the source the test was configuring. The fixture's bytes are the ground truth.
@@ -2095,6 +2219,7 @@ to the same source the tests were previously hard-coding. Fixes #28."
 ### Task E.4: Replay-test rework — per-fixture metadata
 
 **Files:**
+
 - Modify: `src/scanner-legacy.test.ts` (add per-fixture metadata + restructure tests)
 
 - [ ] **Step 1: Define the fixture metadata array near the top of the test file**
@@ -2139,50 +2264,50 @@ const FIXTURE_SPECS: FixtureSpec[] = [
 The exact shape will depend on the existing tests' assertions. Skeleton:
 
 ```ts
-  it.each(FIXTURE_SPECS)(
-    "$path: detects $expectedDetectedSource and produces $expectedFileCount file(s)",
-    async ({
-      path: fixturePath,
-      format,
-      duplex,
-      expectedDetectedSource,
-      expectedFileCount,
-      expectedBackPages,
-    }) => {
-      const fixture = loadFixture(path.join(FIXTURES, fixturePath));
-      const fake = new FakeTcpSocket();
-      let detectedSource: string | null = null;
+it.each(FIXTURE_SPECS)(
+  "$path: detects $expectedDetectedSource and produces $expectedFileCount file(s)",
+  async ({
+    path: fixturePath,
+    format,
+    duplex,
+    expectedDetectedSource,
+    expectedFileCount,
+    expectedBackPages,
+  }) => {
+    const fixture = loadFixture(path.join(FIXTURES, fixturePath));
+    const fake = new FakeTcpSocket();
+    let detectedSource: string | null = null;
 
-      const sessionPromise = startScanSessionLegacy(
-        {
-          printerIp: "1.2.3.4",
-          port: 1865,
-          outputDir,
-          tempDir,
-          duplex,
-          forcedSource: null, // pure detection — no override
-          format,
-          jpegQuality: 90,
-          onSourceDetected: (s) => {
-            detectedSource = s;
-          },
+    const sessionPromise = startScanSessionLegacy(
+      {
+        printerIp: "1.2.3.4",
+        port: 1865,
+        outputDir,
+        tempDir,
+        duplex,
+        forcedSource: null, // pure detection — no override
+        format,
+        jpegQuality: 90,
+        onSourceDetected: (s) => {
+          detectedSource = s;
         },
-        fake.asFactory(),
-      );
-      await driveFixture(fixture, fake, sessionPromise);
+      },
+      fake.asFactory(),
+    );
+    await driveFixture(fixture, fake, sessionPromise);
 
-      // Detection assertion — fires only via the test hook.
-      expect(detectedSource).toBe(expectedDetectedSource);
+    // Detection assertion — fires only via the test hook.
+    expect(detectedSource).toBe(expectedDetectedSource);
 
-      const files = readdirSync(outputDir);
-      expect(files).toHaveLength(expectedFileCount);
-      // ... format-specific extension assertion ...
-      // ... back-page-index assertion via PDF /Rotate, etc. ...
-      // (use the same shape the existing tests use — see scanner-legacy.test.ts
-      //  pre-rework body for the format/back-page assertion blocks to lift in.)
-    },
-    60_000,
-  );
+    const files = readdirSync(outputDir);
+    expect(files).toHaveLength(expectedFileCount);
+    // ... format-specific extension assertion ...
+    // ... back-page-index assertion via PDF /Rotate, etc. ...
+    // (use the same shape the existing tests use — see scanner-legacy.test.ts
+    //  pre-rework body for the format/back-page assertion blocks to lift in.)
+  },
+  60_000,
+);
 ```
 
 Keep the small targeted tests (e.g., the `0x0c 0x00` page-eject byte search, the `appendImageChunk` unit test) outside the `it.each` block — they assert different things.
@@ -2210,6 +2335,7 @@ in the fixture."
 ### Task E.5: Fixture-injection test for unknown FS F byte
 
 **Files:**
+
 - Modify: `src/scanner-legacy.test.ts` (one new test that mutates a fixture's STATUS_2 reply)
 
 - [ ] **Step 1: Write a fixture-injection test**
@@ -2217,58 +2343,58 @@ in the fixture."
 Add to `src/scanner-legacy.test.ts`, in a new `describe("FS F unknown-byte handling", …)` block:
 
 ```ts
-  describe("FS F unknown-byte handling", () => {
-    it("rejects when the STATUS_2 FS F byte is not 0x01 or 0x81", async () => {
-      const fixture = loadFixture(path.join(FIXTURES, "adf-single-page-jpeg.jsonl"));
-      // Walk events; the second FS F reply (STATUS_2) is the one we mutate.
-      // STATUS_2 reply is a printer→host event with hex starting with the IS-0xa000
-      // header; the 16-byte payload's byte 0 is the status. Find the second such
-      // event and mutate byte 0 to 0x00 before driving.
-      let fsFCount = 0;
-      const mutated = fixture.map((event) => {
-        if (event.dir !== "p>h" || !("hex" in event)) return event;
-        // IS packet header (see src/protocol.ts):
-        //   bytes 0-1: magic
-        //   bytes 2-3: type (UInt16BE)
-        //   bytes 4-5: 0x000c fixed
-        //   bytes 6-9: payloadSize (UInt32BE)
-        //   bytes 10-11: reserved
-        //   bytes 12+: payload
-        // STATUS_n replies are type 0xa000 with 16-byte payloads.
-        const buf = Buffer.from(event.hex, "hex");
-        if (buf.length < 12 + 16) return event;
-        const type = buf.readUInt16BE(2);
-        const length = buf.readUInt32BE(6);
-        if (type === 0xa000 && length === 16) {
-          fsFCount++;
-          if (fsFCount === 2) {
-            // STATUS_2 — mutate byte 0 of payload (12 + 0)
-            buf[12] = 0x00;
-            return { ...event, hex: buf.toString("hex") };
-          }
+describe("FS F unknown-byte handling", () => {
+  it("rejects when the STATUS_2 FS F byte is not 0x01 or 0x81", async () => {
+    const fixture = loadFixture(path.join(FIXTURES, "adf-single-page-jpeg.jsonl"));
+    // Walk events; the second FS F reply (STATUS_2) is the one we mutate.
+    // STATUS_2 reply is a printer→host event with hex starting with the IS-0xa000
+    // header; the 16-byte payload's byte 0 is the status. Find the second such
+    // event and mutate byte 0 to 0x00 before driving.
+    let fsFCount = 0;
+    const mutated = fixture.map((event) => {
+      if (event.dir !== "p>h" || !("hex" in event)) return event;
+      // IS packet header (see src/protocol.ts):
+      //   bytes 0-1: magic
+      //   bytes 2-3: type (UInt16BE)
+      //   bytes 4-5: 0x000c fixed
+      //   bytes 6-9: payloadSize (UInt32BE)
+      //   bytes 10-11: reserved
+      //   bytes 12+: payload
+      // STATUS_n replies are type 0xa000 with 16-byte payloads.
+      const buf = Buffer.from(event.hex, "hex");
+      if (buf.length < 12 + 16) return event;
+      const type = buf.readUInt16BE(2);
+      const length = buf.readUInt32BE(6);
+      if (type === 0xa000 && length === 16) {
+        fsFCount++;
+        if (fsFCount === 2) {
+          // STATUS_2 — mutate byte 0 of payload (12 + 0)
+          buf[12] = 0x00;
+          return { ...event, hex: buf.toString("hex") };
         }
-        return event;
-      });
-
-      const fake = new FakeTcpSocket();
-      const sessionPromise = startScanSessionLegacy(
-        {
-          printerIp: "1.2.3.4",
-          port: 1865,
-          outputDir,
-          tempDir,
-          duplex: false,
-          forcedSource: null,
-          format: "jpg",
-          jpegQuality: 90,
-        },
-        fake.asFactory(),
-      );
-      await expect(driveFixture(mutated, fake, sessionPromise)).rejects.toThrow(
-        /Unrecognised FS F status 0x00/,
-      );
+      }
+      return event;
     });
+
+    const fake = new FakeTcpSocket();
+    const sessionPromise = startScanSessionLegacy(
+      {
+        printerIp: "1.2.3.4",
+        port: 1865,
+        outputDir,
+        tempDir,
+        duplex: false,
+        forcedSource: null,
+        format: "jpg",
+        jpegQuality: 90,
+      },
+      fake.asFactory(),
+    );
+    await expect(driveFixture(mutated, fake, sessionPromise)).rejects.toThrow(
+      /Unrecognised FS F status 0x00/,
+    );
   });
+});
 ```
 
 (The exact byte offsets for "second FS F reply" may need tweaking — verify by reading `tools/pcap-extract/captures/wf-3620/adf-single-page-jpeg.jsonl` and counting which IS-0xa000 reply with length=16 is STATUS_2. The IS header layout is in `src/protocol.ts`.)
@@ -2278,6 +2404,7 @@ Add to `src/scanner-legacy.test.ts`, in a new `describe("FS F unknown-byte handl
 ```bash
 npx vitest run src/scanner-legacy.test.ts -t "FS F unknown" --reporter=verbose 2>&1 | tail -20
 ```
+
 Expected: PASS. If FAIL with "Unrecognised FS F status 0xXX" where XX is a different value, you mutated the wrong byte — re-check the fixture event indexing.
 
 If FAIL with timeout: the mutation wasn't applied (still 0x01 or 0x81 in the bytes). Verify `mutated` actually differs from the input `fixture`.
@@ -2287,6 +2414,7 @@ If FAIL with timeout: the mutation wasn't applied (still 0x01 or 0x81 in the byt
 ```bash
 npm test
 ```
+
 Expected: all green. Test count = previous + 6 (E.1) + 1 (E.5) = previous + 7 minimum.
 
 - [ ] **Step 4: Commit**
@@ -2350,6 +2478,7 @@ git switch -C feature/v0.3.0-release origin/dev
 ### Task F.1: Bump version, refresh release notes, refresh CLAUDE.md size annotation
 
 **Files:**
+
 - Modify: `package.json:3` (version bump)
 - Modify: `package-lock.json:3, 9` (lockfile auto-bumps)
 - Modify: `README.md` (release-history section if it exists; otherwise add a "Recent changes" stanza or update the v0.3.0 release notes location the project conventionally uses)
@@ -2358,10 +2487,13 @@ git switch -C feature/v0.3.0-release origin/dev
 - [ ] **Step 1: Bump `package.json` version**
 
 In `package.json:3`, change:
+
 ```json
   "version": "0.2.0",
 ```
+
 to:
+
 ```json
   "version": "0.3.0",
 ```
@@ -2371,6 +2503,7 @@ Run: `npm install --no-audit --no-fund` to update `package-lock.json`.
 - [ ] **Step 2: Refresh `CLAUDE.md`'s `scanner-legacy.ts` size annotation**
 
 In `CLAUDE.md`, locate the line that reads (approximately):
+
 ```
   ~830 LOC / 44 states — parallels rather than reuses the ESC/I-2 scanner
 ```
@@ -2392,6 +2525,7 @@ For each row in the env-var table, update the description from something like "O
 ```bash
 npm run lint && npm run format:check && npm test
 ```
+
 Expected: all green.
 
 - [ ] **Step 5: Commit and push**

--- a/docs/superpowers/specs/2026-05-04-v0.3.0-and-v0.4.0-design.md
+++ b/docs/superpowers/specs/2026-05-04-v0.3.0-and-v0.4.0-design.md
@@ -86,18 +86,18 @@ Test cases in `src/config.test.ts`:
 
 ### 3.3. Promise-contract reconciliation (~40 lines, single PR)
 
-Today `startScanSession` (`src/scanner.ts:131`) is resolve-only — its constructor receives no `reject`. The current architecture is more nuanced than "resolve at hard-error sites": almost no hard-error site resolves the promise *directly*. Instead, errors flow through `transitionToError()` → `socket.end()` → the `socket.on("close")` handler at `scanner.ts:304-308` → `resolveOnce()`. Cert-fingerprint mismatch (line 215) sets `state = "ERROR"`, destroys the socket, and lets the close handler resolve. Only the temp-dir-creation failure (line 153) calls `resolveOnce()` directly, before any connection.
+Today `startScanSession` (`src/scanner.ts:131`) is resolve-only — its constructor receives no `reject`. The current architecture is more nuanced than "resolve at hard-error sites": almost no hard-error site resolves the promise _directly_. Instead, errors flow through `transitionToError()` → `socket.end()` → the `socket.on("close")` handler at `scanner.ts:304-308` → `resolveOnce()`. Cert-fingerprint mismatch (line 215) sets `state = "ERROR"`, destroys the socket, and lets the close handler resolve. Only the temp-dir-creation failure (line 153) calls `resolveOnce()` directly, before any connection.
 
-So just inserting `rejectOnce()` at the existing hard-error sites is not enough — most hard errors *don't* have a resolve site; they thread through the unified close path.
+So just inserting `rejectOnce()` at the existing hard-error sites is not enough — most hard errors _don't_ have a resolve site; they thread through the unified close path.
 
-**Fix shape:** introduce an `errorReason: Error | null` at session scope, populated by hard-error paths *before* the socket close cascade, and have the close handler consult it. Constructor becomes `new Promise<void>((resolve, reject) => …)` with symmetric `resolveOnce` / `rejectOnce` guards.
+**Fix shape:** introduce an `errorReason: Error | null` at session scope, populated by hard-error paths _before_ the socket close cascade, and have the close handler consult it. Constructor becomes `new Promise<void>((resolve, reject) => …)` with symmetric `resolveOnce` / `rejectOnce` guards.
 
 ```ts
 let errorReason: Error | null = null;
 const failOnce = (err: Error) => {
-  if (errorReason) return;       // first-error wins
+  if (errorReason) return; // first-error wins
   errorReason = err;
-  transitionToError();           // triggers the close handler
+  transitionToError(); // triggers the close handler
 };
 
 socket.on("close", () => {
@@ -108,24 +108,24 @@ socket.on("close", () => {
 });
 ```
 
-**Failure-mode classification.** Each hard-error site is updated to call `failOnce(new Error("..."))` *before* (or instead of) `transitionToError()`. The close handler then routes the captured reason into `rejectOnce`:
+**Failure-mode classification.** Each hard-error site is updated to call `failOnce(new Error("..."))` _before_ (or instead of) `transitionToError()`. The close handler then routes the captured reason into `rejectOnce`:
 
-| Site (scanner.ts) | Today | After |
-|---|---|---|
-| Cert fingerprint mismatch (~line 215) | Resolves silently | `failOnce(new Error("Printer cert fingerprint mismatch — expected X, got Y"))` |
-| Temp-dir creation failure (~line 153) | `resolveOnce()` direct | `rejectOnce(new Error("Failed to create session temp dir under X: msg"))` direct (no socket open yet) |
-| Timeout (~line 187) | `transitionToError()` only | `failOnce(new Error("Timeout in state X — no response in Yms"))` |
-| Socket error (~line 297) | `transitionToError()` only | `failOnce(new Error("TLS connection error in state X: <message>"))` |
-| Async ScanCancel (~line 360) | `transitionToError()` only | `failOnce(new Error("Async ScanCancel during state X"))` |
-| Async fatal event (~line 363) | `transitionToError()` only | `failOnce(new Error("Async fatal event 0xXX during state X"))` |
-| Per-state `ensure(false, msg)` sites | `transitionToError()` only | `failOnce(new Error("Protocol error in state X: msg"))` |
-| Zero-image completion (~line 978) | Silent resolve | `failOnce(new Error("Scan completed with zero image chunks"))` |
-| `finalizeSession` failure (~line 992) | Silent resolve | `rejectOnce(new Error("finalizeScan failure: msg"))` direct (socket already closed) |
-| Post-scan-save fallback (line 258, images captured) | Resolves with images saved | **Resolves.** Genuine success — images survived a printer-side cleanup glitch. Behaviour unchanged. |
+| Site (scanner.ts)                                   | Today                      | After                                                                                                 |
+| --------------------------------------------------- | -------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Cert fingerprint mismatch (~line 215)               | Resolves silently          | `failOnce(new Error("Printer cert fingerprint mismatch — expected X, got Y"))`                        |
+| Temp-dir creation failure (~line 153)               | `resolveOnce()` direct     | `rejectOnce(new Error("Failed to create session temp dir under X: msg"))` direct (no socket open yet) |
+| Timeout (~line 187)                                 | `transitionToError()` only | `failOnce(new Error("Timeout in state X — no response in Yms"))`                                      |
+| Socket error (~line 297)                            | `transitionToError()` only | `failOnce(new Error("TLS connection error in state X: <message>"))`                                   |
+| Async ScanCancel (~line 360)                        | `transitionToError()` only | `failOnce(new Error("Async ScanCancel during state X"))`                                              |
+| Async fatal event (~line 363)                       | `transitionToError()` only | `failOnce(new Error("Async fatal event 0xXX during state X"))`                                        |
+| Per-state `ensure(false, msg)` sites                | `transitionToError()` only | `failOnce(new Error("Protocol error in state X: msg"))`                                               |
+| Zero-image completion (~line 978)                   | Silent resolve             | `failOnce(new Error("Scan completed with zero image chunks"))`                                        |
+| `finalizeSession` failure (~line 992)               | Silent resolve             | `rejectOnce(new Error("finalizeScan failure: msg"))` direct (socket already closed)                   |
+| Post-scan-save fallback (line 258, images captured) | Resolves with images saved | **Resolves.** Genuine success — images survived a printer-side cleanup glitch. Behaviour unchanged.   |
 
 **Symmetric for `startScanSessionLegacy`.** Adopt the same `errorReason + failOnce` shape. The existing legacy `fail()` helper already rejects, but classifying its call sites against the same matrix gives both implementations one contract — and gives v0.4.0's shared engine a single, clean failure model to lift.
 
-`dispatchScanSession`'s caller contract is then unambiguous: promise rejects → `one-shot.ts` exits 1 / `index.ts`'s inflight tracker swallows. The structured `{ ok, reason? }` shape proposed in the architecture review is deferred to v0.4.0; it lives at the engine's *internal* boundary, and `dispatchScanSession` continues to reject on engine-`{ ok: false }` to preserve the v0.3.0 contract (see §5 M1).
+`dispatchScanSession`'s caller contract is then unambiguous: promise rejects → `one-shot.ts` exits 1 / `index.ts`'s inflight tracker swallows. The structured `{ ok, reason? }` shape proposed in the architecture review is deferred to v0.4.0; it lives at the engine's _internal_ boundary, and `dispatchScanSession` continues to reject on engine-`{ ok: false }` to preserve the v0.3.0 contract (see §5 M1).
 
 Test cases (TDD):
 
@@ -135,7 +135,7 @@ Test cases (TDD):
 
 ### 3.4. Issue #28 — FS F autodetection (the headline; **single combined PR**, byte-sensitive)
 
-**PR-shape note.** An earlier draft split this into four sub-PRs (API change → detection → downstream rewrite → replay-test rework). That decomposition leaves intermediate states broken: removing `source` as an input to `startScanSessionLegacy` while downstream handlers still read `session.source` won't compile, and reworking replay tests before the API/derivation lands either skips coverage or hard-codes the old shape. The change is one coherent restructure ("switch from config-derived source to wire-detected source") and ships as one PR. The four logical phases below describe the *internal structure* of that PR; they're commits on the feature branch, not separate merges.
+**PR-shape note.** An earlier draft split this into four sub-PRs (API change → detection → downstream rewrite → replay-test rework). That decomposition leaves intermediate states broken: removing `source` as an input to `startScanSessionLegacy` while downstream handlers still read `session.source` won't compile, and reworking replay tests before the API/derivation lands either skips coverage or hard-codes the old shape. The change is one coherent restructure ("switch from config-derived source to wire-detected source") and ships as one PR. The four logical phases below describe the _internal structure_ of that PR; they're commits on the feature branch, not separate merges.
 
 The `STAT` reply that follows the legacy `ESC e 0x01 + FS F` probe carries the source signal in byte 0:
 
@@ -145,19 +145,14 @@ The `STAT` reply that follows the legacy `ESC e 0x01 + FS F` probe carries the s
 
 Today (`src/scanner-legacy.ts:330-362`, state `STATUS_2`) the byte is read but discarded; the source comes from `session.source`, which is config-derived. Internal commit phases of the single combined PR:
 
-**3.4.1. API change** (`startScanSessionLegacy`): take `duplex: boolean` instead of `source: Source`; source becomes a *result*, not an input. Add `forcedSource: Source | null` for `LEGACY_FORCE_SOURCE`. `dispatchScanSession` in `src/startup.ts:115-123` drops the legacy source-mapping; passes `info.duplex` and `config.legacyForceSource ?? null` directly. Type-error driven; the TypeScript compiler is the test.
+**3.4.1. API change** (`startScanSessionLegacy`): take `duplex: boolean` instead of `source: Source`; source becomes a _result_, not an input. Add `forcedSource: Source | null` for `LEGACY_FORCE_SOURCE`. `dispatchScanSession` in `src/startup.ts:115-123` drops the legacy source-mapping; passes `info.duplex` and `config.legacyForceSource ?? null` directly. Type-error driven; the TypeScript compiler is the test.
 
 **3.4.2. Detection rule in `STATUS_2`.** New helper in `src/esci-legacy.ts` returns a Result type — pure (no throw inside an event handler), and gives every detection outcome the same assertable shape:
 
 ```ts
-export type DetectSourceResult =
-  | { ok: true; source: Source }
-  | { ok: false; byte: number };
+export type DetectSourceResult = { ok: true; source: Source } | { ok: false; byte: number };
 
-export function legacyDetectSource(
-  fsfByte: number,
-  duplex: boolean,
-): DetectSourceResult {
+export function legacyDetectSource(fsfByte: number, duplex: boolean): DetectSourceResult {
   if (fsfByte === 0x81) return { ok: true, source: "flatbed" };
   if (fsfByte === 0x01) return { ok: true, source: duplex ? "adf-duplex" : "adf-simplex" };
   return { ok: false, byte: fsfByte };
@@ -169,7 +164,7 @@ export function legacyDetectSource(
 - on `{ ok: true }` — stores `result.source` on the session as `detectedSource`, advances state.
 - on `{ ok: false }` — calls the legacy `fail()` path (the same one used by 16-byte status parse failures today), passing `Unrecognised FS F status 0x{XX} — please file a compatibility issue with LOG_LEVEL=debug output (see CONTRIBUTING.md). Workaround: set LEGACY_FORCE_SOURCE.` This routes through `failOnce`/the legacy equivalent established in 3.3 and rejects the outer promise cleanly.
 
-If `forcedSource` is set, `STATUS_2` short-circuits *before* calling `legacyDetectSource`; emit `[scanner-legacy] LEGACY_FORCE_SOURCE override: <source> (FS F byte 0x{XX} ignored)` at INFO so an actual misfire is debuggable.
+If `forcedSource` is set, `STATUS_2` short-circuits _before_ calling `legacyDetectSource`; emit `[scanner-legacy] LEGACY_FORCE_SOURCE override: <source> (FS F byte 0x{XX} ignored)` at INFO so an actual misfire is debuggable.
 
 Edge case worth pinning: what if `0x81` arrives with `duplex===true` (panel says duplex but we're on a flatbed)? Treat as `flatbed` regardless of duplex flag — a flatbed has no second-side concept. The `legacyDetectSource` unit test covers this.
 
@@ -211,7 +206,7 @@ Edge case worth pinning: what if `0x81` arrives with `duplex===true` (panel says
 
 **Coverage gap accepted, documented in release notes:**
 
-- Unknown FS F bytes for empty-tray, jam, mid-feed, panel-conflict. Unit test pins the *rejection* shape for two unknown bytes; the actual values produced by real WF-3620 firmware in those states are unknown until captures arrive. Strict-fail with the verbose error message is the safety net; `LEGACY_FORCE_SOURCE` is the immediate workaround.
+- Unknown FS F bytes for empty-tray, jam, mid-feed, panel-conflict. Unit test pins the _rejection_ shape for two unknown bytes; the actual values produced by real WF-3620 firmware in those states are unknown until captures arrive. Strict-fail with the verbose error message is the safety net; `LEGACY_FORCE_SOURCE` is the immediate workaround.
 - `dispatchScanSession` itself remains untested at unit level (deferred-tech-debt item from `.reference/next-steps.md`). Folds naturally into v0.4.0's engine extraction.
 
 **CI gate:** v0.3.0 prep adds `dev` to the workflow's `pull_request.branches` (see 3.5). After that, `npm run lint`, `npm run format:check`, `npm test` runs on every PR to `dev`/`main`. Pre-push hook mirrors. Test count target ~290+, up from current 271 (the failure-mode matrix is the largest single contributor).
@@ -223,7 +218,7 @@ Sequenced milestones; each = one PR back to the long-lived `feature/v0.4.0-archi
 **M1 — Shared scan-session engine** (~2 days, prerequisite for M2/M3)
 New module `src/scan-session.ts`. Owns: socket factory injection, recv-buffer accumulator (the deferred-concat shape from `scanner.ts`, not the per-event concat from `scanner-legacy.ts`), IS-packet pump, single rolling timeout, page-flush hook (`(jpeg: Buffer, side: 'front' | 'back') => Promise<void>`), back-page index tracking, EXIF orientation injection for back pages, `setImmediate → finalizeSession` tail. Each consumer scanner supplies a state-graph definition + a per-page-encode strategy.
 
-**Engine-vs-caller contract.** The engine returns a structured `{ ok: true } | { ok: false; reason: Error }` from its `runScanSession()` entry point. This is the engine's *internal* boundary — useful for the engine to thread the failure-mode matrix from §3.3 into a single result without throwing across the state-graph plumbing. **`dispatchScanSession` continues to reject on `{ ok: false }`, normalising the engine result into the same promise-rejection contract established by v0.3.0.** Neither `one-shot.ts` nor `index.ts` change: they consume `dispatchScanSession`'s rejection-on-error promise just as they do post-v0.3.0. This keeps the v0.4.0 architectural change invisible at the daemon / CLI boundary; only the scanner *internals* see the structured shape.
+**Engine-vs-caller contract.** The engine returns a structured `{ ok: true } | { ok: false; reason: Error }` from its `runScanSession()` entry point. This is the engine's _internal_ boundary — useful for the engine to thread the failure-mode matrix from §3.3 into a single result without throwing across the state-graph plumbing. **`dispatchScanSession` continues to reject on `{ ok: false }`, normalising the engine result into the same promise-rejection contract established by v0.3.0.** Neither `one-shot.ts` nor `index.ts` change: they consume `dispatchScanSession`'s rejection-on-error promise just as they do post-v0.3.0. This keeps the v0.4.0 architectural change invisible at the daemon / CLI boundary; only the scanner _internals_ see the structured shape.
 
 **M2 — `scanner.ts` refactor onto engine** (~1 day, blocked by M1)
 Salvage the existing state machine. Add `awaitAck(next, sendNext)` and `statThenDrain(onDone)` helpers; collapse 32 states to ~12 via declarative state graph. Replay tests pin every byte; drift surfaces immediately.
@@ -238,6 +233,7 @@ First step: its own mini-brainstorm covering the open fixture-storage decision (
 Extract the 928-byte shared tail; assemble per-source variants programmatically with `Buffer.concat`. The three meaningful deltas (`#ADF` vs `#FB ` token, `#PAGd000` block in ADF only, `#ACQi` start-offset value) become explicit. Replay tests pin the wire bytes byte-for-byte. Can land any time after v0.3.0.
 
 **M6 — Remaining YAGNI / module-scoped cleanups** (~half-day)
+
 - Replace `__resetShutdownStateForTesting` with deps-injected state on `ShutdownDeps`.
 - Bind `src/health.ts` to `127.0.0.1` by default with opt-in `HEALTH_BIND_HOST` for LAN exposure (the CLAUDE.md-acknowledged "binds to all interfaces" gap; this is a behaviour change worth flagging in v0.4.0 release notes).
 - Inline `safeInspect` if it's still a one-call helper after the engine work.
@@ -251,17 +247,17 @@ Substantive headline: "internal architecture rebuild + WF-3620 quality oracle". 
 
 **v0.3.0 risks:**
 
-- *Unknown FS F bytes hit real users.* Strict-fail with verbose error message points at CONTRIBUTING.md; `LEGACY_FORCE_SOURCE` is the immediate workaround. A compatibility issue from a user surfaces the next state to capture and ships in a v0.3.x point release.
-- *Promise-contract change breaks daemon error tolerance or accidentally rejects a path users rely on resolving.* Mitigation: the failure-mode matrix in §3.3 enumerates each site explicitly; the post-scan-save fallback resolve is called out as **unchanged**; the existing `lifecycle.test.ts:23` already pins inflight rejection-tolerance. The matrix is the artifact a reviewer can scan to confirm no path is mis-classified.
-- *Real-hardware test against maltris's WF-3620.* Two distinct gates that the original framing conflated:
+- _Unknown FS F bytes hit real users._ Strict-fail with verbose error message points at CONTRIBUTING.md; `LEGACY_FORCE_SOURCE` is the immediate workaround. A compatibility issue from a user surfaces the next state to capture and ships in a v0.3.x point release.
+- _Promise-contract change breaks daemon error tolerance or accidentally rejects a path users rely on resolving._ Mitigation: the failure-mode matrix in §3.3 enumerates each site explicitly; the post-scan-save fallback resolve is called out as **unchanged**; the existing `lifecycle.test.ts:23` already pins inflight rejection-tolerance. The matrix is the artifact a reviewer can scan to confirm no path is mis-classified.
+- _Real-hardware test against maltris's WF-3620._ Two distinct gates that the original framing conflated:
   - **Technical gate for tagging v0.3.0:** #28 lands in `dev`; all replay tests + the new failure-mode matrix green; CI green on `dev → main`. **No external hardware dependency.** Tag the release as soon as this gate clears.
-  - **Issue #24 close-out:** maltris (or any WF-3620 owner) confirms an end-to-end real-hardware scan against `dev` or against the `:v0.3.0` Docker image. Decoupled from the tag — the v0.3.0 release notes call this out explicitly: *"WF-3620 support landed; closing-confirmation against 2014 firmware pending real-hardware run, expected within X days of release; track at issue #24."* This avoids holding the tag on coordination with an external user, and lets v0.4.0 work begin immediately after the cut.
+  - **Issue #24 close-out:** maltris (or any WF-3620 owner) confirms an end-to-end real-hardware scan against `dev` or against the `:v0.3.0` Docker image. Decoupled from the tag — the v0.3.0 release notes call this out explicitly: _"WF-3620 support landed; closing-confirmation against 2014 firmware pending real-hardware run, expected within X days of release; track at issue #24."_ This avoids holding the tag on coordination with an external user, and lets v0.4.0 work begin immediately after the cut.
 
 **v0.4.0 risks:**
 
-- *Feature branch drifts from `dev` over 2-3 weeks.* Mitigation: small/frequent merges *into* the feature branch from `dev` (rather than rebasing). Each milestone PR gets reviewed and merged back to `dev` immediately when green; only the final v0.4.0 cut is `dev → main`.
-- *M3 scanner-legacy rewrite breaks pixel content the replay tests don't catch.* Exactly what M4 (#27 oracle) is designed to catch. Slot M4 to start *during* M3 so the oracle is ready when M3's PR review needs it.
-- *Engine API gets the contract wrong, both scanners pay.* Mitigation: M1 is built test-first against scaffolding tests (no protocol bytes). M2 + M3 don't start until M1's interface is shaped and reviewed. If the interface needs a change after M2/M3 work begins, the change is a small refactor, not a redesign.
+- _Feature branch drifts from `dev` over 2-3 weeks._ Mitigation: small/frequent merges _into_ the feature branch from `dev` (rather than rebasing). Each milestone PR gets reviewed and merged back to `dev` immediately when green; only the final v0.4.0 cut is `dev → main`.
+- _M3 scanner-legacy rewrite breaks pixel content the replay tests don't catch._ Exactly what M4 (#27 oracle) is designed to catch. Slot M4 to start _during_ M3 so the oracle is ready when M3's PR review needs it.
+- _Engine API gets the contract wrong, both scanners pay._ Mitigation: M1 is built test-first against scaffolding tests (no protocol bytes). M2 + M3 don't start until M1's interface is shaped and reviewed. If the interface needs a change after M2/M3 work begins, the change is a small refactor, not a redesign.
 
 ## 7. Branch / CI strategy
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -11,7 +11,6 @@ describe("loadConfig", () => {
     delete process.env.SCAN_DEST_NAME;
     delete process.env.SCAN_DEST_ID;
     delete process.env.OUTPUT_DIR;
-    delete process.env.KEEPALIVE_INTERVAL;
     delete process.env.HEALTH_PORT;
     delete process.env.LOG_LEVEL;
     delete process.env.LOG_FORMAT;
@@ -40,7 +39,6 @@ describe("loadConfig", () => {
     expect(config.scanDestName).toBe("Paperless");
     expect(config.scanDestId).toBe(0x02);
     expect(config.outputDir).toBe("/output");
-    expect(config.keepaliveInterval).toBe(500);
     expect(config.healthPort).toBe(3000);
     expect(config.logLevel).toBe("info");
     expect(config.logFormat).toBe("text");
@@ -52,7 +50,6 @@ describe("loadConfig", () => {
     process.env.SCAN_DEST_NAME = "MyScanner";
     process.env.SCAN_DEST_ID = "05";
     process.env.OUTPUT_DIR = "/scans";
-    process.env.KEEPALIVE_INTERVAL = "1000";
     process.env.HEALTH_PORT = "8080";
     process.env.LOG_LEVEL = "debug";
     process.env.LANGUAGE = "de";
@@ -61,7 +58,6 @@ describe("loadConfig", () => {
     expect(config.scanDestName).toBe("MyScanner");
     expect(config.scanDestId).toBe(0x05);
     expect(config.outputDir).toBe("/scans");
-    expect(config.keepaliveInterval).toBe(1000);
     expect(config.healthPort).toBe(8080);
     expect(config.logLevel).toBe("debug");
     expect(config.language).toBe("de");

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,6 @@ const configSchema = z
     // scanDestId is a hex byte (e.g. "02"); parsed in loadConfig.
     scanDestId: z.number().int().min(1).max(255).default(0x02),
     outputDir: z.string().default("/output"),
-    keepaliveInterval: z.coerce.number().int().min(100).default(500),
     healthPort: z.coerce.number().int().min(1).max(65535).default(3000),
     logLevel: z.enum(["debug", "info", "warn", "error"]).default("info"),
     logFormat: z.enum(["text", "json"]).default("text"),
@@ -76,7 +75,6 @@ export function loadConfig(): Config {
     scanDestName: process.env.SCAN_DEST_NAME || undefined,
     scanDestId: process.env.SCAN_DEST_ID ? parseInt(process.env.SCAN_DEST_ID, 16) : undefined,
     outputDir: process.env.OUTPUT_DIR || undefined,
-    keepaliveInterval: process.env.KEEPALIVE_INTERVAL || undefined,
     healthPort: process.env.HEALTH_PORT || undefined,
     logLevel: process.env.LOG_LEVEL || undefined,
     logFormat: process.env.LOG_FORMAT || undefined,

--- a/src/esci.ts
+++ b/src/esci.ts
@@ -68,8 +68,8 @@ export function buildParaHeader(payloadLength: number): Buffer {
  *
  * `duplex` is ignored when `source === "flatbed"` (glass cannot duplex).
  * Caller sends as passthru with cmd_size=<returned.length>, reply_size=64.
- * See docs/notes/2026-04-20-multi-page-duplex-analysis.md (ADF variants)
- * and docs/notes/2026-04-21-flatbed-protocol-analysis.md (flatbed diff).
+ * See `docs/HOW-IT-WORKS.md` for the protocol layering and per-source
+ * variant rationale.
  */
 export function buildParaPayload(opts: { source: "adf" | "flatbed"; duplex: boolean }): Buffer {
   if (opts.source === "flatbed") {

--- a/src/output-tail.ts
+++ b/src/output-tail.ts
@@ -26,30 +26,26 @@ export interface FinalizeSessionArgs {
 export async function finalizeSession(args: FinalizeSessionArgs): Promise<void> {
   const { sessionTempDir, outputDir, sessionTs, action, backPageIndices, paperless } = args;
   try {
+    let savedPaths: string[];
     if (action === "jpg") {
-      const saved = promoteTempPagesToOutput(sessionTempDir, outputDir, sessionTs, "jpg");
-      log.info(`Scan complete — wrote ${saved.length} JPG file(s); first: ${saved[0]}`);
-      if (paperless) {
-        await uploadAllToPaperless(saved, paperless);
+      savedPaths = promoteTempPagesToOutput(sessionTempDir, outputDir, sessionTs, "jpg");
+      log.info(`Scan complete — wrote ${savedPaths.length} JPG file(s); first: ${savedPaths[0]}`);
+    } else {
+      try {
+        const pdfBuf = await composePdfFromJpegs(sessionTempDir, { backPages: backPageIndices });
+        const pdfName = generateFilename(sessionTs, "pdf");
+        const pdfPath = writeOutputFile(outputDir, pdfName, pdfBuf);
+        log.info(`Scan complete — saved PDF to ${pdfPath}`);
+        savedPaths = [pdfPath];
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.error(`PDF composition failed: ${msg}. Falling back to JPG output.`);
+        savedPaths = promoteTempPagesToOutput(sessionTempDir, outputDir, sessionTs, "jpg");
+        log.info(`Saved ${savedPaths.length} JPG file(s) as fallback`);
       }
-      return;
     }
-    try {
-      const pdfBuf = await composePdfFromJpegs(sessionTempDir, { backPages: backPageIndices });
-      const pdfName = generateFilename(sessionTs, "pdf");
-      const savedPath = writeOutputFile(outputDir, pdfName, pdfBuf);
-      log.info(`Scan complete — saved PDF to ${savedPath}`);
-      if (paperless) {
-        await uploadAllToPaperless([savedPath], paperless);
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.error(`PDF composition failed: ${msg}. Falling back to JPG output.`);
-      const saved = promoteTempPagesToOutput(sessionTempDir, outputDir, sessionTs, "jpg");
-      log.info(`Saved ${saved.length} JPG file(s) as fallback`);
-      if (paperless) {
-        await uploadAllToPaperless(saved, paperless);
-      }
+    if (paperless) {
+      await uploadAllToPaperless(savedPaths, paperless);
     }
   } finally {
     fs.rmSync(sessionTempDir, { recursive: true, force: true });

--- a/src/output.ts
+++ b/src/output.ts
@@ -89,16 +89,21 @@ export function resolveSessionTimestamp(base: Date, outputDir: string): Date {
  * If `ext` is provided, only files with that extension are kept; otherwise
  * any extension matches. Non-matching names are dropped silently.
  */
-export function sortedPageFiles(names: string[], ext?: string): string[] {
+export interface PageEntry {
+  name: string;
+  page: number;
+}
+
+export function sortedPageFiles(names: string[], ext?: string): PageEntry[] {
   const extPattern = ext ? ext.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : "[^.]+";
   const re = new RegExp(`^page_(\\d+)\\.${extPattern}$`);
-  const matched: { name: string; page: number }[] = [];
+  const matched: PageEntry[] = [];
   for (const name of names) {
     const m = re.exec(name);
     if (m) matched.push({ name, page: parseInt(m[1], 10) });
   }
   matched.sort((a, b) => a.page - b.page);
-  return matched.map((e) => e.name);
+  return matched;
 }
 
 /**
@@ -117,14 +122,13 @@ export function promoteTempPagesToOutput(
   sessionTs: Date,
   extension: string,
 ): string[] {
-  const entries = sortedPageFiles(fs.readdirSync(tempDir));
+  const entries = sortedPageFiles(fs.readdirSync(tempDir), extension);
 
   const paths: string[] = [];
   for (const entry of entries) {
-    const src = path.join(tempDir, entry);
+    const src = path.join(tempDir, entry.name);
     const data = fs.readFileSync(src);
-    const pageNum = parseInt(entry.match(/^page_(\d+)/)![1], 10);
-    const pageIndex = entries.length > 1 ? pageNum : undefined;
+    const pageIndex = entries.length > 1 ? entry.page : undefined;
     const filename = generateFilename(sessionTs, extension, pageIndex);
     const out = writeOutputFile(outputDir, filename, data);
     fs.unlinkSync(src);

--- a/src/paperless-upload.ts
+++ b/src/paperless-upload.ts
@@ -65,9 +65,13 @@ export async function uploadAllToPaperless(
   opts: PaperlessUploadOptions,
 ): Promise<void> {
   log.info(`Uploading ${filePaths.length} file(s) to Paperless-ngx`);
-  await Promise.allSettled(
+  // Per-upload catch logs and swallows; Promise.all is safe because no
+  // mapped promise rejects. Decision: log-and-continue on any single
+  // upload failure — see paperless-upload.ts:56-60 for the broader
+  // "scan complete = local file written" policy.
+  await Promise.all(
     filePaths.map((p) =>
-      uploadOne(p, opts).catch((err) => {
+      uploadOne(p, opts).catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
         log.error(`Paperless upload failed for ${basename(p)}: ${msg}`);
       }),

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -35,7 +35,9 @@ export async function composePdfFromJpegs(
   const backSet = new Set(options.backPages);
 
   // File reads are independent; embedJpg mutates `doc` so that stays sequential.
-  const buffers = await Promise.all(entries.map((entry) => fs.readFile(path.join(tempDir, entry))));
+  const buffers = await Promise.all(
+    entries.map((entry) => fs.readFile(path.join(tempDir, entry.name))),
+  );
 
   for (let i = 0; i < entries.length; i++) {
     const buf = buffers[i];

--- a/src/pushscan.test.ts
+++ b/src/pushscan.test.ts
@@ -2,7 +2,6 @@ import net from "node:net";
 import type { AddressInfo } from "node:net";
 import { describe, it, expect } from "vitest";
 import {
-  PUSHSCAN_RESPONSE,
   buildPushScanResponse,
   parsePushScanRequest,
   createPushScanServer,
@@ -11,27 +10,29 @@ import {
   type PushScanInfo,
 } from "./pushscan.js";
 
-describe("PUSHSCAN_RESPONSE", () => {
+describe("buildPushScanResponse default x-uid (xuid=1)", () => {
+  const response = buildPushScanResponse("1");
+
   it("starts with HTTP/1.0 200 OK", () => {
-    expect(PUSHSCAN_RESPONSE.startsWith("HTTP/1.0 200 OK\r\n")).toBe(true);
+    expect(response.startsWith("HTTP/1.0 200 OK\r\n")).toBe(true);
   });
 
   it("contains the required Epson headers with spaces before colons", () => {
-    expect(PUSHSCAN_RESPONSE).toContain("Server : Epson Net Scan Monitor/2.0");
-    expect(PUSHSCAN_RESPONSE).toContain("x-protocol-name : Epson Network Service Protocol");
-    expect(PUSHSCAN_RESPONSE).toContain("x-protocol-version : 2.00");
-    expect(PUSHSCAN_RESPONSE).toContain("x-status : 0001");
+    expect(response).toContain("Server : Epson Net Scan Monitor/2.0");
+    expect(response).toContain("x-protocol-name : Epson Network Service Protocol");
+    expect(response).toContain("x-protocol-version : 2.00");
+    expect(response).toContain("x-status : 0001");
   });
 
   it("has correct Content-Length matching the body", () => {
-    const parts = PUSHSCAN_RESPONSE.split("\r\n\r\n");
+    const parts = response.split("\r\n\r\n");
     const body = parts[1];
     const bodyLength = Buffer.byteLength(body, "utf-8");
-    expect(PUSHSCAN_RESPONSE).toContain(`Content-Length : ${bodyLength}`);
+    expect(response).toContain(`Content-Length : ${bodyLength}`);
   });
 
   it("contains the SOAP PushScanResponse with StatusOut OK", () => {
-    expect(PUSHSCAN_RESPONSE).toContain("<StatusOut>OK</StatusOut>");
+    expect(response).toContain("<StatusOut>OK</StatusOut>");
   });
 });
 
@@ -46,10 +47,6 @@ describe("buildPushScanResponse", () => {
       const response = buildPushScanResponse(xuid);
       expect(response).toContain(`x-uid : ${xuid}\r\n`);
     }
-  });
-
-  it("produces PUSHSCAN_RESPONSE when called with the legacy default '1'", () => {
-    expect(buildPushScanResponse("1")).toBe(PUSHSCAN_RESPONSE);
   });
 
   it("still contains all the other required fixed headers regardless of x-uid", () => {

--- a/src/pushscan.ts
+++ b/src/pushscan.ts
@@ -34,11 +34,6 @@ export function buildPushScanResponse(xuid: string): string {
   return headers + "\r\n" + RESPONSE_BODY;
 }
 
-// Legacy fixed-x-uid response — kept for tests that assert the exact byte
-// layout of the default. The live server builds its response per-request
-// via buildPushScanResponse(echoedXuid).
-export const PUSHSCAN_RESPONSE = buildPushScanResponse("1");
-
 export type PushScanAction = "jpg" | "pdf" | "preview" | "unknown";
 
 export interface PushScanInfo {

--- a/src/pushscan.ts
+++ b/src/pushscan.ts
@@ -20,7 +20,7 @@ const RESPONSE_BODY_LENGTH = Buffer.byteLength(RESPONSE_BODY, "utf-8");
 // counter it increments and expects to see echoed back in our 200 OK. When
 // the values mismatch, the printer surfaces "Scanning Error" on the panel
 // even though the scan itself completes. See
-// docs/notes/2026-04-19-panel-error-investigation.md.
+// `docs/HOW-IT-WORKS.md` (push-scan trigger section).
 export function buildPushScanResponse(xuid: string): string {
   const headers =
     `HTTP/1.0 200 OK\r\n` +

--- a/src/scanner-legacy.ts
+++ b/src/scanner-legacy.ts
@@ -146,7 +146,7 @@ export function startScanSessionLegacy(
     let imageBuffer = Buffer.alloc(0);
     let imageBufferOffset = 0;
     let expectedBytes = 0;
-    const pageJpegPaths: string[] = [];
+    let pageCount = 0;
     let gammaChannelIdx = 0;
     const backPageIndices: number[] = [];
     // Set to true when looping back for the back side of a duplex sheet; controls
@@ -595,8 +595,8 @@ export function startScanSessionLegacy(
           // is the back side of the same sheet.
           // Pages are 1-indexed: 1 (front), 2 (back), 3 (front), 4 (back) ... so back-pages
           // are even indices. We push them as we discover them.
-          if (session.source === "adf-duplex" && pageJpegPaths.length % 2 === 1) {
-            backPageIndices.push(pageJpegPaths.length + 1);
+          if (session.source === "adf-duplex" && pageCount % 2 === 1) {
+            backPageIndices.push(pageCount + 1);
             // We push speculatively (next page may not arrive on hardware fault).
             // composePdfFromJpegs uses Set.has() so a dangling index is benign.
           }
@@ -693,7 +693,7 @@ export function startScanSessionLegacy(
           session.jpegQuality,
         );
         if (getState() === "ERROR") return; // bail if fail() ran during the ~8s encode
-        const pageNum = pageJpegPaths.length + 1;
+        const pageNum = pageCount + 1;
         // Duplex: even-numbered pages (2, 4, …) are back pages and come out rotated 180° due to
         // the ADF U-turn path. Insert EXIF Orientation=3 so viewers render them right-side up.
         if (session.source === "adf-duplex" && pageNum % 2 === 0) {
@@ -701,7 +701,7 @@ export function startScanSessionLegacy(
         }
         const jpgPath = path.join(sessionTempDir, `page_${String(pageNum).padStart(2, "0")}.jpg`);
         fs.writeFileSync(jpgPath, jpg);
-        pageJpegPaths.push(jpgPath);
+        pageCount++;
         log.debug(`Page ${pageNum} encoded, ${jpg.length} bytes -> ${jpgPath}`);
       } catch (err) {
         fail(`raw-to-jpeg encoding failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -595,7 +595,7 @@ export function startScanSession(
       // of the INIT_POLL loop: length 0 → ADF, length 12 → flatbed (payload is
       // filler `#---#---#---`). Later STATs (POSTSCAN cycles) can carry non-
       // zero lengths for unrelated reasons, so we only sample the first.
-      // See docs/notes/2026-04-21-flatbed-protocol-analysis.md.
+      // See `docs/HOW-IT-WORKS.md` (ESC/I-2 INIT_POLL section).
       const header = parseEsci2ReplyHeader(payload);
       if (initPollIteration === 0) {
         if (header) {
@@ -815,7 +815,7 @@ export function startScanSession(
       // On flatbed, any #pen is terminal because the glass is inherently single-
       // page and the printer never emits #lftd000 on that path. On ADF, #lft
       // disambiguates "terminal" vs "page boundary, more coming".
-      // See docs/notes/2026-04-21-flatbed-protocol-analysis.md.
+      // See `docs/HOW-IT-WORKS.md` (ESC/I-2 IMG loop / page boundary section).
       pageEndKind = tokens.has("pen")
         ? source === "flatbed" || tokens.has("lft")
           ? "last"

--- a/src/test-support/legacy-replay.ts
+++ b/src/test-support/legacy-replay.ts
@@ -16,15 +16,6 @@ const MAX_CHUNK_SIZE = 65536;
 const FILL_BUFFER = Buffer.alloc(MAX_CHUNK_SIZE, 0xb0);
 
 /**
- * Synthesise an IS-0xa200 image stream of `totalBytes` total bytes from
- * fixed-fill chunks of `chunkSize` (last chunk may be short).
- *
- * Used by replay tests to substitute for the real ~108 MB pixel stream
- * that we never commit. The fill byte is 0xb0 — a mid-grey RGB triplet
- * that yields a recognisable JPEG when sharp encodes it (useful for
- * eyeballing test failures).
- */
-/**
  * Drive a fixture replay: connect the fake socket, feed all printer→host events in
  * order (with a setImmediate yield before each to let the state machine process the
  * previous reply), then await the session promise.
@@ -49,7 +40,16 @@ export async function driveFixture(
   await sessionPromise;
 }
 
-export function synthesiseImageStream(totalBytes: number, chunkSize: number): Buffer[] {
+/**
+ * Synthesise an IS-0xa200 image stream of `totalBytes` total bytes from
+ * fixed-fill chunks of `chunkSize` (last chunk may be short).
+ *
+ * Used by replay tests to substitute for the real ~108 MB pixel stream
+ * that we never commit. The fill byte is 0xb0 — a mid-grey RGB triplet
+ * that yields a recognisable JPEG when sharp encodes it (useful for
+ * eyeballing test failures).
+ */
+function synthesiseImageStream(totalBytes: number, chunkSize: number): Buffer[] {
   if (chunkSize > MAX_CHUNK_SIZE) {
     throw new Error(`synthesiseImageStream: chunkSize ${chunkSize} exceeds MAX_CHUNK_SIZE`);
   }


### PR DESCRIPTION
## Summary

Phase A.1 + Phase B of v0.3.0. CI workflow tweak (one line) + eight independent low-risk cleanups from `.reference/reviews/kiss-dry-yagni-definitive.md` recommended priority order #1, plus the broken `docs/notes/...` references flagged by the architecture review.

### Phase A.1 (PR-level CI gate)

- Add `dev` to `.github/workflows/test.yml` `pull_request.branches` so milestone PRs to `dev` get the same lint/format/test gate as PRs to `main`. Required prep for the rest of v0.3.0.

### Phase B (sweep)

- Drop unused `KEEPALIVE_INTERVAL` env var (parsed + documented but never wired through)
- Collapse `pageJpegPaths` array to a counter (`.length` was the only thing read)
- Drop `PUSHSCAN_RESPONSE` export (tests use `buildPushScanResponse("1")` inline; tautology test gone)
- Tighten `output.ts` page-promotion filter (`sortedPageFiles` returns `PageEntry[]` so callers use the parsed page number directly; duplicate regex gone; `pdf.ts` caller updated for the new return shape)
- Simplify `paperless-upload.ts` (`Promise.allSettled` → `Promise.all` since per-upload `.catch()` already swallows)
- Consolidate `output-tail.ts` upload sites (single `savedPaths` + one `uploadAllToPaperless` call)
- Drop `synthesiseImageStream` export (only call site is in the same file); fix orphaned doc comment
- Redirect `docs/notes/...` source comments to `docs/HOW-IT-WORKS.md` (notes themselves stay private under `.reference/notes/`)

No wire-byte changes; replay tests unaffected. Test count 271 → 270 (sweep B.3 removed the `PUSHSCAN_RESPONSE` tautology).

Plus a controller-side commit applying prettier to the v0.3.0 spec + plan files (pre-existing format drift caught by `npm run format:check`).

## Test plan

- [ ] CI green (lint + format:check + test)
- [ ] Replay tests in `scanner.test.ts` (6 fixtures) and `scanner-legacy.test.ts` (10 fixtures) still pass byte-equivalent
- [ ] Test count: 270 (1 skipped) — down 1 from baseline 271 because of the deliberate B.3 tautology removal