### PR TITLE
chore: gitignore AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage/
 scan.log*
 command.bat
 CLAUDE.local.md
+AGENTS.md

--- a/docs/superpowers/plans/2026-05-04-v0.3.0-implementation.md
+++ b/docs/superpowers/plans/2026-05-04-v0.3.0-implementation.md
@@ -62,25 +62,25 @@ git commit -m "ci: run test workflow on PRs targeting dev"
 git push -u origin feature/v0.3.0-wf3620-autodetect
 ```
 
-- [ ] **Step 4: Open PR1 and verify CI fires**
+- [ ] **Step 4: Open PR1**
 
 ```bash
 gh pr create --base dev --head feature/v0.3.0-wf3620-autodetect --title "ci: run test workflow on PRs targeting dev" --body "Adds dev to the test workflow's pull_request.branches so milestone PRs to dev get the same lint/format/test gate as PRs to main. Required prep for the rest of v0.3.0."
 ```
 
-Verify: GitHub Actions tab shows `test / test` running on this PR. If it doesn't, the workflow change is wrong — re-check step 2.
+**Note on CI for PR1 itself:** the workflow currently filters PRs to `main` only, so PR1 (which targets `dev`) will *not* trigger the `test` workflow on the PR. CI fires after merge via the `push: branches: [dev, main]` trigger. Verify locally that lint/format/test are green (`npm run lint && npm run format:check && npm test`) — that's the gate for this PR. PR2 onwards will get the proper PR-level CI gate.
 
-- [ ] **Step 5: Merge PR1 once CI is green**
+- [ ] **Step 5: Merge PR1 once CI is green, recreate the local branch from new dev tip**
 
-Use squash-merge via `gh pr merge --squash --delete-branch` or the GitHub UI. **Do NOT delete the local branch** — re-create it from the new dev tip:
+Use squash-merge via `gh pr merge --squash --delete-branch` or the GitHub UI. The local branch still exists; reset it to the post-merge dev tip:
 
 ```bash
 git checkout dev
 git pull origin dev
-git checkout -b feature/v0.3.0-wf3620-autodetect
+git switch -C feature/v0.3.0-wf3620-autodetect origin/dev
 ```
 
-(Subsequent PRs all branch from `dev` post-merge.)
+(`switch -C` creates-or-resets the branch — works whether or not the local branch survives the remote delete. Subsequent phases use the same idiom for fresh per-PR branches off updated dev.)
 
 ---
 
@@ -329,6 +329,8 @@ buildPushScanResponse('1') call; drop the tautology assertion."
 
 **Files:**
 - Modify: `src/output.ts:92-134`
+- Modify: `src/pdf.ts:38` (also calls `sortedPageFiles`; signature change forces a `.name` access)
+- Modify: `src/output.test.ts` (any tests asserting on `sortedPageFiles` returning strings)
 
 - [ ] **Step 1: Update `sortedPageFiles` to also expose the parsed page number**
 
@@ -418,30 +420,49 @@ export function promoteTempPagesToOutput(
 }
 ```
 
-- [ ] **Step 3: Update any tests that assume `sortedPageFiles` returns `string[]`**
+- [ ] **Step 3: Update `src/pdf.ts` for the new return shape**
 
-Run: `grep -rn "sortedPageFiles" src/` to find all call sites and tests.
+`pdf.ts:38` is the second caller of `sortedPageFiles`. Today it iterates `entries` and passes each entry directly to `path.join(tempDir, entry)`. With the new shape this is a type error.
 
-If `src/output.test.ts` (or similar) asserts on `sortedPageFiles` returning strings, update those tests to read `.name` from each entry. If you find unrelated callers (none expected — this is a single-caller helper), update them.
+In `src/pdf.ts:38`, change:
+```ts
+  const buffers = await Promise.all(entries.map((entry) => fs.readFile(path.join(tempDir, entry))));
+```
+to:
+```ts
+  const buffers = await Promise.all(
+    entries.map((entry) => fs.readFile(path.join(tempDir, entry.name))),
+  );
+```
 
-- [ ] **Step 4: Run replay tests (the wire-byte regression shield exercises this code path)**
+The `for (let i = 0; i < entries.length; i++)` loop a few lines down indexes `entries[i]` to obtain the page number; verify that loop body. If it reads `entries[i]` as a string anywhere (e.g. for a filename), change those reads to `entries[i].name`.
+
+- [ ] **Step 4: Update any tests asserting on `sortedPageFiles` returning `string[]`**
+
+Run: `grep -rn "sortedPageFiles" src/`
+Expected hits: `src/output.ts` (definition + caller), `src/pdf.ts` (caller, just patched), and possibly `src/output.test.ts`.
+
+If `src/output.test.ts` asserts on the return shape, update those tests to read `.name` from each entry.
+
+- [ ] **Step 5: Run replay tests (the wire-byte regression shield exercises this code path through `composePdfFromJpegs`)**
 
 ```bash
 npm run lint && npm run format:check && npm test
 ```
 
-Expected: all green.
+Expected: all green. PDF replay tests in both `scanner.test.ts` and `scanner-legacy.test.ts` exercise `pdf.ts` end-to-end.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add src/output.ts src/output.test.ts
+git add src/output.ts src/pdf.ts src/output.test.ts
 git commit -m "refactor(output): tighten promoteTempPagesToOutput filter, drop duplicate regex parse
 
 sortedPageFiles now returns { name, page }[] so callers can use the
 parsed page number directly. promoteTempPagesToOutput passes 'jpg'
 to filter — current temp dirs only contain JPEGs, so no behaviour
-change, but the contract is now explicit."
+change, but the contract is now explicit. pdf.ts's caller updated
+to read entry.name."
 ```
 
 ### Task B.5: Simplify `paperless-upload.ts:uploadAllToPaperless`
@@ -775,7 +796,7 @@ Use `gh pr checks <PR_NUM> --watch` or the GitHub UI. Squash-merge.
 ```bash
 git checkout dev
 git pull origin dev
-git checkout -b feature/v0.3.0-wf3620-autodetect-cert  # fresh branch for PR3
+git switch -C feature/v0.3.0-wf3620-autodetect-cert origin/dev  # fresh branch for PR3
 ```
 
 ---
@@ -900,7 +921,7 @@ Wait for CI green; squash-merge. Then:
 ```bash
 git checkout dev
 git pull origin dev
-git checkout -b feature/v0.3.0-wf3620-autodetect-contract
+git switch -C feature/v0.3.0-wf3620-autodetect-contract origin/dev
 ```
 
 ---
@@ -1130,28 +1151,33 @@ Add inside the `describe("startScanSession failure-mode matrix", …)` block:
 
 ```ts
     it("rejects on timeout (no response in TIMEOUT_MS)", async () => {
-      // Use vi.useFakeTimers() + advance past TIMEOUT_MS without feeding any data.
-      // Adapt the FakeTlsSocket pattern to leave the connection idle after WELCOME.
-      const fake = new FakeTlsSocket();
-      const scanPromise = startScanSession(
-        {
-          printerIp: "1.2.3.4",
-          port: 1865,
-          destId: 0x02,
-          outputDir: "/tmp",
-          tempDir: "/tmp",
-          duplex: false,
-          action: "jpg",
-          paperless: undefined,
-        },
-        fake.asFactory(),
-      );
-      fake.simulateConnect();
-      // No data fed; advance fake timers past TIMEOUT_MS (declared in scanner.ts ~line 65)
+      // CRITICAL: install fake timers BEFORE startScanSession runs. The scanner
+      // schedules a setTimeout(TIMEOUT_MS) inside the connect callback fired by
+      // simulateConnect(); if useFakeTimers is called after, the real timer is
+      // already armed and advancing fake timers won't fire it.
       vi.useFakeTimers();
-      vi.advanceTimersByTime(120_000);
-      vi.useRealTimers();
-      await expect(scanPromise).rejects.toThrow(/timeout/i);
+      try {
+        const fake = new FakeTlsSocket();
+        const scanPromise = startScanSession(
+          {
+            printerIp: "1.2.3.4",
+            port: 1865,
+            destId: 0x02,
+            outputDir: "/tmp",
+            tempDir: "/tmp",
+            duplex: false,
+            action: "jpg",
+            paperless: undefined,
+          },
+          fake.asFactory(),
+        );
+        fake.simulateConnect();
+        // TIMEOUT_MS is 30_000 in scanner.ts (line 113); 60_000 overshoots safely.
+        await vi.advanceTimersByTimeAsync(60_000);
+        await expect(scanPromise).rejects.toThrow(/timeout/i);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("rejects on socket error mid-session", async () => {
@@ -1213,9 +1239,10 @@ Add inside the `describe("startScanSession failure-mode matrix", …)` block:
         fake.asFactory(),
       );
       fake.simulateConnect();
-      // ASYNC_FATAL set in scanner.ts contains specific dispatch bytes — pick one.
-      // Confirm by reading src/scanner.ts:121-124 for the actual constants.
-      const fatalPacket = buildIsPacket(0x9000, Buffer.from([0x05]));
+      // ASYNC_FATAL in scanner.ts:124 contains 0x02 (Disconnect), 0x80 (Timeout),
+      // 0xa0 (ServerError). Use 0x02. (0x05 is "unknown" and falls through to
+      // log.warn with no rejection.)
+      const fatalPacket = buildIsPacket(0x9000, Buffer.from([0x02]));
       fake.feed(fatalPacket);
       await expect(scanPromise).rejects.toThrow(/fatal/i);
     });
@@ -1409,7 +1436,7 @@ These are accepted as a v0.3.0 coverage gap, mitigated by:
 
 - [ ] **Step 2: Migrate the zero-image-completion site**
 
-In `src/scanner.ts:978-981`, change:
+In `src/scanner.ts:977-981`, change:
 ```ts
       socket.end();
       if (imageChunks.length === 0) {
@@ -1419,13 +1446,18 @@ In `src/scanner.ts:978-981`, change:
 ```
 to:
 ```ts
-      socket.end();
       if (imageChunks.length === 0) {
         log.error("Scan completed with zero image chunks");
-        errorReason = new Error("Scan completed with zero image chunks");
-        // Close handler will reject.
+        // rejectOnce BEFORE socket.end(): on a real TLS socket end() is async, but
+        // FakeTlsSocket.end() emits "close" synchronously — the close handler
+        // would call resolveOnce() before we ever set errorReason. Reject up
+        // front; socket.end() afterwards just cleans up the socket (resolveOnce
+        // in the close handler will be a no-op via the `resolved` guard).
+        rejectOnce(new Error("Scan completed with zero image chunks"));
+        socket.end();
         return;
       }
+      socket.end();
 ```
 
 - [ ] **Step 3: Migrate the finalizeSession-failure site**
@@ -1595,7 +1627,7 @@ Below the existing describe block, add:
       await expect(scanPromise).rejects.toThrow(/socket error|ECONNREFUSED/i);
     });
 
-    it("rejects on protocol violation (unexpected packet shape)", async () => {
+    it("rejects on protocol violation (welcome with wrong packet type)", async () => {
       const fake = new FakeTcpSocket();
       const scanPromise = startScanSessionLegacy(
         {
@@ -1603,20 +1635,21 @@ Below the existing describe block, add:
           port: 1865,
           outputDir,
           tempDir,
-          source: "adf-simplex",
+          duplex: false,
+          forcedSource: "adf-simplex", // forcedSource short-circuits STATUS_2; matches old test shape
           format: "jpg",
           jpegQuality: 90,
         },
         fake.asFactory(),
       );
       fake.simulateConnect();
-      // Feed a malformed packet that ends up in STATUS_2 with the wrong length.
-      // Easier: feed a single byte the welcome handler doesn't expect.
-      // Walk through the existing fixture's first few events to reach a stable state,
-      // then inject garbage. (Implementation detail; depends on driveFixture extension.)
-      // For now, send raw garbage at the welcome stage:
-      fake.feed(Buffer.from("00".repeat(20), "hex"));
-      await expect(scanPromise).rejects.toThrow();
+      // WELCOME state expects a valid IS packet of type 0x8000 (scanner-legacy.ts:247).
+      // Feed type 0xa000 instead — fail() rejects immediately with
+      //   "expected welcome (0x8000), got 0xa000".
+      // (Raw garbage that doesn't form a valid IS header would just buffer until
+      //  the 60s timeout, not reject.)
+      fake.feed(buildIsPacket(0xa000, Buffer.alloc(0)));
+      await expect(scanPromise).rejects.toThrow(/expected welcome \(0x8000\)/);
     });
   });
 ```
@@ -1681,7 +1714,7 @@ gh pr checks --watch
 # After merge:
 git checkout dev
 git pull origin dev
-git checkout -b feature/v0.3.0-wf3620-autodetect-fsf
+git switch -C feature/v0.3.0-wf3620-autodetect-fsf origin/dev
 ```
 
 ---
@@ -1825,6 +1858,13 @@ export interface LegacyScanSession {
   format: Format;
   jpegQuality: number;
   paperless?: PaperlessUploadOptions;
+  /**
+   * Test-only hook fired once when STATUS_2 has decided the source (either
+   * from the FS F byte via legacyDetectSource or from forcedSource). Lets
+   * the replay-test matrix assert per-fixture detection without needing a
+   * mutable return value. Production code does not pass this.
+   */
+  onSourceDetected?: (source: Source) => void;
 }
 ```
 
@@ -1960,6 +2000,8 @@ In `src/scanner-legacy.ts:330-362`, replace the entire STATUS_2 case body with:
             detectedSource = result.source;
             log.info(`STATUS_2: source detected from FS F byte 0x${statusByte.toString(16)} → ${detectedSource}`);
           }
+          // Fire the test hook (no-op in production — the field is undefined).
+          session.onSourceDetected?.(detectedSource);
           // Original branching, now in terms of detectedSource:
           if (statusByte === 0x81) {
             // Scanner signalled busy — initiate reset cycle
@@ -2099,9 +2141,17 @@ The exact shape will depend on the existing tests' assertions. Skeleton:
 ```ts
   it.each(FIXTURE_SPECS)(
     "$path: detects $expectedDetectedSource and produces $expectedFileCount file(s)",
-    async ({ path: fixturePath, format, duplex, expectedDetectedSource, expectedFileCount, expectedBackPages }) => {
+    async ({
+      path: fixturePath,
+      format,
+      duplex,
+      expectedDetectedSource,
+      expectedFileCount,
+      expectedBackPages,
+    }) => {
       const fixture = loadFixture(path.join(FIXTURES, fixturePath));
       const fake = new FakeTcpSocket();
+      let detectedSource: string | null = null;
 
       const sessionPromise = startScanSessionLegacy(
         {
@@ -2113,15 +2163,23 @@ The exact shape will depend on the existing tests' assertions. Skeleton:
           forcedSource: null, // pure detection — no override
           format,
           jpegQuality: 90,
+          onSourceDetected: (s) => {
+            detectedSource = s;
+          },
         },
         fake.asFactory(),
       );
       await driveFixture(fixture, fake, sessionPromise);
 
+      // Detection assertion — fires only via the test hook.
+      expect(detectedSource).toBe(expectedDetectedSource);
+
       const files = readdirSync(outputDir);
       expect(files).toHaveLength(expectedFileCount);
       // ... format-specific extension assertion ...
       // ... back-page-index assertion via PDF /Rotate, etc. ...
+      // (use the same shape the existing tests use — see scanner-legacy.test.ts
+      //  pre-rework body for the format/back-page assertion blocks to lift in.)
     },
     60_000,
   );
@@ -2169,11 +2227,17 @@ Add to `src/scanner-legacy.test.ts`, in a new `describe("FS F unknown-byte handl
       let fsFCount = 0;
       const mutated = fixture.map((event) => {
         if (event.dir !== "p>h" || !("hex" in event)) return event;
-        // IS packet structure: 12-byte header (with type at bytes 4-5), then payload.
-        // STATUS replies are 16-byte payloads.
+        // IS packet header (see src/protocol.ts):
+        //   bytes 0-1: magic
+        //   bytes 2-3: type (UInt16BE)
+        //   bytes 4-5: 0x000c fixed
+        //   bytes 6-9: payloadSize (UInt32BE)
+        //   bytes 10-11: reserved
+        //   bytes 12+: payload
+        // STATUS_n replies are type 0xa000 with 16-byte payloads.
         const buf = Buffer.from(event.hex, "hex");
         if (buf.length < 12 + 16) return event;
-        const type = buf.readUInt16BE(4);
+        const type = buf.readUInt16BE(2);
         const length = buf.readUInt32BE(6);
         if (type === 0xa000 && length === 16) {
           fsFCount++;
@@ -2276,7 +2340,7 @@ EOF
 gh pr checks --watch
 git checkout dev
 git pull origin dev
-git checkout -b feature/v0.3.0-release
+git switch -C feature/v0.3.0-release origin/dev
 ```
 
 ---
@@ -2406,14 +2470,15 @@ EOF
 )"
 ```
 
-- [ ] **Step 3: After CI green, merge with a merge-commit (preserves history)**
+- [ ] **Step 3: After CI green, merge with `--rebase`**
 
-Use the GitHub UI's "Create a merge commit" option, or:
+`main` has linear-history branch protection (per `CLAUDE.md`'s "Server-side branch protection on main: PR required, CI status check required, **linear history required**"), so merge commits are blocked. Use rebase merge — it replays each commit from `dev` onto `main`, preserving the per-PR history without a merge commit:
+
 ```bash
-gh pr merge --merge <PR_NUM>
+gh pr merge --rebase <PR_NUM>
 ```
 
-(Squash would collapse the six v0.3.0 PRs into one main-side commit, losing the per-PR history. Use a merge commit.)
+(`--squash` would collapse the six v0.3.0 PRs into one main-side commit and lose per-PR history. `--rebase` preserves them. `--merge` is blocked by the linear-history requirement.)
 
 ### Task G.2: Tag the release
 

--- a/docs/superpowers/plans/2026-05-04-v0.3.0-implementation.md
+++ b/docs/superpowers/plans/2026-05-04-v0.3.0-implementation.md
@@ -1,0 +1,2484 @@
+# v0.3.0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship v0.3.0 — close the WF-3620 gate (issue #28 FS F autodetection), close the cert-pinning bypass, reconcile the promise contract between the two scanner paths, sweep the small KISS/DRY/YAGNI items, and tag a release.
+
+**Architecture:** v0.3.0 is byte-conservative — no protocol bytes change on the wire. The replay tests (`src/scanner.test.ts`, `src/scanner-legacy.test.ts`) are the regression shield; every commit must keep them green. Six PRs land in order against `dev` on a short-lived branch `feature/v0.3.0-wf3620-autodetect`. Final `dev → main` cuts the release.
+
+**Tech Stack:** Node.js 24.15.0; TypeScript (NodeNext); Vitest; Zod schemas; ESLint typescript-eslint; Prettier; pre-push hook + GitHub Actions for lint + format:check + test gate.
+
+**Spec:** `docs/superpowers/specs/2026-05-04-v0.3.0-and-v0.4.0-design.md` is the source of truth — re-read §3 before each phase.
+
+**Branch setup before starting:**
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feature/v0.3.0-wf3620-autodetect
+```
+
+**After each task:** run the local CI mirror — `npm run lint && npm run format:check && npm test` — before committing. If anything fails, fix before progressing. The pre-push hook enforces this when you push to `origin`.
+
+---
+
+## Phase A — CI workflow tweak (PR1)
+
+This phase lands first because subsequent PRs target `dev`, and the workflow currently doesn't run on PRs to `dev`. Without this, the PR-level CI gate the rest of v0.3.0 relies on doesn't exist.
+
+### Task A.1: Add `dev` to `pull_request.branches`
+
+**Files:**
+- Modify: `.github/workflows/test.yml:7`
+
+- [ ] **Step 1: Open the workflow file and verify current shape**
+
+Run: `cat .github/workflows/test.yml | head -10`
+Expected: line 4-7 reads
+```yaml
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [main]
+```
+
+- [ ] **Step 2: Edit the workflow**
+
+Change line 7 from `branches: [main]` to `branches: [dev, main]`. After the edit, lines 4-7 read:
+```yaml
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+```
+
+- [ ] **Step 3: Commit and push**
+
+```bash
+git add .github/workflows/test.yml
+git commit -m "ci: run test workflow on PRs targeting dev"
+git push -u origin feature/v0.3.0-wf3620-autodetect
+```
+
+- [ ] **Step 4: Open PR1 and verify CI fires**
+
+```bash
+gh pr create --base dev --head feature/v0.3.0-wf3620-autodetect --title "ci: run test workflow on PRs targeting dev" --body "Adds dev to the test workflow's pull_request.branches so milestone PRs to dev get the same lint/format/test gate as PRs to main. Required prep for the rest of v0.3.0."
+```
+
+Verify: GitHub Actions tab shows `test / test` running on this PR. If it doesn't, the workflow change is wrong — re-check step 2.
+
+- [ ] **Step 5: Merge PR1 once CI is green**
+
+Use squash-merge via `gh pr merge --squash --delete-branch` or the GitHub UI. **Do NOT delete the local branch** — re-create it from the new dev tip:
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feature/v0.3.0-wf3620-autodetect
+```
+
+(Subsequent PRs all branch from `dev` post-merge.)
+
+---
+
+## Phase B — KISS/DRY/YAGNI sweep 1 (PR2)
+
+Eight independent items. Each is a separate commit; the whole phase is one PR with `~30 lines` net diff. None changes wire bytes; none should perturb replay tests.
+
+**Branch:** still `feature/v0.3.0-wf3620-autodetect` (recreated from dev tip after PR1 merge).
+
+### Task B.1: Remove `KEEPALIVE_INTERVAL` from config + tests + README
+
+**Files:**
+- Modify: `src/config.ts` (drop `keepaliveInterval` schema field + raw-env wiring)
+- Modify: `src/config.test.ts` (drop the two cases referencing `keepaliveInterval`)
+- Modify: `README.md:102` (drop the row)
+
+- [ ] **Step 1: Run the existing tests to establish a baseline**
+
+Run: `npx vitest run src/config.test.ts --reporter=verbose 2>&1 | tail -40`
+Expected: all loadConfig tests pass.
+
+- [ ] **Step 2: Remove the schema field**
+
+In `src/config.ts:15`, delete the line:
+```ts
+    keepaliveInterval: z.coerce.number().int().min(100).default(500),
+```
+
+In `src/config.ts:79`, delete the line:
+```ts
+    keepaliveInterval: process.env.KEEPALIVE_INTERVAL || undefined,
+```
+
+- [ ] **Step 3: Drop the test cases that reference `keepaliveInterval`**
+
+In `src/config.test.ts:14`, delete the line:
+```ts
+    delete process.env.KEEPALIVE_INTERVAL;
+```
+
+In `src/config.test.ts:43`, delete:
+```ts
+    expect(config.keepaliveInterval).toBe(500);
+```
+
+In `src/config.test.ts:55`, delete:
+```ts
+    process.env.KEEPALIVE_INTERVAL = "1000";
+```
+
+In `src/config.test.ts:64`, delete:
+```ts
+    expect(config.keepaliveInterval).toBe(1000);
+```
+
+- [ ] **Step 4: Drop the README row**
+
+Delete line 102 from `README.md` (the `KEEPALIVE_INTERVAL` row in the env-var table).
+
+- [ ] **Step 5: Run lint + format + tests**
+
+```bash
+npm run lint && npm run format:check && npm test
+```
+
+Expected: all green. Test count drops by 0 (removed two assertions, not tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config.ts src/config.test.ts README.md
+git commit -m "refactor(config): drop unused KEEPALIVE_INTERVAL env var"
+```
+
+### Task B.2: Replace `pageJpegPaths` with a counter
+
+**Files:**
+- Modify: `src/scanner-legacy.ts:149, 598-602, 696-704`
+
+- [ ] **Step 1: Verify current behaviour by replay tests**
+
+Run: `npx vitest run src/scanner-legacy.test.ts --reporter=verbose 2>&1 | tail -20`
+Expected: all replay tests green.
+
+- [ ] **Step 2: Replace declaration**
+
+In `src/scanner-legacy.ts:149`, change:
+```ts
+    const pageJpegPaths: string[] = [];
+```
+to:
+```ts
+    let pageCount = 0;
+```
+
+- [ ] **Step 3: Replace the `length` reads**
+
+Two sites use `pageJpegPaths.length` to test "completed pages so far":
+
+In `src/scanner-legacy.ts:598-599`:
+```ts
+          if (session.source === "adf-duplex" && pageJpegPaths.length % 2 === 1) {
+            backPageIndices.push(pageJpegPaths.length + 1);
+```
+becomes:
+```ts
+          if (session.source === "adf-duplex" && pageCount % 2 === 1) {
+            backPageIndices.push(pageCount + 1);
+```
+
+In `src/scanner-legacy.ts:696`:
+```ts
+        const pageNum = pageJpegPaths.length + 1;
+```
+becomes:
+```ts
+        const pageNum = pageCount + 1;
+```
+
+- [ ] **Step 4: Replace the push**
+
+In `src/scanner-legacy.ts:702-704` the path is computed and `push`ed for `length` only:
+```ts
+        const jpgPath = path.join(sessionTempDir, `page_${String(pageNum).padStart(2, "0")}.jpg`);
+        fs.writeFileSync(jpgPath, jpg);
+        pageJpegPaths.push(jpgPath);
+```
+becomes:
+```ts
+        const jpgPath = path.join(sessionTempDir, `page_${String(pageNum).padStart(2, "0")}.jpg`);
+        fs.writeFileSync(jpgPath, jpg);
+        pageCount++;
+```
+
+- [ ] **Step 5: Run replay tests + lint**
+
+```bash
+npm run lint && npx vitest run src/scanner-legacy.test.ts
+```
+
+Expected: all replay tests green (the change is internal bookkeeping, fixtures unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/scanner-legacy.ts
+git commit -m "refactor(scanner-legacy): collapse pageJpegPaths array to a counter
+
+The array's strings were never read — only .length was consulted.
+finalizeSession discovers final paths via readdirSync(sessionTempDir)."
+```
+
+### Task B.3: Drop `PUSHSCAN_RESPONSE` export and rewrite the tautology test
+
+**Files:**
+- Modify: `src/pushscan.ts:36-40` (drop the const + comment)
+- Modify: `src/pushscan.test.ts:5, 14-36, 51-52` (rewrite tests to call `buildPushScanResponse("1")` inline; drop the `expect(buildPushScanResponse("1")).toBe(PUSHSCAN_RESPONSE)` tautology)
+
+- [ ] **Step 1: Drop the export from pushscan.ts**
+
+In `src/pushscan.ts`, delete lines 37-40:
+```ts
+// Legacy fixed-x-uid response — kept for tests that assert the exact byte
+// layout of the default. The live server builds its response per-request
+// via buildPushScanResponse(echoedXuid).
+export const PUSHSCAN_RESPONSE = buildPushScanResponse("1");
+```
+
+- [ ] **Step 2: Update pushscan.test.ts imports**
+
+In `src/pushscan.test.ts:4-12`, change:
+```ts
+import {
+  PUSHSCAN_RESPONSE,
+  buildPushScanResponse,
+  ...
+} from "./pushscan.js";
+```
+to drop `PUSHSCAN_RESPONSE`:
+```ts
+import {
+  buildPushScanResponse,
+  ...
+} from "./pushscan.js";
+```
+
+- [ ] **Step 3: Rewrite the `describe("PUSHSCAN_RESPONSE", …)` block**
+
+In `src/pushscan.test.ts:14-36`, replace the entire block with one that calls `buildPushScanResponse("1")` inline:
+```ts
+describe("buildPushScanResponse default x-uid (xuid=1)", () => {
+  const response = buildPushScanResponse("1");
+
+  it("starts with HTTP/1.0 200 OK", () => {
+    expect(response.startsWith("HTTP/1.0 200 OK\r\n")).toBe(true);
+  });
+
+  it("contains the required Epson headers with spaces before colons", () => {
+    expect(response).toContain("Server : Epson Net Scan Monitor/2.0");
+    expect(response).toContain("x-protocol-name : Epson Network Service Protocol");
+    expect(response).toContain("x-protocol-version : 2.00");
+    expect(response).toContain("x-status : 0001");
+  });
+
+  it("has correct Content-Length matching the body", () => {
+    const parts = response.split("\r\n\r\n");
+    const body = parts[1];
+    const bodyLength = Buffer.byteLength(body, "utf-8");
+    expect(response).toContain(`Content-Length : ${bodyLength}`);
+  });
+
+  it("contains the SOAP PushScanResponse with StatusOut OK", () => {
+    expect(response).toContain("<StatusOut>OK</StatusOut>");
+  });
+});
+```
+
+- [ ] **Step 4: Drop the tautology test**
+
+In `src/pushscan.test.ts:51-53`, delete:
+```ts
+  it("produces PUSHSCAN_RESPONSE when called with the legacy default '1'", () => {
+    expect(buildPushScanResponse("1")).toBe(PUSHSCAN_RESPONSE);
+  });
+```
+
+- [ ] **Step 5: Run lint + tests**
+
+```bash
+npm run lint && npm run format:check && npx vitest run src/pushscan.test.ts
+```
+
+Expected: all green; test count down by 1.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pushscan.ts src/pushscan.test.ts
+git commit -m "refactor(pushscan): drop PUSHSCAN_RESPONSE export, kept only for tests
+
+Move the default-xuid fixture into the test file as an inline
+buildPushScanResponse('1') call; drop the tautology assertion."
+```
+
+### Task B.4: Tighten `output.ts:promoteTempPagesToOutput` page filter and drop the duplicate regex parse
+
+**Files:**
+- Modify: `src/output.ts:92-134`
+
+- [ ] **Step 1: Update `sortedPageFiles` to also expose the parsed page number**
+
+Today `sortedPageFiles` builds `{ name, page }[]` internally and discards `page` on return. The only caller (`promoteTempPagesToOutput`) re-parses it via regex. Extend the return shape:
+
+In `src/output.ts:92-102`, change:
+```ts
+export function sortedPageFiles(names: string[], ext?: string): string[] {
+  const extPattern = ext ? ext.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : "[^.]+";
+  const re = new RegExp(`^page_(\\d+)\\.${extPattern}$`);
+  const matched: { name: string; page: number }[] = [];
+  for (const name of names) {
+    const m = re.exec(name);
+    if (m) matched.push({ name, page: parseInt(m[1], 10) });
+  }
+  matched.sort((a, b) => a.page - b.page);
+  return matched.map((e) => e.name);
+}
+```
+to:
+```ts
+export interface PageEntry {
+  name: string;
+  page: number;
+}
+
+export function sortedPageFiles(names: string[], ext?: string): PageEntry[] {
+  const extPattern = ext ? ext.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") : "[^.]+";
+  const re = new RegExp(`^page_(\\d+)\\.${extPattern}$`);
+  const matched: PageEntry[] = [];
+  for (const name of names) {
+    const m = re.exec(name);
+    if (m) matched.push({ name, page: parseInt(m[1], 10) });
+  }
+  matched.sort((a, b) => a.page - b.page);
+  return matched;
+}
+```
+
+- [ ] **Step 2: Update `promoteTempPagesToOutput` to use the parsed entries and pass the extension filter**
+
+In `src/output.ts:114-134`, change:
+```ts
+export function promoteTempPagesToOutput(
+  tempDir: string,
+  outputDir: string,
+  sessionTs: Date,
+  extension: string,
+): string[] {
+  const entries = sortedPageFiles(fs.readdirSync(tempDir));
+
+  const paths: string[] = [];
+  for (const entry of entries) {
+    const src = path.join(tempDir, entry);
+    const data = fs.readFileSync(src);
+    const pageNum = parseInt(entry.match(/^page_(\d+)/)![1], 10);
+    const pageIndex = entries.length > 1 ? pageNum : undefined;
+    const filename = generateFilename(sessionTs, extension, pageIndex);
+    const out = writeOutputFile(outputDir, filename, data);
+    fs.unlinkSync(src);
+    paths.push(out);
+  }
+  return paths;
+}
+```
+to:
+```ts
+export function promoteTempPagesToOutput(
+  tempDir: string,
+  outputDir: string,
+  sessionTs: Date,
+  extension: string,
+): string[] {
+  const entries = sortedPageFiles(fs.readdirSync(tempDir), extension);
+
+  const paths: string[] = [];
+  for (const entry of entries) {
+    const src = path.join(tempDir, entry.name);
+    const data = fs.readFileSync(src);
+    const pageIndex = entries.length > 1 ? entry.page : undefined;
+    const filename = generateFilename(sessionTs, extension, pageIndex);
+    const out = writeOutputFile(outputDir, filename, data);
+    fs.unlinkSync(src);
+    paths.push(out);
+  }
+  return paths;
+}
+```
+
+- [ ] **Step 3: Update any tests that assume `sortedPageFiles` returns `string[]`**
+
+Run: `grep -rn "sortedPageFiles" src/` to find all call sites and tests.
+
+If `src/output.test.ts` (or similar) asserts on `sortedPageFiles` returning strings, update those tests to read `.name` from each entry. If you find unrelated callers (none expected — this is a single-caller helper), update them.
+
+- [ ] **Step 4: Run replay tests (the wire-byte regression shield exercises this code path)**
+
+```bash
+npm run lint && npm run format:check && npm test
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/output.ts src/output.test.ts
+git commit -m "refactor(output): tighten promoteTempPagesToOutput filter, drop duplicate regex parse
+
+sortedPageFiles now returns { name, page }[] so callers can use the
+parsed page number directly. promoteTempPagesToOutput passes 'jpg'
+to filter — current temp dirs only contain JPEGs, so no behaviour
+change, but the contract is now explicit."
+```
+
+### Task B.5: Simplify `paperless-upload.ts:uploadAllToPaperless`
+
+**Files:**
+- Modify: `src/paperless-upload.ts:63-76`
+
+- [ ] **Step 1: Verify current behaviour**
+
+The current code wraps each `uploadOne` in `.catch()` (so it never rejects), then uses `Promise.allSettled` (which never rejects either). Two layers of "never throw" is one too many.
+
+- [ ] **Step 2: Replace with a clearer shape**
+
+In `src/paperless-upload.ts:63-76`, change:
+```ts
+export async function uploadAllToPaperless(
+  filePaths: string[],
+  opts: PaperlessUploadOptions,
+): Promise<void> {
+  log.info(`Uploading ${filePaths.length} file(s) to Paperless-ngx`);
+  await Promise.allSettled(
+    filePaths.map((p) =>
+      uploadOne(p, opts).catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.error(`Paperless upload failed for ${basename(p)}: ${msg}`);
+      }),
+    ),
+  );
+}
+```
+to:
+```ts
+export async function uploadAllToPaperless(
+  filePaths: string[],
+  opts: PaperlessUploadOptions,
+): Promise<void> {
+  log.info(`Uploading ${filePaths.length} file(s) to Paperless-ngx`);
+  // Per-upload catch logs and swallows; Promise.all is safe because no
+  // mapped promise rejects. Decision: log-and-continue on any single
+  // upload failure — see paperless-upload.ts:56-60 for the broader
+  // "scan complete = local file written" policy.
+  await Promise.all(
+    filePaths.map((p) =>
+      uploadOne(p, opts).catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.error(`Paperless upload failed for ${basename(p)}: ${msg}`);
+      }),
+    ),
+  );
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+npm run lint && npm test
+```
+
+Expected: all green. The behavioural change is zero (both `Promise.allSettled` and `Promise.all` resolve when no mapped promise rejects).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/paperless-upload.ts
+git commit -m "refactor(paperless): drop redundant Promise.allSettled wrap
+
+Per-upload .catch() already swallows rejections, so Promise.allSettled
+gives no extra safety. Promise.all reads more clearly given the policy
+is 'log every failure, never abort completed scans'."
+```
+
+### Task B.6: Consolidate the three Paperless upload sites in `output-tail.ts`
+
+**Files:**
+- Modify: `src/output-tail.ts:26-57`
+
+- [ ] **Step 1: Refactor `finalizeSession` to compute `savedPaths` once, then upload once**
+
+In `src/output-tail.ts:26-57`, replace the body of `finalizeSession` with:
+```ts
+export async function finalizeSession(args: FinalizeSessionArgs): Promise<void> {
+  const { sessionTempDir, outputDir, sessionTs, action, backPageIndices, paperless } = args;
+  try {
+    let savedPaths: string[];
+    if (action === "jpg") {
+      savedPaths = promoteTempPagesToOutput(sessionTempDir, outputDir, sessionTs, "jpg");
+      log.info(`Scan complete — wrote ${savedPaths.length} JPG file(s); first: ${savedPaths[0]}`);
+    } else {
+      try {
+        const pdfBuf = await composePdfFromJpegs(sessionTempDir, { backPages: backPageIndices });
+        const pdfName = generateFilename(sessionTs, "pdf");
+        const pdfPath = writeOutputFile(outputDir, pdfName, pdfBuf);
+        log.info(`Scan complete — saved PDF to ${pdfPath}`);
+        savedPaths = [pdfPath];
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.error(`PDF composition failed: ${msg}. Falling back to JPG output.`);
+        savedPaths = promoteTempPagesToOutput(sessionTempDir, outputDir, sessionTs, "jpg");
+        log.info(`Saved ${savedPaths.length} JPG file(s) as fallback`);
+      }
+    }
+    if (paperless) {
+      await uploadAllToPaperless(savedPaths, paperless);
+    }
+  } finally {
+    fs.rmSync(sessionTempDir, { recursive: true, force: true });
+  }
+}
+```
+
+- [ ] **Step 2: Run output-tail tests + replay tests**
+
+```bash
+npm run lint && npm run format:check && npm test
+```
+
+Expected: all green. `output-tail.test.ts` should still cover all three branches (JPG path, PDF success path, PDF fallback path); none of the assertions targeted the per-branch upload call directly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/output-tail.ts
+git commit -m "refactor(output-tail): compute savedPaths once, upload once
+
+Three identical \`if (paperless) await uploadAllToPaperless(...)\`
+branches collapsed into a single call after the action/fallback
+decision. No behavioural change."
+```
+
+### Task B.7: Drop `synthesiseImageStream` export and fix the orphaned doc comment
+
+**Files:**
+- Modify: `src/test-support/legacy-replay.ts:18-26, 52`
+
+- [ ] **Step 1: Drop the export keyword and reattach the doc comment**
+
+In `src/test-support/legacy-replay.ts:18-26` is a doc comment that *should* attach to `synthesiseImageStream` (line 52) but currently sits above `driveFixture`. Move it.
+
+In `src/test-support/legacy-replay.ts:18-31, 52`:
+
+Replace the block at lines 18-31 (the orphaned + driveFixture comments):
+```ts
+/**
+ * Synthesise an IS-0xa200 image stream of `totalBytes` total bytes from
+ * fixed-fill chunks of `chunkSize` (last chunk may be short).
+ *
+ * Used by replay tests to substitute for the real ~108 MB pixel stream
+ * that we never commit. The fill byte is 0xb0 — a mid-grey RGB triplet
+ * that yields a recognisable JPEG when sharp encodes it (useful for
+ * eyeballing test failures).
+ */
+/**
+ * Drive a fixture replay: connect the fake socket, feed all printer→host events in
+ * order (with a setImmediate yield before each to let the state machine process the
+ * previous reply), then await the session promise.
+ */
+```
+with just the driveFixture comment:
+```ts
+/**
+ * Drive a fixture replay: connect the fake socket, feed all printer→host events in
+ * order (with a setImmediate yield before each to let the state machine process the
+ * previous reply), then await the session promise.
+ */
+```
+
+In `src/test-support/legacy-replay.ts:52`, change:
+```ts
+export function synthesiseImageStream(totalBytes: number, chunkSize: number): Buffer[] {
+```
+to:
+```ts
+/**
+ * Synthesise an IS-0xa200 image stream of `totalBytes` total bytes from
+ * fixed-fill chunks of `chunkSize` (last chunk may be short).
+ *
+ * Used by replay tests to substitute for the real ~108 MB pixel stream
+ * that we never commit. The fill byte is 0xb0 — a mid-grey RGB triplet
+ * that yields a recognisable JPEG when sharp encodes it (useful for
+ * eyeballing test failures).
+ */
+function synthesiseImageStream(totalBytes: number, chunkSize: number): Buffer[] {
+```
+
+- [ ] **Step 2: Verify nothing else imports `synthesiseImageStream`**
+
+Run: `grep -rn "synthesiseImageStream" src/ tools/`
+Expected: only the in-file reference at line 44 (inside `driveFixture`). If any other file imports it, that file's test was duplicating `driveFixture` work; coordinate the change there before proceeding.
+
+- [ ] **Step 3: Run lint + replay tests**
+
+```bash
+npm run lint && npm run format:check && npx vitest run src/scanner-legacy.test.ts
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/test-support/legacy-replay.ts
+git commit -m "refactor(test-support): drop synthesiseImageStream export, fix orphaned doc
+
+Only call site is driveFixture in the same file. The doc comment that
+was sitting above driveFixture actually describes synthesiseImageStream;
+moved it to the right declaration."
+```
+
+### Task B.8: Fix `docs/notes/...` references in tracked source comments
+
+**Files:**
+- Modify: `src/esci.ts:71-72`
+- Modify: `src/scanner.ts:598, 818`
+- Modify: `src/pushscan.ts:23`
+
+`docs/notes/` does not exist in the tracked tree (notes live under gitignored `.reference/notes/`). The references are dead links for any contributor.
+
+- [ ] **Step 1: Replace `esci.ts` references**
+
+In `src/esci.ts:71-72`, change:
+```ts
+ * See docs/notes/2026-04-20-multi-page-duplex-analysis.md (ADF variants)
+ * and docs/notes/2026-04-21-flatbed-protocol-analysis.md (flatbed diff).
+```
+to:
+```ts
+ * See `docs/HOW-IT-WORKS.md` for the protocol layering and per-source
+ * variant rationale.
+```
+
+- [ ] **Step 2: Replace `scanner.ts:598` reference**
+
+In `src/scanner.ts:598`, change:
+```ts
+      // See docs/notes/2026-04-21-flatbed-protocol-analysis.md.
+```
+to:
+```ts
+      // See `docs/HOW-IT-WORKS.md` (ESC/I-2 INIT_POLL section).
+```
+
+- [ ] **Step 3: Replace `scanner.ts:818` reference**
+
+In `src/scanner.ts:818`, change:
+```ts
+      // See docs/notes/2026-04-21-flatbed-protocol-analysis.md.
+```
+to:
+```ts
+      // See `docs/HOW-IT-WORKS.md` (ESC/I-2 IMG loop / page boundary section).
+```
+
+- [ ] **Step 4: Replace `pushscan.ts:23` reference**
+
+In `src/pushscan.ts:22-23`, change:
+```ts
+// even though the scan itself completes. See
+// docs/notes/2026-04-19-panel-error-investigation.md.
+```
+to:
+```ts
+// even though the scan itself completes. See
+// `docs/HOW-IT-WORKS.md` (push-scan trigger section).
+```
+
+- [ ] **Step 5: Verify no other `docs/notes/...` references remain**
+
+Run: `grep -rn "docs/notes" src/ tools/`
+Expected: zero hits.
+
+- [ ] **Step 6: Run full CI mirror**
+
+```bash
+npm run lint && npm run format:check && npm test
+```
+
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/esci.ts src/scanner.ts src/pushscan.ts
+git commit -m "docs: redirect docs/notes/... references to docs/HOW-IT-WORKS.md
+
+The docs/notes/ tree is local-only (gitignored, lives under .reference/);
+public-tree comments shouldn't reference it. Pointing at HOW-IT-WORKS.md
+gives any contributor a working link."
+```
+
+### Task B.9: Open PR2
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feature/v0.3.0-wf3620-autodetect
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --base dev --head feature/v0.3.0-wf3620-autodetect --title "refactor: KISS/DRY/YAGNI sweep 1" --body "$(cat <<'EOF'
+## Summary
+
+Eight independent low-risk cleanups from the kiss-dry-yagni-definitive review's recommended priority order #1, plus the broken docs/notes/... references flagged by the architecture review.
+
+- Drop unused KEEPALIVE_INTERVAL env var
+- Replace pageJpegPaths array with pageCount counter
+- Drop PUSHSCAN_RESPONSE export, rewrite tautology test
+- Tighten output.ts page-promotion filter, drop duplicate regex
+- Simplify paperless-upload.ts Promise.allSettled
+- Consolidate output-tail.ts upload sites
+- Drop synthesiseImageStream export, fix orphaned doc
+- Redirect docs/notes/... source comments to docs/HOW-IT-WORKS.md
+
+No wire-byte changes; replay tests unaffected. ~30 lines net diff.
+
+## Test plan
+
+- [ ] CI green (lint + format:check + test)
+- [ ] Replay tests in `scanner.test.ts` and `scanner-legacy.test.ts` still pass byte-equivalent
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI; merge once green**
+
+Use `gh pr checks <PR_NUM> --watch` or the GitHub UI. Squash-merge.
+
+- [ ] **Step 4: Update local dev**
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feature/v0.3.0-wf3620-autodetect-cert  # fresh branch for PR3
+```
+
+---
+
+## Phase C — Cert-pinning bypass fix (PR3)
+
+One config-level change. TDD: tests first.
+
+### Task C.1: Add `superRefine` rejecting `auto + fingerprint` and tests
+
+**Files:**
+- Modify: `src/config.test.ts` (new tests)
+- Modify: `src/config.ts` (new superRefine clause)
+
+- [ ] **Step 1: Write the failing tests first**
+
+In `src/config.test.ts`, locate the `describe("loadConfig", …)` block. Near the existing test at line 250 (`"rejects PRINTER_CERT_FINGERPRINT with PRINTER_PROTOCOL=legacy"`), add three new tests:
+
+```ts
+  it("rejects PRINTER_CERT_FINGERPRINT with PRINTER_PROTOCOL=auto", () => {
+    process.env.PRINTER_IP = "10.0.0.1";
+    process.env.PRINTER_PROTOCOL = "auto";
+    process.env.PRINTER_CERT_FINGERPRINT =
+      "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89";
+    expect(() => loadConfig()).toThrow(/PRINTER_PROTOCOL=esci2/);
+  });
+
+  it("accepts PRINTER_PROTOCOL=auto without a fingerprint", () => {
+    process.env.PRINTER_IP = "10.0.0.1";
+    process.env.PRINTER_PROTOCOL = "auto";
+    expect(loadConfig().printerProtocol).toBe("auto");
+    expect(loadConfig().printerCertFingerprint).toBeUndefined();
+  });
+
+  it("accepts PRINTER_CERT_FINGERPRINT with PRINTER_PROTOCOL=esci2", () => {
+    process.env.PRINTER_IP = "10.0.0.1";
+    process.env.PRINTER_PROTOCOL = "esci2";
+    process.env.PRINTER_CERT_FINGERPRINT =
+      "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89";
+    const config = loadConfig();
+    expect(config.printerProtocol).toBe("esci2");
+    expect(config.printerCertFingerprint).toBe(
+      "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89",
+    );
+  });
+```
+
+- [ ] **Step 2: Run them — they should fail (the auto+fingerprint test) or pass spuriously**
+
+Run: `npx vitest run src/config.test.ts --reporter=verbose 2>&1 | tail -30`
+Expected: `"rejects PRINTER_CERT_FINGERPRINT with PRINTER_PROTOCOL=auto"` FAILS — `loadConfig()` does not throw because there's no rule yet. The other two pass.
+
+- [ ] **Step 3: Add the superRefine clause**
+
+In `src/config.ts:38-55`, find the existing superRefine. Add a third clause after the existing ones:
+
+```ts
+  .superRefine((cfg, ctx) => {
+    if (cfg.printerProtocol === "legacy" && cfg.printerCertFingerprint) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "PRINTER_CERT_FINGERPRINT is incompatible with PRINTER_PROTOCOL=legacy (the legacy variant uses plain TCP, not TLS).",
+        path: ["printerCertFingerprint"],
+      });
+    }
+    if (cfg.printerProtocol === "esci2" && cfg.legacyForceSource) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "LEGACY_FORCE_SOURCE has no effect with PRINTER_PROTOCOL=esci2; remove one or the other.",
+        path: ["legacyForceSource"],
+      });
+    }
+    if (cfg.printerProtocol === "auto" && cfg.printerCertFingerprint) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "PRINTER_CERT_FINGERPRINT requires PRINTER_PROTOCOL=esci2 explicitly. Under PRINTER_PROTOCOL=auto, a probe failure can downgrade silently to legacy (plain TCP, no TLS), which would bypass the pin.",
+        path: ["printerCertFingerprint"],
+      });
+    }
+  });
+```
+
+- [ ] **Step 4: Re-run the tests**
+
+Run: `npx vitest run src/config.test.ts --reporter=verbose 2>&1 | tail -10`
+Expected: all three new tests PASS. All previously-passing tests still PASS.
+
+- [ ] **Step 5: Run lint + format + full suite**
+
+```bash
+npm run lint && npm run format:check && npm test
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config.ts src/config.test.ts
+git commit -m "fix(config): reject PRINTER_PROTOCOL=auto with PRINTER_CERT_FINGERPRINT
+
+Defense-in-depth: under auto, a LAN attacker who can RST the TLS probe
+forces a silent downgrade to legacy (plain TCP, no TLS) — the pinned
+fingerprint then has no effect. Symmetrical to the existing legacy +
+fingerprint and esci2 + LEGACY_FORCE_SOURCE rejections.
+
+Users who want fingerprint pinning must set PRINTER_PROTOCOL=esci2."
+```
+
+- [ ] **Step 7: Push, open PR, merge**
+
+```bash
+git push -u origin feature/v0.3.0-wf3620-autodetect-cert
+gh pr create --base dev --head feature/v0.3.0-wf3620-autodetect-cert --title "fix(config): reject auto+fingerprint to prevent silent pin bypass" --body "Defense-in-depth — closes the cert-pinning bypass under PRINTER_PROTOCOL=auto when a LAN attacker can RST the TLS probe and force a silent downgrade to plain-TCP legacy. See spec §3.2."
+```
+
+Wait for CI green; squash-merge. Then:
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feature/v0.3.0-wf3620-autodetect-contract
+```
+
+---
+
+## Phase D — Promise-contract reconciliation (PR4)
+
+The biggest semantic change of v0.3.0. Re-read spec §3.3 (the failure-mode classification table). TDD throughout — write each failure-mode test first, watch fail, then migrate the site.
+
+### Task D.1: Add `errorReason + failOnce` machinery to `scanner.ts` and migrate the cert + temp-dir paths
+
+**Files:**
+- Modify: `src/scanner.ts:127-308` (Promise constructor + close handler + failOnce + cert path + temp-dir path)
+- Modify: `src/scanner.test.ts` (add two new failing tests)
+
+- [ ] **Step 1: Write the two failing tests first**
+
+In `src/scanner.test.ts`, near the existing fixture tests, add:
+
+```ts
+  describe("startScanSession failure-mode matrix", () => {
+    it("rejects when the printer cert fingerprint does not match the pin", async () => {
+      const fake = new FakeTlsSocket();
+      fake.setPeerCertificate("AA:BB:CC"); // FakeTlsSocket.setPeerCertificate takes a string
+      const scanPromise = startScanSession(
+        {
+          printerIp: "1.2.3.4",
+          port: 1865,
+          destId: 0x02,
+          outputDir: "/tmp/out-doesnotmatter",
+          tempDir: "/tmp",
+          duplex: false,
+          action: "jpg",
+          paperless: undefined,
+          printerCertFingerprint: "DE:AD:BE:EF",
+        },
+        fake.asFactory(),
+      );
+      fake.simulateConnect();
+      await expect(scanPromise).rejects.toThrow(/fingerprint mismatch/i);
+    });
+
+    it("rejects when the session temp dir cannot be created", async () => {
+      const fake = new FakeTlsSocket();
+      // tempDir points at a path that mkdtempSync cannot resolve.
+      const scanPromise = startScanSession(
+        {
+          printerIp: "1.2.3.4",
+          port: 1865,
+          destId: 0x02,
+          outputDir: "/tmp/out-doesnotmatter",
+          tempDir: "/this/path/definitely/does/not/exist",
+          duplex: false,
+          action: "jpg",
+          paperless: undefined,
+        },
+        fake.asFactory(),
+      );
+      await expect(scanPromise).rejects.toThrow(/temp dir/i);
+    });
+  });
+```
+
+(Adjust the import for `FakeTlsSocket` — likely `import { FakeTlsSocket } from "./test-support/fake-tls-socket.js";`. Check the existing imports in `scanner.test.ts` for the pattern.)
+
+- [ ] **Step 2: Run them, watch fail**
+
+Run: `npx vitest run src/scanner.test.ts -t "failure-mode matrix" --reporter=verbose 2>&1 | tail -30`
+Expected: both tests FAIL — the cert mismatch resolves silently today; the temp-dir failure also resolves silently (currently `resolveOnce()` direct).
+
+- [ ] **Step 3: Migrate the constructor + close handler**
+
+In `src/scanner.ts:131-308`, change the constructor to expose `reject`:
+
+Before (line 131):
+```ts
+  return new Promise<void>((resolve) => {
+```
+After:
+```ts
+  return new Promise<void>((resolve, reject) => {
+    let errorReason: Error | null = null;
+```
+
+Below `resolveOnce` (which sits around line 133-137), add `rejectOnce`:
+```ts
+    const rejectOnce = (err: Error): void => {
+      if (resolved) return;
+      resolved = true;
+      reject(err);
+    };
+    const failOnce = (err: Error): void => {
+      if (errorReason) return; // first-error wins
+      errorReason = err;
+      transitionToError(); // existing helper triggers the close cascade
+    };
+```
+
+In the `socket.on("close", () => { … })` handler at line 304-308, change:
+```ts
+    socket.on("close", () => {
+      clearTimeoutTimer();
+      log.info("TLS connection closed");
+      resolveOnce();
+    });
+```
+to:
+```ts
+    socket.on("close", () => {
+      clearTimeoutTimer();
+      log.info("TLS connection closed");
+      if (errorReason) rejectOnce(errorReason);
+      else resolveOnce();
+    });
+```
+
+- [ ] **Step 4: Migrate the temp-dir-failure path (direct reject)**
+
+In `src/scanner.ts:152-156`, change:
+```ts
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`Failed to create session temp dir under ${tempBase}: ${msg}. Aborting scan.`);
+      resolveOnce();
+      return; // never start the TLS session
+    }
+```
+to:
+```ts
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`Failed to create session temp dir under ${tempBase}: ${msg}. Aborting scan.`);
+      rejectOnce(new Error(`Failed to create session temp dir under ${tempBase}: ${msg}`));
+      return; // never start the TLS session
+    }
+```
+
+- [ ] **Step 5: Migrate the cert-fingerprint mismatch path**
+
+In `src/scanner.ts:212-232` (the cert-fingerprint check inside the TLS connect callback), change the early-return block from:
+```ts
+        if (session.printerCertFingerprint) {
+          const peer = socket.getPeerCertificate();
+          const actual = peer?.fingerprint256;
+          if (actual !== session.printerCertFingerprint) {
+            log.error(
+              `Printer cert fingerprint mismatch — expected ${session.printerCertFingerprint}, ` +
+                `got ${actual ?? "(none)"} — aborting scan`,
+            );
+            state = "ERROR";
+            clearTimeoutTimer();
+            try {
+              fs.rmSync(sessionTempDir, { recursive: true, force: true });
+            } catch {
+              /* ignore — cleanup best-effort */
+            }
+            socket.destroy();
+            // Don't call transitionToError() — it sends an UNLOCK packet, but
+            // we never sent the LOCK (we're aborting at handshake). The
+            // socket's "close" handler resolves the outer promise.
+            return;
+          }
+          log.debug(`Printer cert fingerprint verified: ${actual}`);
+        }
+```
+to:
+```ts
+        if (session.printerCertFingerprint) {
+          const peer = socket.getPeerCertificate();
+          const actual = peer?.fingerprint256;
+          if (actual !== session.printerCertFingerprint) {
+            const msg =
+              `Printer cert fingerprint mismatch — expected ${session.printerCertFingerprint}, ` +
+              `got ${actual ?? "(none)"}`;
+            log.error(`${msg} — aborting scan`);
+            errorReason = new Error(msg);
+            state = "ERROR";
+            clearTimeoutTimer();
+            try {
+              fs.rmSync(sessionTempDir, { recursive: true, force: true });
+            } catch {
+              /* ignore — cleanup best-effort */
+            }
+            socket.destroy();
+            // Close handler reads errorReason and rejects.
+            return;
+          }
+          log.debug(`Printer cert fingerprint verified: ${actual}`);
+        }
+```
+
+- [ ] **Step 6: Re-run the two new tests**
+
+Run: `npx vitest run src/scanner.test.ts -t "failure-mode matrix" --reporter=verbose 2>&1 | tail -20`
+Expected: both PASS.
+
+- [ ] **Step 7: Run the full ESC/I-2 replay suite (existing happy-path tests must stay green)**
+
+Run: `npx vitest run src/scanner.test.ts --reporter=verbose 2>&1 | tail -30`
+Expected: all original 6 fixtures still pass byte-equivalent.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/scanner.ts src/scanner.test.ts
+git commit -m "fix(scanner): reject on cert mismatch and temp-dir failure
+
+Adds errorReason + failOnce + rejectOnce machinery; close handler
+now consults errorReason to decide resolve vs reject. Migrates the
+two direct-resolve paths (cert fingerprint mismatch, temp dir
+creation failure) to populate errorReason / call rejectOnce.
+
+Failure-mode matrix coverage: cert-fingerprint mismatch + temp-dir
+failure. The remaining seven rows (timeout, socket error, async
+cancel, async fatal, ensure() failures, zero-image completion,
+finalize failure) follow in subsequent commits."
+```
+
+### Task D.2: Migrate the `transitionToError` sites (timeout, socket error, async cancel/fatal, ensure failures)
+
+**Files:**
+- Modify: `src/scanner.ts` (timeout, socket error, async events, ensure-failure sites)
+- Modify: `src/scanner.test.ts` (5 new failure-mode tests)
+
+- [ ] **Step 1: Write all five failing tests**
+
+Add inside the `describe("startScanSession failure-mode matrix", …)` block:
+
+```ts
+    it("rejects on timeout (no response in TIMEOUT_MS)", async () => {
+      // Use vi.useFakeTimers() + advance past TIMEOUT_MS without feeding any data.
+      // Adapt the FakeTlsSocket pattern to leave the connection idle after WELCOME.
+      const fake = new FakeTlsSocket();
+      const scanPromise = startScanSession(
+        {
+          printerIp: "1.2.3.4",
+          port: 1865,
+          destId: 0x02,
+          outputDir: "/tmp",
+          tempDir: "/tmp",
+          duplex: false,
+          action: "jpg",
+          paperless: undefined,
+        },
+        fake.asFactory(),
+      );
+      fake.simulateConnect();
+      // No data fed; advance fake timers past TIMEOUT_MS (declared in scanner.ts ~line 65)
+      vi.useFakeTimers();
+      vi.advanceTimersByTime(120_000);
+      vi.useRealTimers();
+      await expect(scanPromise).rejects.toThrow(/timeout/i);
+    });
+
+    it("rejects on socket error mid-session", async () => {
+      const fake = new FakeTlsSocket();
+      const scanPromise = startScanSession(
+        {
+          printerIp: "1.2.3.4",
+          port: 1865,
+          destId: 0x02,
+          outputDir: "/tmp",
+          tempDir: "/tmp",
+          duplex: false,
+          action: "jpg",
+          paperless: undefined,
+        },
+        fake.asFactory(),
+      );
+      fake.simulateConnect();
+      fake.emit("error", Object.assign(new Error("ECONNREFUSED"), { code: "ECONNREFUSED" }));
+      await expect(scanPromise).rejects.toThrow(/ECONNREFUSED/);
+    });
+
+    it("rejects on async ScanCancel event mid-session", async () => {
+      const fake = new FakeTlsSocket();
+      const scanPromise = startScanSession(
+        {
+          printerIp: "1.2.3.4",
+          port: 1865,
+          destId: 0x02,
+          outputDir: "/tmp",
+          tempDir: "/tmp",
+          duplex: false,
+          action: "jpg",
+          paperless: undefined,
+        },
+        fake.asFactory(),
+      );
+      fake.simulateConnect();
+      // Feed a synthesised IS-0x9000 packet with payload [0x03] (ScanCancel).
+      // Use buildIsPacket(0x9000, Buffer.from([0x03])) from src/protocol.ts.
+      const cancelPacket = buildIsPacket(0x9000, Buffer.from([0x03]));
+      fake.feed(cancelPacket);
+      await expect(scanPromise).rejects.toThrow(/ScanCancel/);
+    });
+
+    it("rejects on async fatal event mid-session", async () => {
+      const fake = new FakeTlsSocket();
+      const scanPromise = startScanSession(
+        {
+          printerIp: "1.2.3.4",
+          port: 1865,
+          destId: 0x02,
+          outputDir: "/tmp",
+          tempDir: "/tmp",
+          duplex: false,
+          action: "jpg",
+          paperless: undefined,
+        },
+        fake.asFactory(),
+      );
+      fake.simulateConnect();
+      // ASYNC_FATAL set in scanner.ts contains specific dispatch bytes — pick one.
+      // Confirm by reading src/scanner.ts:121-124 for the actual constants.
+      const fatalPacket = buildIsPacket(0x9000, Buffer.from([0x05]));
+      fake.feed(fatalPacket);
+      await expect(scanPromise).rejects.toThrow(/fatal/i);
+    });
+
+    it("rejects on per-state assertion failure (unexpected packet type)", async () => {
+      const fake = new FakeTlsSocket();
+      const scanPromise = startScanSession(
+        {
+          printerIp: "1.2.3.4",
+          port: 1865,
+          destId: 0x02,
+          outputDir: "/tmp",
+          tempDir: "/tmp",
+          duplex: false,
+          action: "jpg",
+          paperless: undefined,
+        },
+        fake.asFactory(),
+      );
+      fake.simulateConnect();
+      // Feed a packet whose type doesn't match the WELCOME state's expectation.
+      // Confirm by reading src/scanner.ts:onWelcome — it expects type 0xa000.
+      // Feed type 0xa999 instead to force ensure(... === 0xa000, ...) to fail.
+      const wrongTypePacket = buildIsPacket(0xa999, Buffer.alloc(0));
+      fake.feed(wrongTypePacket);
+      await expect(scanPromise).rejects.toThrow(/protocol error/i);
+    });
+```
+
+- [ ] **Step 2: Run them, all should fail**
+
+Run: `npx vitest run src/scanner.test.ts -t "failure-mode matrix" --reporter=verbose 2>&1 | tail -40`
+Expected: 5 of these new tests FAIL (resolve silently or never settle); the 2 from D.1 still PASS.
+
+- [ ] **Step 3: Migrate the timeout site**
+
+In `src/scanner.ts:185-190` (resetTimeout), change:
+```ts
+    const resetTimeout = () => {
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      timeoutTimer = setTimeout(() => {
+        log.error(`Timeout in state ${state} — no response in ${TIMEOUT_MS}ms`);
+        transitionToError();
+      }, TIMEOUT_MS);
+    };
+```
+to:
+```ts
+    const resetTimeout = () => {
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      timeoutTimer = setTimeout(() => {
+        const msg = `Timeout in state ${state} — no response in ${TIMEOUT_MS}ms`;
+        log.error(msg);
+        failOnce(new Error(msg));
+      }, TIMEOUT_MS);
+    };
+```
+
+- [ ] **Step 4: Migrate the socket-error site**
+
+In `src/scanner.ts:285-302` (the `socket.on("error", …)` handler), change:
+```ts
+    socket.on("error", (err: NodeJS.ErrnoException) => {
+      if (state === "DONE" && err.code === "ECONNRESET") {
+        log.debug("Benign post-unlock ECONNRESET (scan already saved)");
+        clearTimeoutTimer();
+        return;
+      }
+      if (state === "ERROR") {
+        log.debug(`Post-destroy error ignored: ${err.message}`);
+        return;
+      }
+      log.error(`TLS connection error in state ${state}`, err);
+      clearTimeoutTimer();
+      if (state !== "DONE") {
+        transitionToError();
+      }
+    });
+```
+to:
+```ts
+    socket.on("error", (err: NodeJS.ErrnoException) => {
+      if (state === "DONE" && err.code === "ECONNRESET") {
+        log.debug("Benign post-unlock ECONNRESET (scan already saved)");
+        clearTimeoutTimer();
+        return;
+      }
+      if (state === "ERROR") {
+        log.debug(`Post-destroy error ignored: ${err.message}`);
+        return;
+      }
+      log.error(`TLS connection error in state ${state}`, err);
+      clearTimeoutTimer();
+      if (state !== "DONE") {
+        failOnce(new Error(`TLS connection error in state ${state}: ${err.message}`));
+      }
+    });
+```
+
+- [ ] **Step 5: Migrate the async-cancel and async-fatal sites**
+
+In `src/scanner.ts:359-364` (handleAsyncEvent), change:
+```ts
+      } else if (ASYNC_CANCEL.has(dispatch)) {
+        log.warn(`Async event: ScanCancel (0x${dispatch.toString(16)}) — aborting`);
+        transitionToError();
+      } else if (ASYNC_FATAL.has(dispatch)) {
+        log.error(`Async event: fatal (0x${dispatch.toString(16)}) — aborting`);
+        transitionToError();
+```
+to:
+```ts
+      } else if (ASYNC_CANCEL.has(dispatch)) {
+        log.warn(`Async event: ScanCancel (0x${dispatch.toString(16)}) — aborting`);
+        failOnce(new Error(`Async ScanCancel (0x${dispatch.toString(16)}) during state ${state}`));
+      } else if (ASYNC_FATAL.has(dispatch)) {
+        log.error(`Async event: fatal (0x${dispatch.toString(16)}) — aborting`);
+        failOnce(new Error(`Async fatal event 0x${dispatch.toString(16)} during state ${state}`));
+```
+
+- [ ] **Step 6: Migrate the `ensure(...)` failure site**
+
+In `src/scanner.ts:442-448` (the `ensure` helper) — confirm the current shape with a Read first. The helper likely calls `transitionToError()` on `false`. Change it to call `failOnce(new Error(message))` instead, *then* return `false`:
+
+Before (approximate; verify by Read):
+```ts
+    function ensure(condition: boolean, message: string): boolean {
+      if (!condition) {
+        log.error(message);
+        transitionToError();
+        return false;
+      }
+      return true;
+    }
+```
+After:
+```ts
+    function ensure(condition: boolean, message: string): boolean {
+      if (!condition) {
+        log.error(message);
+        failOnce(new Error(`Protocol error in state ${state}: ${message}`));
+        return false;
+      }
+      return true;
+    }
+```
+
+- [ ] **Step 7: Run all the failure-mode tests**
+
+Run: `npx vitest run src/scanner.test.ts -t "failure-mode matrix" --reporter=verbose 2>&1 | tail -30`
+Expected: all 7 tests (2 from D.1 + 5 from D.2) PASS.
+
+- [ ] **Step 8: Run all replay tests**
+
+Run: `npx vitest run src/scanner.test.ts --reporter=verbose 2>&1 | tail -20`
+Expected: original 6 fixture replays still PASS byte-equivalent.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/scanner.ts src/scanner.test.ts
+git commit -m "fix(scanner): reject on timeout, socket error, async cancel/fatal, ensure failures
+
+Migrates five sites that previously called transitionToError() into
+failOnce() so the close-handler cascade rejects with a classified
+error message. Adds five failure-mode tests."
+```
+
+### Task D.3: Migrate completion-path failures (zero-image, finalize), pin post-scan-save fallback unchanged
+
+**Files:**
+- Modify: `src/scanner.ts:978-999` (zero-image + finalize tail)
+- Modify: `src/scanner.test.ts` (3 new tests)
+
+- [ ] **Step 1: Coverage note — these three sites ship without dedicated unit tests**
+
+Three failure-mode rows are migrated by code change without a dedicated TDD unit test in v0.3.0:
+
+- **Zero-image completion** (`scanner.ts:978-981`). Reaching this site requires a synthesised wire trace that ends in UNLOCK without any IS-0xa000 IMG_DATA — non-trivial fixture surgery for a single state.
+- **`finalizeSession` failure** (`scanner.ts:992`). Reaching this requires mocking `finalizeSession` to throw, which means restructuring the import for vi.mock-ability.
+- **Post-scan-save fallback resolves** (`scanner.ts:258-262`). Triggering this requires injecting a NAK/error response during POSTSCAN_* while keeping imageChunks non-empty — the most fixture-fragile of the three.
+
+These are accepted as a v0.3.0 coverage gap, mitigated by:
+
+1. The migration code at each site is small (3-5 lines per site) and visually reviewable against the failure-mode matrix in the spec.
+2. The post-scan-save resolve property is enforced by an explicit `errorReason = null` line (Step 4 below) — easy to spot in code review.
+3. v0.4.0's #27 patch-sampling oracle + the shared scan-session engine make injection cleaner; these tests can be added then with less fixture pain.
+4. Symmetric coverage exists in `scanner-legacy.test.ts` (Task D.4) for analogous paths in the legacy implementation.
+
+**Add no TODO test bodies.** Move directly to the migration steps.
+
+- [ ] **Step 2: Migrate the zero-image-completion site**
+
+In `src/scanner.ts:978-981`, change:
+```ts
+      socket.end();
+      if (imageChunks.length === 0) {
+        log.error("Scan completed with zero image chunks");
+        return;
+      }
+```
+to:
+```ts
+      socket.end();
+      if (imageChunks.length === 0) {
+        log.error("Scan completed with zero image chunks");
+        errorReason = new Error("Scan completed with zero image chunks");
+        // Close handler will reject.
+        return;
+      }
+```
+
+- [ ] **Step 3: Migrate the finalizeSession-failure site**
+
+In `src/scanner.ts:990-998`, change the `.catch()` body to populate `errorReason`:
+
+Before:
+```ts
+        finalizeSession({...})
+          .catch((err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            log.error(`Unexpected finalizeScan failure: ${msg}`);
+          })
+          .finally(() => {
+            resolveOnce();
+          });
+```
+After:
+```ts
+        finalizeSession({...})
+          .catch((err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            log.error(`Unexpected finalizeScan failure: ${msg}`);
+            rejectOnce(new Error(`finalizeScan failure: ${msg}`));
+          })
+          .finally(() => {
+            // resolveOnce is no-op if rejectOnce already ran; if finalize succeeded,
+            // we resolve here.
+            resolveOnce();
+          });
+```
+
+(`rejectOnce` and `resolveOnce` both guard via `resolved` — first wins.)
+
+- [ ] **Step 4: Verify post-scan-save fallback path is untouched**
+
+In `src/scanner.ts:249-274` (transitionToError), confirm the `inPostScan && imageChunks.length > 0` branch still calls `finalizeScan()` *without* setting `errorReason`. If `errorReason` is null at that point, the close handler resolves — which is the desired "images survived a glitch" success behaviour.
+
+If you find that earlier sites (e.g., the per-state `ensure(...)`) populated `errorReason` *before* reaching this branch, the resolve-anyway requirement will be violated. Mitigate: in the `inPostScan && imageChunks.length > 0` branch, *clear* `errorReason` before calling `finalizeScan()`:
+
+In `src/scanner.ts:258-262`, change:
+```ts
+      if (inPostScan && imageChunks.length > 0) {
+        log.warn(`Error during post-scan cleanup in ${priorState} — saving captured image anyway`);
+        finalizeScan();
+        return;
+      }
+```
+to:
+```ts
+      if (inPostScan && imageChunks.length > 0) {
+        log.warn(`Error during post-scan cleanup in ${priorState} — saving captured image anyway`);
+        // Cleanup-state error after the IMG loop succeeded is treated as success;
+        // clear any error captured during cleanup so the close handler resolves.
+        errorReason = null;
+        finalizeScan();
+        return;
+      }
+```
+
+- [ ] **Step 5: Run replay tests**
+
+Run: `npx vitest run src/scanner.test.ts --reporter=verbose 2>&1 | tail -20`
+Expected: all original 6 fixture replays still PASS byte-equivalent (the change only affects error paths the fixtures don't exercise).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/scanner.ts src/scanner.test.ts
+git commit -m "fix(scanner): reject on zero-image completion and finalize failure
+
+Migrates the two completion-path silent-resolve sites to populate
+errorReason / call rejectOnce. Pins the post-scan-save fallback
+(images captured before a cleanup-state glitch) as still-resolves
+by clearing errorReason in transitionToError when entering the
+images-present recovery branch.
+
+Coverage note: these three rows ship without dedicated unit tests —
+mid-fixture surgery and finalizeSession mocking are non-trivial
+without v0.4.0's shared engine extraction. Migration is small
+enough to review visually against the failure-mode matrix; symmetric
+legacy coverage in scanner-legacy.test.ts (D.4) catches analogous
+paths."
+```
+
+### Task D.4: Symmetric `errorReason + failOnce` shape in `scanner-legacy.ts` + matrix tests
+
+**Files:**
+- Modify: `src/scanner-legacy.ts:130-201` (the existing `fail()` already rejects; align its shape with scanner.ts)
+- Modify: `src/scanner-legacy.test.ts` (add failure-mode tests where fixtures permit)
+
+- [ ] **Step 1: Read `scanner-legacy.ts:183-201` to understand existing shape**
+
+The legacy path already rejects via `fail()`. The work here is alignment — give it the same `failOnce(err: Error)` *and* `errorReason` variable so v0.4.0's engine extraction lifts a single shape.
+
+In `src/scanner-legacy.ts:140-201`, refactor:
+
+Before:
+```ts
+    let resolved = false;
+    ...
+    function resolveOnce(): void { ... }
+    function fail(reason: string): void {
+      if (state === "ERROR") return;
+      state = "ERROR";
+      log.error(`State machine error: ${reason}`);
+      ...
+      if (resolved) return;
+      resolved = true;
+      reject(new Error(reason));
+    }
+```
+After (preserve all the existing cleanup code; just add `errorReason` + introduce `failOnce` while keeping `fail` as a thin wrapper for the existing call sites):
+```ts
+    let resolved = false;
+    let errorReason: Error | null = null;
+    ...
+    function resolveOnce(): void { ... }
+    function failOnce(err: Error): void {
+      if (errorReason) return;
+      errorReason = err;
+      if (state === "ERROR") return;
+      state = "ERROR";
+      log.error(`State machine error: ${err.message}`);
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      try {
+        socket.destroy();
+      } catch {
+        /* swallow */
+      }
+      try {
+        fs.rmSync(sessionTempDir, { recursive: true, force: true });
+      } catch {
+        /* swallow */
+      }
+      if (resolved) return;
+      resolved = true;
+      reject(err);
+    }
+    function fail(reason: string): void {
+      failOnce(new Error(reason));
+    }
+```
+
+- [ ] **Step 2: Add a failure-mode-matrix describe block in `scanner-legacy.test.ts`**
+
+Below the existing describe block, add:
+
+```ts
+  describe("startScanSessionLegacy failure-mode matrix", () => {
+    it("rejects on socket error mid-session", async () => {
+      const fake = new FakeTcpSocket();
+      const scanPromise = startScanSessionLegacy(
+        {
+          printerIp: "1.2.3.4",
+          port: 1865,
+          outputDir,
+          tempDir,
+          source: "adf-simplex",
+          format: "jpg",
+          jpegQuality: 90,
+        },
+        fake.asFactory(),
+      );
+      fake.simulateConnect();
+      fake.emit("error", new Error("ECONNREFUSED"));
+      await expect(scanPromise).rejects.toThrow(/socket error|ECONNREFUSED/i);
+    });
+
+    it("rejects on protocol violation (unexpected packet shape)", async () => {
+      const fake = new FakeTcpSocket();
+      const scanPromise = startScanSessionLegacy(
+        {
+          printerIp: "1.2.3.4",
+          port: 1865,
+          outputDir,
+          tempDir,
+          source: "adf-simplex",
+          format: "jpg",
+          jpegQuality: 90,
+        },
+        fake.asFactory(),
+      );
+      fake.simulateConnect();
+      // Feed a malformed packet that ends up in STATUS_2 with the wrong length.
+      // Easier: feed a single byte the welcome handler doesn't expect.
+      // Walk through the existing fixture's first few events to reach a stable state,
+      // then inject garbage. (Implementation detail; depends on driveFixture extension.)
+      // For now, send raw garbage at the welcome stage:
+      fake.feed(Buffer.from("00".repeat(20), "hex"));
+      await expect(scanPromise).rejects.toThrow();
+    });
+  });
+```
+
+- [ ] **Step 3: Run the new tests**
+
+Run: `npx vitest run src/scanner-legacy.test.ts -t "failure-mode matrix" --reporter=verbose 2>&1 | tail -20`
+Expected: both PASS (the existing `fail()` path already rejects; the new tests just lock in that behaviour against specific failure modes).
+
+- [ ] **Step 4: Run all replay tests**
+
+Run: `npm test`
+Expected: all 271+ original tests + the new ones PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/scanner-legacy.ts src/scanner-legacy.test.ts
+git commit -m "refactor(scanner-legacy): align error shape with scanner.ts; add matrix tests
+
+Introduces errorReason + failOnce parallel to scanner.ts. Existing
+fail(reason: string) is now a thin string-message wrapper. v0.4.0's
+shared engine extraction can lift one shape from both files.
+
+Adds two failure-mode tests (socket error, protocol violation)."
+```
+
+### Task D.5: Open PR4
+
+- [ ] **Step 1: Push and open the PR**
+
+```bash
+git push -u origin feature/v0.3.0-wf3620-autodetect-contract
+gh pr create --base dev --head feature/v0.3.0-wf3620-autodetect-contract --title "fix(scanner): reconcile promise-contract; reject on hard errors" --body "$(cat <<'EOF'
+## Summary
+
+Resolves the exit-code asymmetry flagged in the architecture review (HIGH): scanner.ts (ESC/I-2) was resolve-only on hard errors, scanner-legacy.ts (ESC/I) rejects via fail(). After this PR, both reject — covered by the failure-mode matrix from spec §3.3.
+
+- scanner.ts: errorReason + failOnce; close handler routes captured reason into rejectOnce
+- Migrated all nine hard-error sites (cert mismatch, temp-dir failure, timeout, socket error, async cancel, async fatal, per-state assertion failures, zero-image completion, finalize failure)
+- Post-scan-save fallback explicitly preserved as resolve (images captured before cleanup glitch is success)
+- scanner-legacy.ts: aligned shape (errorReason + failOnce) for v0.4.0 engine lift
+- New failure-mode matrix tests in both replay test files
+
+Existing replay coverage in scanner.test.ts (6 fixtures) and scanner-legacy.test.ts (10 fixtures) stays byte-equivalent.
+
+## Test plan
+
+- [ ] All replay tests green
+- [ ] New failure-mode tests green
+- [ ] lifecycle.test.ts (existing inflight rejection-tolerance) still green
+- [ ] one-shot CLI now exits non-zero on cert-fingerprint mismatch (manual verify if a real or fixture-based test is added)
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for CI green, merge, recreate branch**
+
+```bash
+# Watch CI
+gh pr checks --watch
+# After merge:
+git checkout dev
+git pull origin dev
+git checkout -b feature/v0.3.0-wf3620-autodetect-fsf
+```
+
+---
+
+## Phase E — Issue #28: FS F autodetection (PR5)
+
+The largest single PR of v0.3.0. Per the spec, this is one combined PR with internal commit phases. **Do NOT** open it as four separate PRs — intermediate states won't compile.
+
+### Task E.1: Add `legacyDetectSource` Result-type helper + unit tests
+
+**Files:**
+- Modify: `src/esci-legacy.ts` (new export)
+- Create: `src/esci-legacy.test.ts` (new file with the unit tests)
+
+- [ ] **Step 1: Write the failing tests first**
+
+Create `src/esci-legacy.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { legacyDetectSource } from "./esci-legacy.js";
+
+describe("legacyDetectSource", () => {
+  it("0x81 + simplex → flatbed", () => {
+    expect(legacyDetectSource(0x81, false)).toEqual({ ok: true, source: "flatbed" });
+  });
+
+  it("0x81 + duplex → flatbed (panel-says-duplex on glass is impossible; flatbed wins)", () => {
+    expect(legacyDetectSource(0x81, true)).toEqual({ ok: true, source: "flatbed" });
+  });
+
+  it("0x01 + simplex → adf-simplex", () => {
+    expect(legacyDetectSource(0x01, false)).toEqual({ ok: true, source: "adf-simplex" });
+  });
+
+  it("0x01 + duplex → adf-duplex", () => {
+    expect(legacyDetectSource(0x01, true)).toEqual({ ok: true, source: "adf-duplex" });
+  });
+
+  it("0x00 + simplex → { ok: false, byte: 0x00 }", () => {
+    expect(legacyDetectSource(0x00, false)).toEqual({ ok: false, byte: 0x00 });
+  });
+
+  it("0xFF + duplex → { ok: false, byte: 0xFF }", () => {
+    expect(legacyDetectSource(0xff, true)).toEqual({ ok: false, byte: 0xff });
+  });
+});
+```
+
+- [ ] **Step 2: Run, watch fail**
+
+Run: `npx vitest run src/esci-legacy.test.ts --reporter=verbose 2>&1 | tail -20`
+Expected: all 6 tests FAIL — `legacyDetectSource` is not exported.
+
+- [ ] **Step 3: Implement the helper in `src/esci-legacy.ts`**
+
+At the bottom of `src/esci-legacy.ts`, add:
+
+```ts
+export type DetectSourceResult =
+  | { ok: true; source: Source }
+  | { ok: false; byte: number };
+
+/**
+ * Map the legacy FS F status byte (byte 0 of the 16-byte STATUS_2 reply)
+ * to a scan source. The Windows driver's Wireshark captures show two known
+ * values:
+ *   - 0x81 → flatbed (no ADF paper / no ADF present)
+ *   - 0x01 → ADF has paper; duplex flag from the panel disambiguates
+ *            simplex vs duplex
+ * Other values (jam, mid-feed, panel-vs-paper conflict, empty-tray for
+ * ADF-equipped models with paperless trays) are not yet captured. Return
+ * { ok: false, byte } so the caller can route through fail() with a
+ * compatibility-issue message.
+ */
+export function legacyDetectSource(fsfByte: number, duplex: boolean): DetectSourceResult {
+  if (fsfByte === 0x81) return { ok: true, source: "flatbed" };
+  if (fsfByte === 0x01) return { ok: true, source: duplex ? "adf-duplex" : "adf-simplex" };
+  return { ok: false, byte: fsfByte };
+}
+```
+
+- [ ] **Step 4: Re-run the tests**
+
+Run: `npx vitest run src/esci-legacy.test.ts --reporter=verbose 2>&1 | tail -20`
+Expected: all 6 PASS.
+
+- [ ] **Step 5: Run lint + format + the full suite**
+
+```bash
+npm run lint && npm run format:check && npm test
+```
+
+Expected: all green; +6 new tests.
+
+- [ ] **Step 6: Commit (no merge yet — this is commit 1 of 5 on the same PR branch)**
+
+```bash
+git add src/esci-legacy.ts src/esci-legacy.test.ts
+git commit -m "feat(esci-legacy): add legacyDetectSource Result-type helper
+
+Maps the FS F status byte to a Source, or returns { ok: false } for
+unknown bytes. Pure helper; STATUS_2 will route { ok: false } through
+fail() for end-to-end rejection."
+```
+
+### Task E.2: API change — `startScanSessionLegacy(duplex)` and dispatch plumbing
+
+**Files:**
+- Modify: `src/scanner-legacy.ts:53-62` (`LegacyScanSession` interface)
+- Modify: `src/scanner-legacy.ts:130-138` (constructor + temp-dir + fields)
+- Modify: `src/startup.ts:115-133` (`dispatchScanSession` legacy branch)
+- Modify: `src/scanner-legacy.test.ts:33-44` and similar fixture-test sites (call-site arg shape) — leaving green as a transitional step
+
+- [ ] **Step 1: Update `LegacyScanSession`**
+
+In `src/scanner-legacy.ts:53-62`, change:
+```ts
+export interface LegacyScanSession {
+  printerIp: string;
+  port: number;
+  outputDir: string;
+  tempDir: string;
+  source: Source;
+  format: Format;
+  jpegQuality: number;
+  paperless?: PaperlessUploadOptions;
+}
+```
+to:
+```ts
+export interface LegacyScanSession {
+  printerIp: string;
+  port: number;
+  outputDir: string;
+  tempDir: string;
+  /** Panel-side Sides selection (true → 2-Sided). Source is detected from FS F. */
+  duplex: boolean;
+  /** Override for FS F autodetection — set via LEGACY_FORCE_SOURCE env var. */
+  forcedSource: Source | null;
+  format: Format;
+  jpegQuality: number;
+  paperless?: PaperlessUploadOptions;
+}
+```
+
+- [ ] **Step 2: Update `dispatchScanSession`'s legacy branch**
+
+In `src/startup.ts:115-133`, change:
+```ts
+  // Legacy. PushScan carries duplex+action but no explicit flatbed-vs-ADF byte.
+  // v1 mapping: duplex → adf-duplex, otherwise adf-simplex; LEGACY_FORCE_SOURCE
+  // overrides for users who need flatbed scanning from the panel.
+  let source: Source;
+  if (args.config.legacyForceSource) {
+    source = args.config.legacyForceSource;
+  } else {
+    source = args.duplex ? "adf-duplex" : "adf-simplex";
+  }
+  return startScanSessionLegacy({
+    printerIp: args.config.printerIp,
+    port: 1865,
+    outputDir: args.config.outputDir,
+    tempDir: args.config.tempDir,
+    source,
+    format: args.action,
+    jpegQuality: args.config.jpegQuality,
+    paperless: args.paperless,
+  });
+```
+to:
+```ts
+  // Legacy. Source is autodetected from the FS F status byte (see scanner-legacy.ts
+  // STATUS_2). LEGACY_FORCE_SOURCE overrides the autodetection for users hitting
+  // edge cases the autodetect doesn't cover (yet).
+  return startScanSessionLegacy({
+    printerIp: args.config.printerIp,
+    port: 1865,
+    outputDir: args.config.outputDir,
+    tempDir: args.config.tempDir,
+    duplex: args.duplex,
+    forcedSource: args.config.legacyForceSource ?? null,
+    format: args.action,
+    jpegQuality: args.config.jpegQuality,
+    paperless: args.paperless,
+  });
+```
+
+(May also need to drop the `Source` import from `startup.ts` if it's now unused — TypeScript will tell you.)
+
+- [ ] **Step 3: Update test files calling `startScanSessionLegacy`**
+
+Run: `grep -n "startScanSessionLegacy" src/`
+Expected: hits in `scanner-legacy.test.ts` (multiple test bodies). Each existing call passes `source: "..."` — change to `duplex: …, forcedSource: "..."` for the override-equivalent behaviour:
+
+For each test currently passing `source: "adf-simplex"`, change to `duplex: false, forcedSource: "adf-simplex"`.
+For each test passing `source: "adf-duplex"`, change to `duplex: true, forcedSource: "adf-duplex"`.
+For each test passing `source: "flatbed"`, change to `duplex: false, forcedSource: "flatbed"`.
+
+This keeps the tests green during the transition — they're now exercising the *forced-source* path, which still bypasses the FS F detection. The detection logic itself is wired in E.3.
+
+- [ ] **Step 4: Compile-check**
+
+Run: `npm run lint`
+Expected: zero errors. If you see "Property 'source' is missing", you missed a call site — fix.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+npm test
+```
+Expected: all green; the replay tests still pass byte-equivalent because `forcedSource` short-circuits STATUS_2 to the same source the test was configuring before.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/scanner-legacy.ts src/startup.ts src/scanner-legacy.test.ts
+git commit -m "refactor(scanner-legacy): take duplex+forcedSource instead of source
+
+API change in preparation for FS F autodetection. dispatchScanSession
+no longer maps PushScan duplex to a hardcoded source; that mapping
+becomes a wire-bytes detection result. forcedSource is the explicit
+override path for LEGACY_FORCE_SOURCE.
+
+All scanner-legacy.test.ts call sites switched to the override shape
+to keep replay tests green during the transition; the detection
+logic lands in the next commit."
+```
+
+### Task E.3: Wire detection rule into `STATUS_2` + downstream rewrite
+
+**Files:**
+- Modify: `src/scanner-legacy.ts:330-362` (STATUS_2)
+- Modify: `src/scanner-legacy.ts:130-200` (session-scope fields, add `detectedSource`)
+- Modify: `src/scanner-legacy.ts` (every `session.source` read after STATUS_2) — `:401, 422, 460, 520, 538, 598, 625, 628, 687, 699` and possibly more
+
+- [ ] **Step 1: Add `detectedSource` to session scope**
+
+In `src/scanner-legacy.ts` near line 145-150, add:
+```ts
+    // Set in STATUS_2 from the FS F byte (or short-circuited by session.forcedSource).
+    // Replaces session.source for all downstream reads.
+    let detectedSource: Source = session.forcedSource ?? "adf-simplex"; // safe default; overwritten in STATUS_2
+```
+
+- [ ] **Step 2: Wire the detection helper into STATUS_2**
+
+In `src/scanner-legacy.ts:330-362`, replace the entire STATUS_2 case body with:
+```ts
+        case "STATUS_2": {
+          // Status after source-set probe.
+          // FS F byte 0 carries the source signal:
+          //   0x81 → flatbed (no ADF paper / no ADF present)
+          //   0x01 → ADF has paper; duplex flag disambiguates simplex/duplex
+          //   other → unknown (jam, mid-feed, panel-conflict). Reject loudly.
+          // session.forcedSource (LEGACY_FORCE_SOURCE) short-circuits the detection.
+          if (pkt.payload.length !== 16) {
+            return fail(`expected 16-byte status in STATUS_2, got ${pkt.payload.length}`);
+          }
+          const statusByte = pkt.payload[0];
+          if (session.forcedSource) {
+            log.info(
+              `STATUS_2: LEGACY_FORCE_SOURCE override: ${session.forcedSource} ` +
+                `(FS F byte 0x${statusByte.toString(16)} ignored)`,
+            );
+            detectedSource = session.forcedSource;
+          } else {
+            const result = legacyDetectSource(statusByte, session.duplex);
+            if (!result.ok) {
+              return fail(
+                `Unrecognised FS F status 0x${result.byte.toString(16).padStart(2, "0")} ` +
+                  `— please file a compatibility issue with LOG_LEVEL=debug output ` +
+                  `(see CONTRIBUTING.md). Workaround: set LEGACY_FORCE_SOURCE.`,
+              );
+            }
+            detectedSource = result.source;
+            log.info(`STATUS_2: source detected from FS F byte 0x${statusByte.toString(16)} → ${detectedSource}`);
+          }
+          // Original branching, now in terms of detectedSource:
+          if (statusByte === 0x81) {
+            // Scanner signalled busy — initiate reset cycle
+            log.debug("STATUS_2: scanner busy (0x81), starting reset cycle");
+            state = "RESET_PAREN";
+            sendCmd(buildEscParen(), 1);
+          } else if (detectedSource !== "flatbed") {
+            // ADF source: re-probe with ESC e before entering the reset cycle.
+            log.debug(
+              `STATUS_2: ADF status 0x${statusByte.toString(16)}, starting ADF pre-reset probe`,
+            );
+            state = "ADF_PRESRC_CMD";
+            sendCmd(buildEscE(), 1);
+            sendCmd(Buffer.from([PROBE_SOURCE_BYTE]), 1);
+          } else {
+            // Flatbed scanner ready — proceed to gamma phase
+            log.debug(
+              `STATUS_2: scanner ready (0x${statusByte.toString(16)}), entering gamma phase`,
+            );
+            enterGammaPhase();
+          }
+          return;
+        }
+```
+
+Add the `legacyDetectSource` import to the top of the file:
+```ts
+import {
+  ...
+  legacyDetectSource,
+  ...
+} from "./esci-legacy.js";
+```
+
+- [ ] **Step 3: Replace every `session.source` read with `detectedSource`**
+
+Run: `grep -n "session\.source" src/scanner-legacy.ts`
+
+For each hit, replace `session.source` with `detectedSource`. Sites (approximate; verify with grep):
+- `~398-401` (`RESET_INIT` → `sendCmd(Buffer.from([SOURCE_BYTE[session.source]]), 1)`)
+- `~422` (`STATUS_READY` → `if (session.source !== "flatbed")`)
+- `~447, 450` (`ADF_IDENTITY_B`)
+- `~487` (gamma)
+- `~495` (`buildFsWBlock({ source: session.source, … })`)
+- `~527` (`computeExpectedBytes(session.source, …)`)
+- `~598-599` (`PAGE_EJECT_WAIT` duplex check)
+- `~625-628` (`CLEANUP_1`)
+- `~687, 699` (`onPageComplete`)
+
+Each `session.source` becomes `detectedSource`. Example for line 401:
+```ts
+          sendCmd(Buffer.from([SOURCE_BYTE[session.source]]), 1);
+```
+becomes:
+```ts
+          sendCmd(Buffer.from([SOURCE_BYTE[detectedSource]]), 1);
+```
+
+Final check after editing:
+Run: `grep -n "session\.source" src/scanner-legacy.ts`
+Expected: zero hits.
+
+- [ ] **Step 4: Drop `source` from `LegacyScanSession` if any straggler reads remain**
+
+The interface no longer has `source` (E.2 removed it), so any straggler reads will be type errors. Confirm with `npm run lint`.
+
+- [ ] **Step 5: Run all replay tests**
+
+```bash
+npm test
+```
+Expected: all replay tests still pass byte-equivalent. The detection logic now picks `detectedSource` from the wire bytes; the test fixtures' wire bytes drive that to the same value the test was previously forcing.
+
+If any fixture fails: re-read the fixture's STATUS_2 reply (search for the FS F status byte in the raw events) and verify `legacyDetectSource(byte, duplex)` produces the source the test was configuring. The fixture's bytes are the ground truth.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/scanner-legacy.ts
+git commit -m "feat(scanner-legacy): autodetect source from FS F status byte
+
+STATUS_2 now reads the FS F byte and routes through legacyDetectSource;
+unknown bytes hard-fail with a CONTRIBUTING.md pointer + LEGACY_FORCE_SOURCE
+workaround note. Every downstream session.source read switches to a
+locally-derived detectedSource.
+
+Replay tests pass byte-equivalent — the wire bytes in each fixture map
+to the same source the tests were previously hard-coding. Fixes #28."
+```
+
+### Task E.4: Replay-test rework — per-fixture metadata
+
+**Files:**
+- Modify: `src/scanner-legacy.test.ts` (add per-fixture metadata + restructure tests)
+
+- [ ] **Step 1: Define the fixture metadata array near the top of the test file**
+
+Below the existing `FIXTURES` constant, add:
+
+```ts
+interface FixtureSpec {
+  path: string;
+  format: "jpg" | "pdf";
+  duplex: boolean;
+  expectedDetectedSource: "adf-simplex" | "adf-duplex" | "flatbed";
+  expectedFileCount: number;
+  expectedBackPages: number[];
+}
+
+const FIXTURE_SPECS: FixtureSpec[] = [
+  {
+    path: "adf-single-page-jpeg.jsonl",
+    format: "jpg",
+    duplex: false,
+    expectedDetectedSource: "adf-simplex",
+    expectedFileCount: 1,
+    expectedBackPages: [],
+  },
+  {
+    path: "adf-single-page-pdf.jsonl",
+    format: "pdf",
+    duplex: false,
+    expectedDetectedSource: "adf-simplex",
+    expectedFileCount: 1,
+    expectedBackPages: [],
+  },
+  // ... add one entry per existing fixture file in tools/pcap-extract/captures/wf-3620/
+];
+```
+
+(List every fixture file in the tracked captures directory. Run `ls tools/pcap-extract/captures/wf-3620/` to enumerate. Each gets one entry; populate the expected fields by reading the existing tests' assertions.)
+
+- [ ] **Step 2: Replace the bespoke per-fixture tests with `it.each(FIXTURE_SPECS)`**
+
+The exact shape will depend on the existing tests' assertions. Skeleton:
+
+```ts
+  it.each(FIXTURE_SPECS)(
+    "$path: detects $expectedDetectedSource and produces $expectedFileCount file(s)",
+    async ({ path: fixturePath, format, duplex, expectedDetectedSource, expectedFileCount, expectedBackPages }) => {
+      const fixture = loadFixture(path.join(FIXTURES, fixturePath));
+      const fake = new FakeTcpSocket();
+
+      const sessionPromise = startScanSessionLegacy(
+        {
+          printerIp: "1.2.3.4",
+          port: 1865,
+          outputDir,
+          tempDir,
+          duplex,
+          forcedSource: null, // pure detection — no override
+          format,
+          jpegQuality: 90,
+        },
+        fake.asFactory(),
+      );
+      await driveFixture(fixture, fake, sessionPromise);
+
+      const files = readdirSync(outputDir);
+      expect(files).toHaveLength(expectedFileCount);
+      // ... format-specific extension assertion ...
+      // ... back-page-index assertion via PDF /Rotate, etc. ...
+    },
+    60_000,
+  );
+```
+
+Keep the small targeted tests (e.g., the `0x0c 0x00` page-eject byte search, the `appendImageChunk` unit test) outside the `it.each` block — they assert different things.
+
+- [ ] **Step 3: Run the test file**
+
+```bash
+npx vitest run src/scanner-legacy.test.ts --reporter=verbose 2>&1 | tail -40
+```
+
+Expected: every fixture replay still PASSES, plus `detectedSource` matches the expected value for each. If any fixture's `expectedDetectedSource` is wrong, the test fails with the actual detected source — update the spec to match (the wire bytes are the ground truth).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/scanner-legacy.test.ts
+git commit -m "test(scanner-legacy): rework replay matrix to per-fixture metadata
+
+Per-fixture { path, format, duplex, expectedDetectedSource, expectedFileCount,
+expectedBackPages } drives it.each. Tests no longer pre-configure source;
+they pre-configure duplex and assert detectedSource matches the FS F bytes
+in the fixture."
+```
+
+### Task E.5: Fixture-injection test for unknown FS F byte
+
+**Files:**
+- Modify: `src/scanner-legacy.test.ts` (one new test that mutates a fixture's STATUS_2 reply)
+
+- [ ] **Step 1: Write a fixture-injection test**
+
+Add to `src/scanner-legacy.test.ts`, in a new `describe("FS F unknown-byte handling", …)` block:
+
+```ts
+  describe("FS F unknown-byte handling", () => {
+    it("rejects when the STATUS_2 FS F byte is not 0x01 or 0x81", async () => {
+      const fixture = loadFixture(path.join(FIXTURES, "adf-single-page-jpeg.jsonl"));
+      // Walk events; the second FS F reply (STATUS_2) is the one we mutate.
+      // STATUS_2 reply is a printer→host event with hex starting with the IS-0xa000
+      // header; the 16-byte payload's byte 0 is the status. Find the second such
+      // event and mutate byte 0 to 0x00 before driving.
+      let fsFCount = 0;
+      const mutated = fixture.map((event) => {
+        if (event.dir !== "p>h" || !("hex" in event)) return event;
+        // IS packet structure: 12-byte header (with type at bytes 4-5), then payload.
+        // STATUS replies are 16-byte payloads.
+        const buf = Buffer.from(event.hex, "hex");
+        if (buf.length < 12 + 16) return event;
+        const type = buf.readUInt16BE(4);
+        const length = buf.readUInt32BE(6);
+        if (type === 0xa000 && length === 16) {
+          fsFCount++;
+          if (fsFCount === 2) {
+            // STATUS_2 — mutate byte 0 of payload (12 + 0)
+            buf[12] = 0x00;
+            return { ...event, hex: buf.toString("hex") };
+          }
+        }
+        return event;
+      });
+
+      const fake = new FakeTcpSocket();
+      const sessionPromise = startScanSessionLegacy(
+        {
+          printerIp: "1.2.3.4",
+          port: 1865,
+          outputDir,
+          tempDir,
+          duplex: false,
+          forcedSource: null,
+          format: "jpg",
+          jpegQuality: 90,
+        },
+        fake.asFactory(),
+      );
+      await expect(driveFixture(mutated, fake, sessionPromise)).rejects.toThrow(
+        /Unrecognised FS F status 0x00/,
+      );
+    });
+  });
+```
+
+(The exact byte offsets for "second FS F reply" may need tweaking — verify by reading `tools/pcap-extract/captures/wf-3620/adf-single-page-jpeg.jsonl` and counting which IS-0xa000 reply with length=16 is STATUS_2. The IS header layout is in `src/protocol.ts`.)
+
+- [ ] **Step 2: Run the test**
+
+```bash
+npx vitest run src/scanner-legacy.test.ts -t "FS F unknown" --reporter=verbose 2>&1 | tail -20
+```
+Expected: PASS. If FAIL with "Unrecognised FS F status 0xXX" where XX is a different value, you mutated the wrong byte — re-check the fixture event indexing.
+
+If FAIL with timeout: the mutation wasn't applied (still 0x01 or 0x81 in the bytes). Verify `mutated` actually differs from the input `fixture`.
+
+- [ ] **Step 3: Run the full suite**
+
+```bash
+npm test
+```
+Expected: all green. Test count = previous + 6 (E.1) + 1 (E.5) = previous + 7 minimum.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/scanner-legacy.test.ts
+git commit -m "test(scanner-legacy): fixture-injection test for unknown FS F byte
+
+Mutates the STATUS_2 reply in adf-single-page-jpeg.jsonl to 0x00 and
+asserts the scan rejects with the verbose 'Unrecognised FS F status'
+message. Exercises the { ok: false } branch end-to-end through the
+state machine, not just at the helper boundary."
+```
+
+### Task E.6: Open PR5
+
+- [ ] **Step 1: Push and open**
+
+```bash
+git push -u origin feature/v0.3.0-wf3620-autodetect-fsf
+gh pr create --base dev --head feature/v0.3.0-wf3620-autodetect-fsf --title "feat(scanner-legacy): FS F source autodetection (closes #28)" --body "$(cat <<'EOF'
+## Summary
+
+Closes #28. WF-3620-class printers no longer need LEGACY_FORCE_SOURCE for flatbed scans — STATUS_2 reads the FS F status byte and routes via legacyDetectSource. LEGACY_FORCE_SOURCE remains as a documented diagnostic override.
+
+Internal commits on this branch:
+1. legacyDetectSource Result-type helper + 6 unit tests
+2. API change: startScanSessionLegacy(duplex, forcedSource) instead of (source); dispatchScanSession plumbing
+3. STATUS_2 wires the helper; downstream session.source → detectedSource rewrite
+4. Replay-test rework: per-fixture { path, format, duplex, expectedDetectedSource, … } with it.each
+5. Fixture-injection test: STATUS_2 byte mutated to 0x00 → rejects with 'Unrecognised FS F status'
+
+Two-state autodetection only (0x81 flatbed, 0x01 ADF). Other bytes (jam, mid-feed, panel-vs-paper conflict, empty-tray) hard-fail with a CONTRIBUTING.md pointer; future hardening pending real-hardware captures.
+
+Replay tests stay byte-equivalent — fixture wire bytes drive detection to the same source the tests previously hard-coded.
+
+## Test plan
+
+- [ ] CI green
+- [ ] All replay fixtures pass with detectedSource asserted from wire bytes
+- [ ] legacyDetectSource unit tests pass (6 cases)
+- [ ] Unknown-byte fixture-injection test rejects cleanly
+- [ ] LEGACY_FORCE_SOURCE override path still works (covered by replay tests using forcedSource)
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for CI green, merge, recreate branch**
+
+```bash
+gh pr checks --watch
+git checkout dev
+git pull origin dev
+git checkout -b feature/v0.3.0-release
+```
+
+---
+
+## Phase F — Release notes + version bump (PR6)
+
+### Task F.1: Bump version, refresh release notes, refresh CLAUDE.md size annotation
+
+**Files:**
+- Modify: `package.json:3` (version bump)
+- Modify: `package-lock.json:3, 9` (lockfile auto-bumps)
+- Modify: `README.md` (release-history section if it exists; otherwise add a "Recent changes" stanza or update the v0.3.0 release notes location the project conventionally uses)
+- Modify: `CLAUDE.md` (`scanner-legacy.ts` size annotation refresh)
+
+- [ ] **Step 1: Bump `package.json` version**
+
+In `package.json:3`, change:
+```json
+  "version": "0.2.0",
+```
+to:
+```json
+  "version": "0.3.0",
+```
+
+Run: `npm install --no-audit --no-fund` to update `package-lock.json`.
+
+- [ ] **Step 2: Refresh `CLAUDE.md`'s `scanner-legacy.ts` size annotation**
+
+In `CLAUDE.md`, locate the line that reads (approximately):
+```
+  ~830 LOC / 44 states — parallels rather than reuses the ESC/I-2 scanner
+```
+
+Run `wc -l src/scanner-legacy.ts` to get the current LOC. Count `case "..."` lines for the state count: `grep -c '^  | "' src/scanner-legacy.ts` (approximate; verify by inspection).
+
+Replace the `~830 LOC / 44 states` figure with the current values, e.g. `~860 LOC / 42 states`.
+
+- [ ] **Step 3: Update LEGACY_FORCE_SOURCE description in README**
+
+`README.md` has no release-history / changelog section (release notes live on GitHub Releases — see Phase G). The only README change needed is the `LEGACY_FORCE_SOURCE` row in the env-var table, to reframe it as diagnostic override rather than normal config.
+
+Run: `grep -n "LEGACY_FORCE_SOURCE" README.md`
+
+For each row in the env-var table, update the description from something like "Override source for the legacy path" to "Diagnostic override when FS F autodetection misfires (e.g., for unknown printer firmware states). Set explicitly to `flatbed`, `adf-simplex`, or `adf-duplex`. Normal users do not need this." Match the surrounding row style (length + tone).
+
+- [ ] **Step 4: Run the full CI mirror**
+
+```bash
+npm run lint && npm run format:check && npm test
+```
+Expected: all green.
+
+- [ ] **Step 5: Commit and push**
+
+```bash
+git add package.json package-lock.json README.md CLAUDE.md
+git commit -m "chore(release): v0.3.0
+
+- WF-3620 source autodetection (closes #28)
+- Cert-pinning bypass under PRINTER_PROTOCOL=auto closed
+- Promise-contract reconciled — both scanner paths reject on hard errors
+- KISS/DRY/YAGNI sweep
+- LEGACY_FORCE_SOURCE reframed as diagnostic override
+- CLAUDE.md size annotation refresh"
+git push -u origin feature/v0.3.0-release
+```
+
+- [ ] **Step 6: Open PR6**
+
+```bash
+gh pr create --base dev --head feature/v0.3.0-release --title "chore(release): v0.3.0" --body "$(cat <<'EOF'
+## Summary
+
+Final v0.3.0 cut. Bumps package.json, refreshes README release notes, refreshes CLAUDE.md size annotation.
+
+After merge: tag v0.3.0 from dev, then PR dev → main.
+
+## Test plan
+
+- [ ] CI green
+EOF
+)"
+```
+
+- [ ] **Step 7: Merge once green**
+
+`gh pr merge --squash --delete-branch <PR_NUM>`.
+
+---
+
+## Phase G — Cut the release (`dev → main` + tag)
+
+### Task G.1: Open `dev → main` PR
+
+- [ ] **Step 1: Verify dev has all six v0.3.0 PRs merged**
+
+```bash
+git checkout dev
+git pull origin dev
+git log --oneline origin/main..dev
+```
+
+Expected: ~6+ squash-commits since the v0.2.0 tip, covering CI tweak, sweep 1, cert-pinning, contract, #28, release.
+
+- [ ] **Step 2: Open the release PR**
+
+```bash
+gh pr create --base main --head dev --title "Release v0.3.0" --body "$(cat <<'EOF'
+## Summary
+
+v0.3.0 — WF-3620 support gate closed. See README release notes for the full list.
+
+Headline changes:
+- WF-3620 source autodetection (closes #28)
+- Cert-pinning bypass under PRINTER_PROTOCOL=auto closed
+- Promise-contract reconciled across both scanner paths
+- KISS/DRY/YAGNI sweep
+
+## Test plan
+
+- [ ] CI green on dev → main PR
+- [ ] Tag v0.3.0 after merge
+- [ ] Docker workflow auto-publishes ghcr.io/mtheuma/epson2paperless:v0.3.0 + :latest
+- [ ] maltris real-hardware confirmation against :v0.3.0 image (issue #24 close-out; non-blocking for the tag)
+EOF
+)"
+```
+
+- [ ] **Step 3: After CI green, merge with a merge-commit (preserves history)**
+
+Use the GitHub UI's "Create a merge commit" option, or:
+```bash
+gh pr merge --merge <PR_NUM>
+```
+
+(Squash would collapse the six v0.3.0 PRs into one main-side commit, losing the per-PR history. Use a merge commit.)
+
+### Task G.2: Tag the release
+
+- [ ] **Step 1: Update local main**
+
+```bash
+git checkout main
+git pull origin main
+```
+
+- [ ] **Step 2: Create and push the annotated tag**
+
+```bash
+git tag -a v0.3.0 -m "v0.3.0 — WF-3620 source autodetection + contract reconciliation"
+git push origin v0.3.0
+```
+
+- [ ] **Step 3: Verify Docker workflow ran**
+
+Run: `gh run list --workflow=docker.yml --limit 5`
+Expected: a run on the `v0.3.0` tag, status `success`. The `ghcr.io/mtheuma/epson2paperless:v0.3.0` and `:latest` tags should be live.
+
+- [ ] **Step 4: Add release notes on GitHub**
+
+```bash
+gh release create v0.3.0 --title "v0.3.0" --notes-file <(cat <<'EOF'
+## Highlights
+
+### WF-3620 source autodetection (closes #28)
+
+Flatbed scans on a WF-3620 now work from the panel without `LEGACY_FORCE_SOURCE`. The state machine reads the FS F status byte and derives the source automatically.
+
+- Covered: `0x81` → flatbed, `0x01` → ADF (with panel duplex flag for simplex/duplex).
+- Future hardening: empty-tray, jam, mid-feed, panel-vs-paper conflict states need real-hardware captures. Unknown FS F bytes hard-fail with a verbose error pointing at CONTRIBUTING.md and noting `LEGACY_FORCE_SOURCE` as workaround.
+
+### Cert-pinning bypass closed
+
+`PRINTER_PROTOCOL=auto` + `PRINTER_CERT_FINGERPRINT` is now a config error. Defense-in-depth: under `auto`, a LAN attacker who could RST the TLS probe could force a silent downgrade to legacy plain-TCP, bypassing the pin. Use `PRINTER_PROTOCOL=esci2` explicitly for fingerprint pinning.
+
+### Promise contract reconciled
+
+Both scanner paths (ESC/I-2 and legacy ESC/I) now reject on hard errors via a unified failure-mode classification. The one-shot CLI (`npm run scan`) now exits non-zero on errors that previously exited 0 (cert-fingerprint mismatch, timeout, etc.).
+
+### Internals
+
+- KISS/DRY/YAGNI sweep: ~30 lines diff across config, output, and test-support modules
+- CI workflow now runs on PRs to `dev` (was: only `main`)
+- `KEEPALIVE_INTERVAL` removed (no behaviour change — it was never wired)
+
+## Issue #24 close-out
+
+WF-3620 support landed; closing-confirmation against 2014 firmware pending real-hardware run via maltris. Track at #24.
+EOF
+)
+```
+
+(Or use the GitHub UI to create the release from the tag.)
+
+---
+
+## Verification checklist (after v0.3.0 ships)
+
+- [ ] `git tag -l v0.3.0` shows the tag.
+- [ ] `gh release list` shows v0.3.0 as the newest release.
+- [ ] `docker pull ghcr.io/mtheuma/epson2paperless:v0.3.0` succeeds (sanity).
+- [ ] Issue #28 closed via the PR-merge auto-link or manually with a comment linking to v0.3.0.
+- [ ] Issue #24 has a comment summarising what shipped + invitation for the real-hardware confirmation.
+- [ ] Local `dev` branch is at the post-v0.3.0 tip; ready to fork `feature/v0.4.0-architecture` for the next cycle.

--- a/docs/superpowers/specs/2026-05-04-v0.3.0-and-v0.4.0-design.md
+++ b/docs/superpowers/specs/2026-05-04-v0.3.0-and-v0.4.0-design.md
@@ -28,9 +28,10 @@ This design splits the work across two releases:
 
 - Issue #28: FS F status-byte autodetection for `0x81 → flatbed` and `0x01 + duplex flag → adf-simplex|adf-duplex`. Strict-fail on unknown bytes. `LEGACY_FORCE_SOURCE` retained as a documented diagnostic override.
 - Cert-pinning bypass fix: config-level rejection of `PRINTER_PROTOCOL=auto` + `PRINTER_CERT_FINGERPRINT` (defense-in-depth).
-- Promise-contract reconciliation between `startScanSession` (currently resolve-only) and `startScanSessionLegacy` (currently rejects via `fail()`). Pick: both reject.
+- Promise-contract reconciliation between `startScanSession` (currently resolve-only) and `startScanSessionLegacy` (currently rejects via `fail()`). Hard-error sites classified into a failure-mode matrix; both implementations adopt an `errorReason + failOnce` pattern that routes hard errors into a promise rejection while preserving today's resolve-on-success behaviours (including the post-scan-save fallback when images were captured).
 - KISS/DRY/YAGNI sweep 1 from the definitive review (~30 lines diff): drop `KEEPALIVE_INTERVAL`, replace `pageJpegPaths`, drop `PUSHSCAN_RESPONSE` export, tighten `output.ts` page promotion, simplify `paperless-upload.ts`, consolidate output-tail upload calls, drop `synthesiseImageStream` export, fix the orphaned doc comment.
 - Fix the `docs/notes/...` references in tracked source comments — rewrite to point at `docs/HOW-IT-WORKS.md` (notes themselves stay private under `.reference/notes/`).
+- CI workflow tweak: add `dev` to `pull_request.branches` in `.github/workflows/test.yml` so milestone PRs to `dev` get the same lint/format/test gate as PRs to `main`. Today the workflow runs on PRs to `main` and on pushes to `dev`/`main`, but not on PRs to `dev` — which is exactly the merge target for v0.3.0 and v0.4.0 milestones.
 - Version bump to `0.3.0`; release notes; `CLAUDE.md` size annotations refreshed.
 
 **In v0.4.0 (post-0.3.0):**
@@ -54,7 +55,7 @@ This design splits the work across two releases:
 
 ## 3. v0.3.0 — detailed design
 
-Five workstreams, ordered by merge sequence on the feature branch `feature/v0.3.0-wf3620-autodetect`. Each merges back to `dev` as a separate PR.
+Six workstreams, ordered by merge sequence on the feature branch `feature/v0.3.0-wf3620-autodetect`. Each merges back to `dev` as a separate PR.
 
 ### 3.1. KISS/DRY/YAGNI sweep 1 (~30 lines, single PR)
 
@@ -83,29 +84,58 @@ Test cases in `src/config.test.ts`:
 - `esci2 + fingerprint` → accept.
 - `legacy + fingerprint` → reject (existing).
 
-### 3.3. Promise-contract reconciliation (~20 lines, single PR)
+### 3.3. Promise-contract reconciliation (~40 lines, single PR)
 
-Today `startScanSession` (`src/scanner.ts:131-137`) only resolves — its constructor receives no `reject`. On cert-fingerprint mismatch (and any other hard error path) it calls `resolveOnce()` and returns. `startScanSessionLegacy` rejects through `fail()`, e.g. on a 16-byte status parse failure. `src/one-shot.ts:56-59` then maps:
+Today `startScanSession` (`src/scanner.ts:131`) is resolve-only — its constructor receives no `reject`. The current architecture is more nuanced than "resolve at hard-error sites": almost no hard-error site resolves the promise *directly*. Instead, errors flow through `transitionToError()` → `socket.end()` → the `socket.on("close")` handler at `scanner.ts:304-308` → `resolveOnce()`. Cert-fingerprint mismatch (line 215) sets `state = "ERROR"`, destroys the socket, and lets the close handler resolve. Only the temp-dir-creation failure (line 153) calls `resolveOnce()` directly, before any connection.
+
+So just inserting `rejectOnce()` at the existing hard-error sites is not enough — most hard errors *don't* have a resolve site; they thread through the unified close path.
+
+**Fix shape:** introduce an `errorReason: Error | null` at session scope, populated by hard-error paths *before* the socket close cascade, and have the close handler consult it. Constructor becomes `new Promise<void>((resolve, reject) => …)` with symmetric `resolveOnce` / `rejectOnce` guards.
 
 ```ts
-scanPromise.then(
-  () => settle({ kind: "complete" }),  // exit 0
-  (err) => settle({ kind: "fail", err }),  // exit 1
-);
+let errorReason: Error | null = null;
+const failOnce = (err: Error) => {
+  if (errorReason) return;       // first-error wins
+  errorReason = err;
+  transitionToError();           // triggers the close handler
+};
+
+socket.on("close", () => {
+  clearTimeoutTimer();
+  log.info("TLS connection closed");
+  if (errorReason) rejectOnce(errorReason);
+  else resolveOnce();
+});
 ```
 
-So an ESC/I-2 fingerprint mismatch exits 0; a legacy parse failure exits 1.
+**Failure-mode classification.** Each hard-error site is updated to call `failOnce(new Error("..."))` *before* (or instead of) `transitionToError()`. The close handler then routes the captured reason into `rejectOnce`:
 
-**Fix:** make `startScanSession` also reject. Replace the constructor with `new Promise<void>((resolve, reject) => …)`; replace each "resolveOnce + log + return" on a hard-error path with `rejectOnce(new Error(...))`. The structured `{ ok, reason? }` shape proposed in the architecture review is deferred to v0.4.0's engine API — that is the right place to design it, with both implementations sharing one interface.
+| Site (scanner.ts) | Today | After |
+|---|---|---|
+| Cert fingerprint mismatch (~line 215) | Resolves silently | `failOnce(new Error("Printer cert fingerprint mismatch — expected X, got Y"))` |
+| Temp-dir creation failure (~line 153) | `resolveOnce()` direct | `rejectOnce(new Error("Failed to create session temp dir under X: msg"))` direct (no socket open yet) |
+| Timeout (~line 187) | `transitionToError()` only | `failOnce(new Error("Timeout in state X — no response in Yms"))` |
+| Socket error (~line 297) | `transitionToError()` only | `failOnce(new Error("TLS connection error in state X: <message>"))` |
+| Async ScanCancel (~line 360) | `transitionToError()` only | `failOnce(new Error("Async ScanCancel during state X"))` |
+| Async fatal event (~line 363) | `transitionToError()` only | `failOnce(new Error("Async fatal event 0xXX during state X"))` |
+| Per-state `ensure(false, msg)` sites | `transitionToError()` only | `failOnce(new Error("Protocol error in state X: msg"))` |
+| Zero-image completion (~line 978) | Silent resolve | `failOnce(new Error("Scan completed with zero image chunks"))` |
+| `finalizeSession` failure (~line 992) | Silent resolve | `rejectOnce(new Error("finalizeScan failure: msg"))` direct (socket already closed) |
+| Post-scan-save fallback (line 258, images captured) | Resolves with images saved | **Resolves.** Genuine success — images survived a printer-side cleanup glitch. Behaviour unchanged. |
 
-`src/index.ts`'s daemon path is unaffected: `inflight.track` already swallows rejections; the change makes more rejections occur, but they're still swallowed by the tracker. Worth an explicit test to lock in that "more rejections do not crash the daemon" remains true.
+**Symmetric for `startScanSessionLegacy`.** Adopt the same `errorReason + failOnce` shape. The existing legacy `fail()` helper already rejects, but classifying its call sites against the same matrix gives both implementations one contract — and gives v0.4.0's shared engine a single, clean failure model to lift.
 
-Test cases:
+`dispatchScanSession`'s caller contract is then unambiguous: promise rejects → `one-shot.ts` exits 1 / `index.ts`'s inflight tracker swallows. The structured `{ ok, reason? }` shape proposed in the architecture review is deferred to v0.4.0; it lives at the engine's *internal* boundary, and `dispatchScanSession` continues to reject on engine-`{ ok: false }` to preserve the v0.3.0 contract (see §5 M1).
 
-- New test in `src/scanner.test.ts`: feed a `FakeTlsSocket` whose certificate fingerprint mismatches the configured pin. Assert the returned promise rejects with an error whose message mentions "fingerprint" or "certificate".
-- New test in `src/lifecycle.test.ts`: a tracked scan promise that rejects does not crash the in-flight tracker; the tracker's count returns to 0.
+Test cases (TDD):
 
-### 3.4. Issue #28 — FS F autodetection (the headline; four sub-PRs, byte-sensitive)
+- New tests in `src/scanner.test.ts`, one per failure-mode row (cert fingerprint mismatch, temp-dir creation failure, timeout, socket error, async ScanCancel, async fatal, zero-image completion, finalize failure). Each asserts the returned promise rejects with an error whose message contains the classifier substring.
+- Symmetric coverage in `src/scanner-legacy.test.ts` for the legacy failure-mode rows.
+- **Existing test in `src/lifecycle.test.ts:23`** (`"settles the tracker slot even when the tracked promise rejects"`) already pins inflight tolerance — retain coverage, no new lifecycle test needed.
+
+### 3.4. Issue #28 — FS F autodetection (the headline; **single combined PR**, byte-sensitive)
+
+**PR-shape note.** An earlier draft split this into four sub-PRs (API change → detection → downstream rewrite → replay-test rework). That decomposition leaves intermediate states broken: removing `source` as an input to `startScanSessionLegacy` while downstream handlers still read `session.source` won't compile, and reworking replay tests before the API/derivation lands either skips coverage or hard-codes the old shape. The change is one coherent restructure ("switch from config-derived source to wire-detected source") and ships as one PR. The four logical phases below describe the *internal structure* of that PR; they're commits on the feature branch, not separate merges.
 
 The `STAT` reply that follows the legacy `ESC e 0x01 + FS F` probe carries the source signal in byte 0:
 
@@ -113,32 +143,47 @@ The `STAT` reply that follows the legacy `ESC e 0x01 + FS F` probe carries the s
 - `0x01` → ADF has paper.
 - Other values → unknown (jam, mid-feed, panel-vs-paper conflict, empty-tray for ADF-equipped models). No fixtures yet.
 
-Today (`src/scanner-legacy.ts:330-362`, state `STATUS_2`) the byte is read but discarded; the source comes from `session.source`, which is config-derived. Sub-PRs:
+Today (`src/scanner-legacy.ts:330-362`, state `STATUS_2`) the byte is read but discarded; the source comes from `session.source`, which is config-derived. Internal commit phases of the single combined PR:
 
 **3.4.1. API change** (`startScanSessionLegacy`): take `duplex: boolean` instead of `source: Source`; source becomes a *result*, not an input. Add `forcedSource: Source | null` for `LEGACY_FORCE_SOURCE`. `dispatchScanSession` in `src/startup.ts:115-123` drops the legacy source-mapping; passes `info.duplex` and `config.legacyForceSource ?? null` directly. Type-error driven; the TypeScript compiler is the test.
 
-**3.4.2. Detection rule in `STATUS_2`.** New helper `legacyDetectSource(fsfByte: number, duplex: boolean): Source` in `src/esci-legacy.ts`:
+**3.4.2. Detection rule in `STATUS_2`.** New helper in `src/esci-legacy.ts` returns a Result type — pure (no throw inside an event handler), and gives every detection outcome the same assertable shape:
 
-```
-fsfByte === 0x81                  → 'flatbed'
-fsfByte === 0x01 && !duplex       → 'adf-simplex'
-fsfByte === 0x01 && duplex        → 'adf-duplex'
-otherwise                         → throw new Error(
-  `Unrecognised FS F status 0x${fsfByte.toString(16).padStart(2, '0')} ` +
-  `— please file a compatibility issue with LOG_LEVEL=debug output ` +
-  `(see CONTRIBUTING.md). Workaround: set LEGACY_FORCE_SOURCE.`
-)
+```ts
+export type DetectSourceResult =
+  | { ok: true; source: Source }
+  | { ok: false; byte: number };
+
+export function legacyDetectSource(
+  fsfByte: number,
+  duplex: boolean,
+): DetectSourceResult {
+  if (fsfByte === 0x81) return { ok: true, source: "flatbed" };
+  if (fsfByte === 0x01) return { ok: true, source: duplex ? "adf-duplex" : "adf-simplex" };
+  return { ok: false, byte: fsfByte };
+}
 ```
 
-`STATUS_2` reads the byte, calls `legacyDetectSource`, stores the result on the session as `detectedSource`. If `forcedSource` is set, short-circuit STATUS_2 to that value; emit `[scanner-legacy] LEGACY_FORCE_SOURCE override: <source> (FS F byte 0x{XX} ignored)` at INFO so an actual misfire is debuggable.
+`STATUS_2` calls the helper:
+
+- on `{ ok: true }` — stores `result.source` on the session as `detectedSource`, advances state.
+- on `{ ok: false }` — calls the legacy `fail()` path (the same one used by 16-byte status parse failures today), passing `Unrecognised FS F status 0x{XX} — please file a compatibility issue with LOG_LEVEL=debug output (see CONTRIBUTING.md). Workaround: set LEGACY_FORCE_SOURCE.` This routes through `failOnce`/the legacy equivalent established in 3.3 and rejects the outer promise cleanly.
+
+If `forcedSource` is set, `STATUS_2` short-circuits *before* calling `legacyDetectSource`; emit `[scanner-legacy] LEGACY_FORCE_SOURCE override: <source> (FS F byte 0x{XX} ignored)` at INFO so an actual misfire is debuggable.
 
 Edge case worth pinning: what if `0x81` arrives with `duplex===true` (panel says duplex but we're on a flatbed)? Treat as `flatbed` regardless of duplex flag — a flatbed has no second-side concept. The `legacyDetectSource` unit test covers this.
+
+**State-machine replay test for unknown bytes.** Beyond the helper-level unit tests, add one fixture-injection test in `scanner-legacy.test.ts` that mutates an existing fixture's FS F status byte to `0x00` (or any unknown value) before driving the replay; assert the scanner promise rejects with an error message containing "Unrecognised FS F status". This ensures the `{ ok: false }` branch is exercised end-to-end, not just at the helper boundary — i.e., that the catch path inside `STATUS_2` actually fires.
 
 **3.4.3. Downstream rewrite.** Every `session.source` read after STATUS_2 (`scanner-legacy.ts:401, 422, 460, 520, 538, …`) becomes a read of `session.detectedSource`. Type-driven: rename the field, fix every call site the compiler complains about.
 
 **3.4.4. Replay-test rework.** Per-fixture metadata: each fixture gets `{ path, format, fsfStatusByte, expectedDetectedSource, expectedFileCount, expectedBackPages }`. The harness drives the fixture with `duplex` (not `source`) and asserts `session.detectedSource === fixture.expectedDetectedSource` plus the existing output assertions. Pure derivation: the test no longer pre-configures source; it asserts the wire bytes produce the correct source.
 
-### 3.5. Release notes + version bump (single PR, last)
+### 3.5. CI workflow tweak (one-line PR, lands first)
+
+`.github/workflows/test.yml` today runs on `push: branches: [dev, main]` and `pull_request: branches: [main]`. Add `dev` to `pull_request.branches` so the lint/format/test gate fires on every milestone PR. This is a prerequisite for the rest of v0.3.0: each subsequent PR targets `dev`, and CI green on the PR before merge is the contract this design relies on. Pre-push hook (`.githooks/pre-push`) remains the local mirror but is opt-in; CI gate is non-negotiable.
+
+### 3.6. Release notes + version bump (single PR, last)
 
 - Bump `package.json` `version` from `0.2.0` to `0.3.0`.
 - Tag `v0.3.0` after `dev → main` merge; existing GHCR Docker workflow auto-publishes `:v0.3.0` and `:latest`.
@@ -149,14 +194,15 @@ Edge case worth pinning: what if `0x81` arrives with `duplex===true` (panel says
 
 **Regression shield (existing, must stay green):**
 
-- `src/scanner.test.ts` — six Frida ESC/I-2 fixtures; byte-equivalent. Untouched by sweep 1, the cert-pinning fix, or #28. Adds one new test for the cert-fingerprint reject path (3.3).
-- `src/scanner-legacy.test.ts` — pcap legacy fixtures. **Reshaped** in 3.4.4: per-fixture metadata replaces the hardcoded `source` arg. Existing fixtures still drive byte-equivalent replay; the test additionally asserts `detectedSource` matches.
+- `src/scanner.test.ts` — six Frida ESC/I-2 fixtures; byte-equivalent. Untouched by sweep 1 and the cert-pinning fix. Grows with the failure-mode classification matrix from 3.3.
+- `src/scanner-legacy.test.ts` — pcap legacy fixtures. **Reshaped** in 3.4.4: per-fixture metadata replaces the hardcoded `source` arg. Existing fixtures still drive byte-equivalent replay; the test additionally asserts `detectedSource` matches. Also gains one fixture-injection test for the unknown-FS-F-byte rejection path (3.4.2).
+- `src/lifecycle.test.ts:23` — already covers `inflight.track` swallowing rejections. Retained as-is; no new lifecycle test needed (the daemon-side tolerance for the now-more-frequent rejections is already pinned).
 
 **TDD-required new code (write tests first, watch fail, implement):**
 
-- **Cert-pinning superRefine** (3.2): four cases in `src/config.test.ts`.
-- **Promise-contract reject path** (3.3): one case in `src/scanner.test.ts`, one in the lifecycle test.
-- **`legacyDetectSource`** (3.4.2): six cases in a unit test — `(0x81, false)`, `(0x81, true)`, `(0x01, false)`, `(0x01, true)`, `(0x00, false)` rejects, `(0xFF, false)` rejects.
+- **Cert-pinning superRefine** (3.2): four cases in `src/config.test.ts` (`auto + fingerprint` reject, `auto + no fingerprint` accept, `esci2 + fingerprint` accept, `legacy + fingerprint` reject — last is existing).
+- **Promise-contract failure-mode matrix** (3.3): one test per row of the failure-mode table in `src/scanner.test.ts` — cert fingerprint mismatch, temp-dir creation failure, timeout, socket error, async ScanCancel, async fatal, zero-image completion, finalize failure. Each asserts `await expect(scanPromise).rejects.toThrow(/<classifier substring>/)`. Symmetric coverage for the equivalent rows in `src/scanner-legacy.test.ts`. Plus one test asserting that the post-scan-save fallback path (images captured + post-scan glitch) still **resolves** — to lock in the unchanged success behaviour.
+- **`legacyDetectSource`** (3.4.2): six unit tests for the Result-type helper — `(0x81, false)` → `{ ok: true, source: 'flatbed' }`, `(0x81, true)` → `{ ok: true, source: 'flatbed' }` (panel-says-duplex on flatbed), `(0x01, false)` → `{ ok: true, source: 'adf-simplex' }`, `(0x01, true)` → `{ ok: true, source: 'adf-duplex' }`, `(0x00, false)` → `{ ok: false, byte: 0x00 }`, `(0xFF, true)` → `{ ok: false, byte: 0xFF }`. Plus the state-machine fixture-injection test from 3.4.2.
 
 **Type-driven changes (compiler is the test):**
 
@@ -168,14 +214,16 @@ Edge case worth pinning: what if `0x81` arrives with `duplex===true` (panel says
 - Unknown FS F bytes for empty-tray, jam, mid-feed, panel-conflict. Unit test pins the *rejection* shape for two unknown bytes; the actual values produced by real WF-3620 firmware in those states are unknown until captures arrive. Strict-fail with the verbose error message is the safety net; `LEGACY_FORCE_SOURCE` is the immediate workaround.
 - `dispatchScanSession` itself remains untested at unit level (deferred-tech-debt item from `.reference/next-steps.md`). Folds naturally into v0.4.0's engine extraction.
 
-**CI gate:** unchanged. `npm run lint`, `npm run format:check`, `npm test` on every PR to `dev`/`main`. Pre-push hook mirrors. Test count target ~285, up from current 271.
+**CI gate:** v0.3.0 prep adds `dev` to the workflow's `pull_request.branches` (see 3.5). After that, `npm run lint`, `npm run format:check`, `npm test` runs on every PR to `dev`/`main`. Pre-push hook mirrors. Test count target ~290+, up from current 271 (the failure-mode matrix is the largest single contributor).
 
 ## 5. v0.4.0 — roadmap
 
 Sequenced milestones; each = one PR back to the long-lived `feature/v0.4.0-architecture` branch off `dev`. Sized in calendar days assuming focused work. Sequential dependencies marked.
 
 **M1 — Shared scan-session engine** (~2 days, prerequisite for M2/M3)
-New module `src/scan-session.ts`. Owns: socket factory injection, recv-buffer accumulator (the deferred-concat shape from `scanner.ts`, not the per-event concat from `scanner-legacy.ts`), IS-packet pump, single rolling timeout, page-flush hook (`(jpeg: Buffer, side: 'front' | 'back') => Promise<void>`), back-page index tracking, EXIF orientation injection for back pages, `setImmediate → finalizeSession` tail. Each consumer scanner supplies a state-graph definition + a per-page-encode strategy. The structured `{ ok, reason? }` result shape from the architecture review can land here as the engine's return type, replacing the v0.3.0 reject-on-error contract on the engine boundary.
+New module `src/scan-session.ts`. Owns: socket factory injection, recv-buffer accumulator (the deferred-concat shape from `scanner.ts`, not the per-event concat from `scanner-legacy.ts`), IS-packet pump, single rolling timeout, page-flush hook (`(jpeg: Buffer, side: 'front' | 'back') => Promise<void>`), back-page index tracking, EXIF orientation injection for back pages, `setImmediate → finalizeSession` tail. Each consumer scanner supplies a state-graph definition + a per-page-encode strategy.
+
+**Engine-vs-caller contract.** The engine returns a structured `{ ok: true } | { ok: false; reason: Error }` from its `runScanSession()` entry point. This is the engine's *internal* boundary — useful for the engine to thread the failure-mode matrix from §3.3 into a single result without throwing across the state-graph plumbing. **`dispatchScanSession` continues to reject on `{ ok: false }`, normalising the engine result into the same promise-rejection contract established by v0.3.0.** Neither `one-shot.ts` nor `index.ts` change: they consume `dispatchScanSession`'s rejection-on-error promise just as they do post-v0.3.0. This keeps the v0.4.0 architectural change invisible at the daemon / CLI boundary; only the scanner *internals* see the structured shape.
 
 **M2 — `scanner.ts` refactor onto engine** (~1 day, blocked by M1)
 Salvage the existing state machine. Add `awaitAck(next, sendNext)` and `statThenDrain(onDone)` helpers; collapse 32 states to ~12 via declarative state graph. Replay tests pin every byte; drift surfaces immediately.
@@ -204,8 +252,10 @@ Substantive headline: "internal architecture rebuild + WF-3620 quality oracle". 
 **v0.3.0 risks:**
 
 - *Unknown FS F bytes hit real users.* Strict-fail with verbose error message points at CONTRIBUTING.md; `LEGACY_FORCE_SOURCE` is the immediate workaround. A compatibility issue from a user surfaces the next state to capture and ships in a v0.3.x point release.
-- *Promise-contract change breaks daemon error tolerance.* Test that `inflight.track` continues to swallow rejections (no process-level crash); test that one-shot now exits non-zero on cert-fingerprint mismatch.
-- *Real-hardware test against maltris's WF-3620 (gate for issue #24).* Out of our control; can be done before or after the v0.3.0 cut. The cut itself doesn't strictly depend on this — it depends on #28 landing in `dev` with replay tests green. Closing #24 is the social/release-notes signal that WF-3620 is supported, and may be a separate moment.
+- *Promise-contract change breaks daemon error tolerance or accidentally rejects a path users rely on resolving.* Mitigation: the failure-mode matrix in §3.3 enumerates each site explicitly; the post-scan-save fallback resolve is called out as **unchanged**; the existing `lifecycle.test.ts:23` already pins inflight rejection-tolerance. The matrix is the artifact a reviewer can scan to confirm no path is mis-classified.
+- *Real-hardware test against maltris's WF-3620.* Two distinct gates that the original framing conflated:
+  - **Technical gate for tagging v0.3.0:** #28 lands in `dev`; all replay tests + the new failure-mode matrix green; CI green on `dev → main`. **No external hardware dependency.** Tag the release as soon as this gate clears.
+  - **Issue #24 close-out:** maltris (or any WF-3620 owner) confirms an end-to-end real-hardware scan against `dev` or against the `:v0.3.0` Docker image. Decoupled from the tag — the v0.3.0 release notes call this out explicitly: *"WF-3620 support landed; closing-confirmation against 2014 firmware pending real-hardware run, expected within X days of release; track at issue #24."* This avoids holding the tag on coordination with an external user, and lets v0.4.0 work begin immediately after the cut.
 
 **v0.4.0 risks:**
 
@@ -215,23 +265,23 @@ Substantive headline: "internal architecture rebuild + WF-3620 quality oracle". 
 
 ## 7. Branch / CI strategy
 
-- v0.3.0: short-lived `feature/v0.3.0-wf3620-autodetect` off `dev`. Five workstreams (3.1-3.5); workstream 3.4 splits into four sub-PRs, the others are one PR each — eight PRs back to `dev` total. Single `dev → main` PR for the release. Tag `v0.3.0`.
-- v0.4.0: long-lived `feature/v0.4.0-architecture` off `dev`. ~7 milestone PRs back to `dev`. Single `dev → main` PR for the release. Tag `v0.4.0`.
-- Existing CI gate (`lint`, `format:check`, `test`) runs unchanged on every PR. Pre-push hook (`.githooks/pre-push`) mirrors. Docker workflow (`.github/workflows/docker.yml`) auto-publishes on the `v0.3.0` and `v0.4.0` tags.
+- v0.3.0: short-lived `feature/v0.3.0-wf3620-autodetect` off `dev`. Six workstreams (3.1-3.6); each is a single PR — six PRs back to `dev` total (the #28 work in 3.4 is one combined PR; see the PR-shape note in §3.4). Single `dev → main` PR for the release. Tag `v0.3.0`.
+- v0.4.0: long-lived `feature/v0.4.0-architecture` off `dev`. Seven milestone PRs back to `dev`. Single `dev → main` PR for the release. Tag `v0.4.0`.
+- CI gate: workstream 3.5 lands the one-line workflow change adding `dev` to `pull_request.branches`. After that, `lint` / `format:check` / `test` run on every PR to `dev` or `main`. Pre-push hook (`.githooks/pre-push`) mirrors. Docker workflow (`.github/workflows/docker.yml`) auto-publishes on the `v0.3.0` and `v0.4.0` tags.
 
 ## 8. Sequencing summary
 
 ```
 v0.3.0 (target: ≤ 1 week elapsed)
   feature/v0.3.0-wf3620-autodetect off dev
-   ├─ PR1: KISS/DRY/YAGNI sweep 1 (3.1)
-   ├─ PR2: cert-pinning superRefine (3.2)
-   ├─ PR3: promise-contract reconciliation (3.3)
-   ├─ PR4: #28.1 API change
-   ├─ PR5: #28.2 detection rule + new unit test
-   ├─ PR6: #28.3 downstream rewrite
-   ├─ PR7: #28.4 replay-test rework
-   └─ PR8: release notes + version bump (3.5)
+   ├─ PR1: CI workflow tweak — add dev to pull_request.branches (3.5, lands first)
+   ├─ PR2: KISS/DRY/YAGNI sweep 1 (3.1)
+   ├─ PR3: cert-pinning superRefine (3.2)
+   ├─ PR4: promise-contract reconciliation + failure-mode matrix (3.3)
+   ├─ PR5: #28 FS F autodetection (3.4 — single combined PR;
+   │       internally: API change + detection rule + downstream
+   │       rewrite + replay-test rework as separate commits)
+   └─ PR6: release notes + version bump (3.6)
   → dev → main → tag v0.3.0
 
 v0.4.0 (target: 2-3 weeks elapsed)

--- a/docs/superpowers/specs/2026-05-04-v0.3.0-and-v0.4.0-design.md
+++ b/docs/superpowers/specs/2026-05-04-v0.3.0-and-v0.4.0-design.md
@@ -1,0 +1,247 @@
+# v0.3.0 and v0.4.0 — release design
+
+Date: 2026-05-04
+Status: draft, pending user review.
+Tracking: GitHub issues [#28](https://github.com/mtheuma/epson2paperless/issues/28) (must-include for v0.3.0), [#27](https://github.com/mtheuma/epson2paperless/issues/27) (deferred to v0.4.0), [#24](https://github.com/mtheuma/epson2paperless/issues/24) (closed by v0.3.0 + maltris real-hardware test).
+Source reviews: `.reference/reviews/kiss-dry-yagni-definitive.md` and `.reference/reviews/2026-05-04-architecture-review-consolidated.md`.
+
+## 1. Background
+
+The `dev` branch (currently at `package.json` version `0.2.0`) carries dual-protocol scanner support: ESC/I-2 over TLS for the ET-4950 family and legacy ESC/I over plain TCP for the WF-3620, auto-detected at session start by `src/protocol-probe.ts` and dispatched via `dispatchScanSession` in `src/startup.ts`. The legacy path was merged on 2026-05-01 (PR #25) as feature-complete except for two follow-ups:
+
+- **Issue #28** — the legacy state machine still branches on `session.source` (config-derived from `LEGACY_FORCE_SOURCE`), not the FS F status byte the printer is already sending. Flatbed scans on a WF-3620 only work today when the user opts into `LEGACY_FORCE_SOURCE=flatbed`; the panel button alone can't trigger one.
+- **Real-hardware test** against maltris's WF-3620 (the closing gate for issue #24).
+
+Two reviews captured the same day flagged structural issues:
+
+- The KISS/DRY/YAGNI review found 13 small-to-medium code-quality items across config, output, scanners, and tests. The recommended priority order groups them into four sweeps; sweep 1 ("low-risk YAGNI clean-ups, ~30 lines diff") is independent of any architectural change.
+- The architecture review identified three HIGH items: a parallel-implemented session-engine layer hiding inside both scanners, a contract asymmetry between them (resolve-only vs reject — produces a real exit-code bug in one-shot), and a structurally tangled legacy state machine. The action plan recommends reconciling the contract first, then extracting a shared engine, then refactoring scanner.ts and rewriting scanner-legacy.ts onto it.
+
+This design splits the work across two releases:
+
+- **v0.3.0** ships the WF-3620 gate (issue #28, defense-in-depth fixes, contract reconciliation, and the small KISS/DRY/YAGNI sweep). No architectural changes.
+- **v0.4.0** ships the architectural rebuild (shared engine, both scanners refactored/rewritten onto it) and the issue #27 patch-sampling regression oracle.
+
+## 2. Scope
+
+**In v0.3.0:**
+
+- Issue #28: FS F status-byte autodetection for `0x81 → flatbed` and `0x01 + duplex flag → adf-simplex|adf-duplex`. Strict-fail on unknown bytes. `LEGACY_FORCE_SOURCE` retained as a documented diagnostic override.
+- Cert-pinning bypass fix: config-level rejection of `PRINTER_PROTOCOL=auto` + `PRINTER_CERT_FINGERPRINT` (defense-in-depth).
+- Promise-contract reconciliation between `startScanSession` (currently resolve-only) and `startScanSessionLegacy` (currently rejects via `fail()`). Pick: both reject.
+- KISS/DRY/YAGNI sweep 1 from the definitive review (~30 lines diff): drop `KEEPALIVE_INTERVAL`, replace `pageJpegPaths`, drop `PUSHSCAN_RESPONSE` export, tighten `output.ts` page promotion, simplify `paperless-upload.ts`, consolidate output-tail upload calls, drop `synthesiseImageStream` export, fix the orphaned doc comment.
+- Fix the `docs/notes/...` references in tracked source comments — rewrite to point at `docs/HOW-IT-WORKS.md` (notes themselves stay private under `.reference/notes/`).
+- Version bump to `0.3.0`; release notes; `CLAUDE.md` size annotations refreshed.
+
+**In v0.4.0 (post-0.3.0):**
+
+- Shared scan-session engine extraction (`src/scan-session.ts`).
+- Refactor `scanner.ts` onto the engine; collapse 32 states to ~12 via declarative state graph.
+- Rewrite `scanner-legacy.ts` onto the engine; fold the five `ESC e + param + double-ACK` pairs; encode ADF vs flatbed as graph paths, not dedicated states.
+- Issue #27 patch-sampling regression oracle for legacy WF-3620 scan output.
+- PARA payload dedup in `esci.ts` (extract shared 928-byte tail).
+- Replace `__resetShutdownStateForTesting` with deps-injected state on `ShutdownDeps`.
+- Bind `health.ts` to `127.0.0.1` by default; opt-in `HEALTH_BIND_HOST` for LAN exposure.
+- Inline `safeInspect` if still a one-call helper.
+- Version bump to `0.4.0`; release notes.
+
+**Out of scope, both releases:**
+
+- Source-autodetect for ET-4950 (already implemented).
+- New panel-side features (Email format, paper sizes other than A4).
+- New protocol generations (no third-protocol probe).
+- Configurable scan parameters (backlog item; awaits its own brainstorm).
+
+## 3. v0.3.0 — detailed design
+
+Five workstreams, ordered by merge sequence on the feature branch `feature/v0.3.0-wf3620-autodetect`. Each merges back to `dev` as a separate PR.
+
+### 3.1. KISS/DRY/YAGNI sweep 1 (~30 lines, single PR)
+
+From `.reference/reviews/kiss-dry-yagni-definitive.md` recommended priority order item 1, plus two items from the architecture review:
+
+- Remove `KEEPALIVE_INTERVAL` from `src/config.ts`, `README.md`, and `src/config.test.ts`. Removal preferred over wiring because the README description ("ms between keepalive responses") describes legacy behaviour; the current responder is event-driven and uses `burstIntervalMs` for intra-burst spacing only. Wiring it would re-document a misleading knob.
+- Replace `pageJpegPaths: string[]` in `src/scanner-legacy.ts` with a `pageCount` counter. Strings are never read — only `.length` is consulted.
+- Drop the `PUSHSCAN_RESPONSE` export from `src/pushscan.ts`. Rewrite `src/pushscan.test.ts` to call `buildPushScanResponse("1")` inline; remove the tautology test.
+- Tighten `src/output.ts:promoteTempPagesToOutput` to pass `"jpg"` into `sortedPageFiles`; drop the duplicate regex parse on `entry.match(/^page_(\d+)/)`.
+- Simplify `src/paperless-upload.ts:uploadAllToPaperless` — either drop the per-upload `.catch()` and read failures from `Promise.allSettled`, or keep the catch and use `Promise.all`. Pick the shape that makes "log failures, never abort completed scans" most obvious.
+- Consolidate the three Paperless upload sites in `src/output-tail.ts` (`output-tail.ts:32-34, 42-44, 50-52`) — produce a single `savedPaths: string[]` from the branch logic, run upload once after the branch.
+- Drop the `export` keyword from `synthesiseImageStream` in `src/test-support/legacy-replay.ts:52`. Move the orphaned doc comment at lines 18-26 to attach to it.
+
+Each item is independent. No wire-byte changes; replay tests unaffected.
+
+### 3.2. Cert-pinning bypass fix (~10 lines, single PR)
+
+Today: when `PRINTER_PROTOCOL=auto` and `PRINTER_CERT_FINGERPRINT` is set, a LAN attacker who can RST the TLS probe forces the auto-detector to classify the printer as legacy, which silently drops the fingerprint pin (legacy uses plain TCP, has no TLS layer). Symmetrical to the existing `legacy + fingerprint` and `esci2 + LEGACY_FORCE_SOURCE` rejections in `src/config.ts`.
+
+Add a `superRefine` rejecting `PRINTER_PROTOCOL=auto` paired with a non-null `PRINTER_CERT_FINGERPRINT`. Users wanting fingerprint pinning must set `PRINTER_PROTOCOL=esci2` explicitly. Existing users with both set today will see a startup error pointing them at the fix.
+
+Test cases in `src/config.test.ts`:
+
+- `auto + fingerprint` → reject.
+- `auto + no fingerprint` → accept.
+- `esci2 + fingerprint` → accept.
+- `legacy + fingerprint` → reject (existing).
+
+### 3.3. Promise-contract reconciliation (~20 lines, single PR)
+
+Today `startScanSession` (`src/scanner.ts:131-137`) only resolves — its constructor receives no `reject`. On cert-fingerprint mismatch (and any other hard error path) it calls `resolveOnce()` and returns. `startScanSessionLegacy` rejects through `fail()`, e.g. on a 16-byte status parse failure. `src/one-shot.ts:56-59` then maps:
+
+```ts
+scanPromise.then(
+  () => settle({ kind: "complete" }),  // exit 0
+  (err) => settle({ kind: "fail", err }),  // exit 1
+);
+```
+
+So an ESC/I-2 fingerprint mismatch exits 0; a legacy parse failure exits 1.
+
+**Fix:** make `startScanSession` also reject. Replace the constructor with `new Promise<void>((resolve, reject) => …)`; replace each "resolveOnce + log + return" on a hard-error path with `rejectOnce(new Error(...))`. The structured `{ ok, reason? }` shape proposed in the architecture review is deferred to v0.4.0's engine API — that is the right place to design it, with both implementations sharing one interface.
+
+`src/index.ts`'s daemon path is unaffected: `inflight.track` already swallows rejections; the change makes more rejections occur, but they're still swallowed by the tracker. Worth an explicit test to lock in that "more rejections do not crash the daemon" remains true.
+
+Test cases:
+
+- New test in `src/scanner.test.ts`: feed a `FakeTlsSocket` whose certificate fingerprint mismatches the configured pin. Assert the returned promise rejects with an error whose message mentions "fingerprint" or "certificate".
+- New test in `src/lifecycle.test.ts`: a tracked scan promise that rejects does not crash the in-flight tracker; the tracker's count returns to 0.
+
+### 3.4. Issue #28 — FS F autodetection (the headline; four sub-PRs, byte-sensitive)
+
+The `STAT` reply that follows the legacy `ESC e 0x01 + FS F` probe carries the source signal in byte 0:
+
+- `0x81` → flatbed (no ADF paper / no ADF present).
+- `0x01` → ADF has paper.
+- Other values → unknown (jam, mid-feed, panel-vs-paper conflict, empty-tray for ADF-equipped models). No fixtures yet.
+
+Today (`src/scanner-legacy.ts:330-362`, state `STATUS_2`) the byte is read but discarded; the source comes from `session.source`, which is config-derived. Sub-PRs:
+
+**3.4.1. API change** (`startScanSessionLegacy`): take `duplex: boolean` instead of `source: Source`; source becomes a *result*, not an input. Add `forcedSource: Source | null` for `LEGACY_FORCE_SOURCE`. `dispatchScanSession` in `src/startup.ts:115-123` drops the legacy source-mapping; passes `info.duplex` and `config.legacyForceSource ?? null` directly. Type-error driven; the TypeScript compiler is the test.
+
+**3.4.2. Detection rule in `STATUS_2`.** New helper `legacyDetectSource(fsfByte: number, duplex: boolean): Source` in `src/esci-legacy.ts`:
+
+```
+fsfByte === 0x81                  → 'flatbed'
+fsfByte === 0x01 && !duplex       → 'adf-simplex'
+fsfByte === 0x01 && duplex        → 'adf-duplex'
+otherwise                         → throw new Error(
+  `Unrecognised FS F status 0x${fsfByte.toString(16).padStart(2, '0')} ` +
+  `— please file a compatibility issue with LOG_LEVEL=debug output ` +
+  `(see CONTRIBUTING.md). Workaround: set LEGACY_FORCE_SOURCE.`
+)
+```
+
+`STATUS_2` reads the byte, calls `legacyDetectSource`, stores the result on the session as `detectedSource`. If `forcedSource` is set, short-circuit STATUS_2 to that value; emit `[scanner-legacy] LEGACY_FORCE_SOURCE override: <source> (FS F byte 0x{XX} ignored)` at INFO so an actual misfire is debuggable.
+
+Edge case worth pinning: what if `0x81` arrives with `duplex===true` (panel says duplex but we're on a flatbed)? Treat as `flatbed` regardless of duplex flag — a flatbed has no second-side concept. The `legacyDetectSource` unit test covers this.
+
+**3.4.3. Downstream rewrite.** Every `session.source` read after STATUS_2 (`scanner-legacy.ts:401, 422, 460, 520, 538, …`) becomes a read of `session.detectedSource`. Type-driven: rename the field, fix every call site the compiler complains about.
+
+**3.4.4. Replay-test rework.** Per-fixture metadata: each fixture gets `{ path, format, fsfStatusByte, expectedDetectedSource, expectedFileCount, expectedBackPages }`. The harness drives the fixture with `duplex` (not `source`) and asserts `session.detectedSource === fixture.expectedDetectedSource` plus the existing output assertions. Pure derivation: the test no longer pre-configures source; it asserts the wire bytes produce the correct source.
+
+### 3.5. Release notes + version bump (single PR, last)
+
+- Bump `package.json` `version` from `0.2.0` to `0.3.0`.
+- Tag `v0.3.0` after `dev → main` merge; existing GHCR Docker workflow auto-publishes `:v0.3.0` and `:latest`.
+- README release-history section: WF-3620 autodetection headline; note that `LEGACY_FORCE_SOURCE` is now diagnostic/override, not normal config; explicitly document "future hardening, captures needed" for unknown FS F bytes.
+- `CLAUDE.md` `scanner-legacy.ts` size annotation refresh (currently says "~830 LOC / 44 states"; will be a touch more after #28).
+
+## 4. v0.3.0 — testing strategy
+
+**Regression shield (existing, must stay green):**
+
+- `src/scanner.test.ts` — six Frida ESC/I-2 fixtures; byte-equivalent. Untouched by sweep 1, the cert-pinning fix, or #28. Adds one new test for the cert-fingerprint reject path (3.3).
+- `src/scanner-legacy.test.ts` — pcap legacy fixtures. **Reshaped** in 3.4.4: per-fixture metadata replaces the hardcoded `source` arg. Existing fixtures still drive byte-equivalent replay; the test additionally asserts `detectedSource` matches.
+
+**TDD-required new code (write tests first, watch fail, implement):**
+
+- **Cert-pinning superRefine** (3.2): four cases in `src/config.test.ts`.
+- **Promise-contract reject path** (3.3): one case in `src/scanner.test.ts`, one in the lifecycle test.
+- **`legacyDetectSource`** (3.4.2): six cases in a unit test — `(0x81, false)`, `(0x81, true)`, `(0x01, false)`, `(0x01, true)`, `(0x00, false)` rejects, `(0xFF, false)` rejects.
+
+**Type-driven changes (compiler is the test):**
+
+- API rename (3.4.1).
+- `session.source` → `session.detectedSource` plumbing (3.4.3).
+
+**Coverage gap accepted, documented in release notes:**
+
+- Unknown FS F bytes for empty-tray, jam, mid-feed, panel-conflict. Unit test pins the *rejection* shape for two unknown bytes; the actual values produced by real WF-3620 firmware in those states are unknown until captures arrive. Strict-fail with the verbose error message is the safety net; `LEGACY_FORCE_SOURCE` is the immediate workaround.
+- `dispatchScanSession` itself remains untested at unit level (deferred-tech-debt item from `.reference/next-steps.md`). Folds naturally into v0.4.0's engine extraction.
+
+**CI gate:** unchanged. `npm run lint`, `npm run format:check`, `npm test` on every PR to `dev`/`main`. Pre-push hook mirrors. Test count target ~285, up from current 271.
+
+## 5. v0.4.0 — roadmap
+
+Sequenced milestones; each = one PR back to the long-lived `feature/v0.4.0-architecture` branch off `dev`. Sized in calendar days assuming focused work. Sequential dependencies marked.
+
+**M1 — Shared scan-session engine** (~2 days, prerequisite for M2/M3)
+New module `src/scan-session.ts`. Owns: socket factory injection, recv-buffer accumulator (the deferred-concat shape from `scanner.ts`, not the per-event concat from `scanner-legacy.ts`), IS-packet pump, single rolling timeout, page-flush hook (`(jpeg: Buffer, side: 'front' | 'back') => Promise<void>`), back-page index tracking, EXIF orientation injection for back pages, `setImmediate → finalizeSession` tail. Each consumer scanner supplies a state-graph definition + a per-page-encode strategy. The structured `{ ok, reason? }` result shape from the architecture review can land here as the engine's return type, replacing the v0.3.0 reject-on-error contract on the engine boundary.
+
+**M2 — `scanner.ts` refactor onto engine** (~1 day, blocked by M1)
+Salvage the existing state machine. Add `awaitAck(next, sendNext)` and `statThenDrain(onDone)` helpers; collapse 32 states to ~12 via declarative state graph. Replay tests pin every byte; drift surfaces immediately.
+
+**M3 — `scanner-legacy.ts` rewrite onto engine** (~2-3 days, blocked by M1; can run parallel to M2)
+Full rewrite. Pull image-chunk encoding into a separate page-assembler object. Fold the five `ESC e + param + double-ACK` pairs into one `escEThenAck(source, next)` helper. Encode ADF vs flatbed as alternative paths in the state graph, not dedicated states. Drop the `getState()` type-system workaround. Replay fixtures from PR #25 plus the new shape from v0.3.0 #28 are the regression shield.
+
+**M4 — Issue #27 patch-sampling regression oracle** (~3-4 days, parallel to M3)
+First step: its own mini-brainstorm covering the open fixture-storage decision (gitignored / Git LFS / compressed in-repo / JSONL extension / hybrid downsampled-preview). Once settled: ΔE2000 colour-patch checks on the 12 RGB swatches in `compatibility-test-page.pdf`, geometry detection on the four corner crosshairs, per-row variance for stripe/smear, channel-equal mean for the three grey patches, duplex-back-page rotation check. One real-hardware capture exercises both M3's rewrite and future protocol edits. Slot recommendation: start the design brainstorm during M2, capture hardware during M3, code the oracle while M3 is in review.
+
+**M5 — PARA payload dedup in `esci.ts`** (~half-day, independent of M1-M4)
+Extract the 928-byte shared tail; assemble per-source variants programmatically with `Buffer.concat`. The three meaningful deltas (`#ADF` vs `#FB ` token, `#PAGd000` block in ADF only, `#ACQi` start-offset value) become explicit. Replay tests pin the wire bytes byte-for-byte. Can land any time after v0.3.0.
+
+**M6 — Remaining YAGNI / module-scoped cleanups** (~half-day)
+- Replace `__resetShutdownStateForTesting` with deps-injected state on `ShutdownDeps`.
+- Bind `src/health.ts` to `127.0.0.1` by default with opt-in `HEALTH_BIND_HOST` for LAN exposure (the CLAUDE.md-acknowledged "binds to all interfaces" gap; this is a behaviour change worth flagging in v0.4.0 release notes).
+- Inline `safeInspect` if it's still a one-call helper after the engine work.
+
+**M7 — v0.4.0 release notes + version bump** (last)
+Substantive headline: "internal architecture rebuild + WF-3620 quality oracle". Note `health.ts` binding default change as a behaviour change.
+
+**Total v0.4.0 sizing:** ~2-3 weeks calendar. Critical path is M1 → M3. M2, M4, M5 are parallelisable.
+
+## 6. Risks
+
+**v0.3.0 risks:**
+
+- *Unknown FS F bytes hit real users.* Strict-fail with verbose error message points at CONTRIBUTING.md; `LEGACY_FORCE_SOURCE` is the immediate workaround. A compatibility issue from a user surfaces the next state to capture and ships in a v0.3.x point release.
+- *Promise-contract change breaks daemon error tolerance.* Test that `inflight.track` continues to swallow rejections (no process-level crash); test that one-shot now exits non-zero on cert-fingerprint mismatch.
+- *Real-hardware test against maltris's WF-3620 (gate for issue #24).* Out of our control; can be done before or after the v0.3.0 cut. The cut itself doesn't strictly depend on this — it depends on #28 landing in `dev` with replay tests green. Closing #24 is the social/release-notes signal that WF-3620 is supported, and may be a separate moment.
+
+**v0.4.0 risks:**
+
+- *Feature branch drifts from `dev` over 2-3 weeks.* Mitigation: small/frequent merges *into* the feature branch from `dev` (rather than rebasing). Each milestone PR gets reviewed and merged back to `dev` immediately when green; only the final v0.4.0 cut is `dev → main`.
+- *M3 scanner-legacy rewrite breaks pixel content the replay tests don't catch.* Exactly what M4 (#27 oracle) is designed to catch. Slot M4 to start *during* M3 so the oracle is ready when M3's PR review needs it.
+- *Engine API gets the contract wrong, both scanners pay.* Mitigation: M1 is built test-first against scaffolding tests (no protocol bytes). M2 + M3 don't start until M1's interface is shaped and reviewed. If the interface needs a change after M2/M3 work begins, the change is a small refactor, not a redesign.
+
+## 7. Branch / CI strategy
+
+- v0.3.0: short-lived `feature/v0.3.0-wf3620-autodetect` off `dev`. Five workstreams (3.1-3.5); workstream 3.4 splits into four sub-PRs, the others are one PR each — eight PRs back to `dev` total. Single `dev → main` PR for the release. Tag `v0.3.0`.
+- v0.4.0: long-lived `feature/v0.4.0-architecture` off `dev`. ~7 milestone PRs back to `dev`. Single `dev → main` PR for the release. Tag `v0.4.0`.
+- Existing CI gate (`lint`, `format:check`, `test`) runs unchanged on every PR. Pre-push hook (`.githooks/pre-push`) mirrors. Docker workflow (`.github/workflows/docker.yml`) auto-publishes on the `v0.3.0` and `v0.4.0` tags.
+
+## 8. Sequencing summary
+
+```
+v0.3.0 (target: ≤ 1 week elapsed)
+  feature/v0.3.0-wf3620-autodetect off dev
+   ├─ PR1: KISS/DRY/YAGNI sweep 1 (3.1)
+   ├─ PR2: cert-pinning superRefine (3.2)
+   ├─ PR3: promise-contract reconciliation (3.3)
+   ├─ PR4: #28.1 API change
+   ├─ PR5: #28.2 detection rule + new unit test
+   ├─ PR6: #28.3 downstream rewrite
+   ├─ PR7: #28.4 replay-test rework
+   └─ PR8: release notes + version bump (3.5)
+  → dev → main → tag v0.3.0
+
+v0.4.0 (target: 2-3 weeks elapsed)
+  feature/v0.4.0-architecture off dev
+   ├─ PR1: M1 shared scan-session engine
+   ├─ PR2: M2 scanner.ts refactor onto engine        (parallel to PR3, PR4)
+   ├─ PR3: M3 scanner-legacy.ts rewrite onto engine  (parallel to PR2, PR4)
+   ├─ PR4: M4 #27 patch-sampling oracle              (parallel to PR2, PR3)
+   ├─ PR5: M5 PARA payload dedup
+   ├─ PR6: M6 misc YAGNI / health.ts bind / safeInspect
+   └─ PR7: M7 release notes + version bump
+  → dev → main → tag v0.4.0
+```


### PR DESCRIPTION
## Summary

Adds \`AGENTS.md\` to \`.gitignore\` parallel to the existing \`CLAUDE.local.md\` entry. \`AGENTS.md\` is the Codex tooling equivalent — keeps the user's local file out of the tracked tree.

Independent of the v0.3.0 stack (PRs #29-#33); can land any time.

## Test plan

- [ ] CI green (one-line gitignore change; lint + format:check + test all unaffected)