### PR TITLE
fix(scanner): reconcile promise-contract; reject on hard errors (re-merge of #31)

### DIFF
--- a/src/scanner-legacy.test.ts
+++ b/src/scanner-legacy.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import { fileURLToPath } from "node:url";
 import { PDFDocument } from "pdf-lib";
 import { startScanSessionLegacy, appendImageChunk } from "./scanner-legacy.js";
-import { parseIsPacket } from "./protocol.js";
+import { parseIsPacket, buildIsPacket } from "./protocol.js";
 import { FakeTcpSocket } from "./test-support/fake-tcp-socket.js";
 import { loadFixture, driveFixture } from "./test-support/legacy-replay.js";
 
@@ -387,5 +387,61 @@ describe("appendImageChunk", () => {
     const offset = appendImageChunk(Buffer.from([0x01]), dest, 1);
     expect(offset).toBe(1);
     expect(Array.from(dest)).toEqual([0xee, 0xee, 0xee, 0xee]);
+  });
+});
+
+describe("startScanSessionLegacy failure-mode matrix", () => {
+  let outputDir: string;
+  let tempDir: string;
+
+  beforeEach(() => {
+    outputDir = mkdtempSync(path.join(os.tmpdir(), "leg-out-"));
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "leg-tmp-"));
+  });
+
+  afterEach(() => {
+    rmSync(outputDir, { recursive: true, force: true });
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("rejects on socket error mid-session", async () => {
+    const fake = new FakeTcpSocket();
+    const scanPromise = startScanSessionLegacy(
+      {
+        printerIp: "1.2.3.4",
+        port: 1865,
+        outputDir,
+        tempDir,
+        source: "adf-simplex",
+        format: "jpg",
+        jpegQuality: 90,
+      },
+      fake.asFactory(),
+    );
+    fake.simulateConnect();
+    fake.emit("error", new Error("ECONNREFUSED"));
+    await expect(scanPromise).rejects.toThrow(/socket error|ECONNREFUSED/i);
+  });
+
+  it("rejects on protocol violation (welcome with wrong packet type)", async () => {
+    const fake = new FakeTcpSocket();
+    const scanPromise = startScanSessionLegacy(
+      {
+        printerIp: "1.2.3.4",
+        port: 1865,
+        outputDir,
+        tempDir,
+        source: "adf-simplex",
+        format: "jpg",
+        jpegQuality: 90,
+      },
+      fake.asFactory(),
+    );
+    fake.simulateConnect();
+    // WELCOME state expects type 0x8000 (scanner-legacy.ts:247).
+    // Feed type 0xa000 — fail() rejects with "expected welcome (0x8000), got 0xa000".
+    // (Raw garbage that doesn't form a valid IS header would just buffer until timeout.)
+    fake.feed(buildIsPacket(0xa000, Buffer.alloc(0)));
+    await expect(scanPromise).rejects.toThrow(/expected welcome \(0x8000\)/);
   });
 });

--- a/src/scanner-legacy.ts
+++ b/src/scanner-legacy.ts
@@ -790,7 +790,16 @@ export function startScanSessionLegacy(
           backPageIndices,
           paperless: session.paperless,
         })
-          .catch((err: unknown) => log.error(`finalizeSession failed: ${String(err)}`))
+          .catch((err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            log.error(`finalizeSession failed: ${msg}`);
+            // Symmetric with scanner.ts D.3: a finalize failure means no
+            // completed scan was saved, so reject — don't let the .finally
+            // resolveOnce silently mask it. failOnce sets errorReason and
+            // rejects via the resolved-guard; the .finally resolveOnce is
+            // then a no-op.
+            failOnce(new Error(`finalizeSession failure: ${msg}`));
+          })
           .finally(() => resolveOnce());
       });
     }

--- a/src/scanner-legacy.ts
+++ b/src/scanner-legacy.ts
@@ -141,6 +141,7 @@ export function startScanSessionLegacy(
     let buffer = Buffer.alloc(0);
     let timeoutTimer: NodeJS.Timeout | null = null;
     let resolved = false;
+    let errorReason: Error | null = null;
 
     let fsGReply: ReturnType<typeof parseFsGReply> | null = null;
     let imageBuffer = Buffer.alloc(0);
@@ -180,10 +181,12 @@ export function startScanSessionLegacy(
       resolve();
     }
 
-    function fail(reason: string): void {
+    function failOnce(err: Error): void {
+      if (errorReason) return;
+      errorReason = err;
       if (state === "ERROR") return;
       state = "ERROR";
-      log.error(`State machine error: ${reason}`);
+      log.error(`State machine error: ${err.message}`);
       if (timeoutTimer) clearTimeout(timeoutTimer);
       try {
         socket.destroy();
@@ -197,7 +200,10 @@ export function startScanSessionLegacy(
       }
       if (resolved) return;
       resolved = true;
-      reject(new Error(reason));
+      reject(err);
+    }
+    function fail(reason: string): void {
+      failOnce(new Error(reason));
     }
 
     function armTimeout(): void {

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { readFileSync, readdirSync, mkdtempSync, rmSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
@@ -496,6 +496,9 @@ describe("scanner targeted tests — error paths", () => {
       },
       fake.asFactory(),
     );
+    // Attach the rejection handler before feeding the fatal packet so the
+    // rejection isn't momentarily unhandled (FakeTlsSocket.destroy() is sync).
+    const rejectsAssertion = expect(sessionPromise).rejects.toThrow(/fatal/i);
     fake.simulateConnect();
     fake.feed(buildIsPacket(0x8000));
     await new Promise((r) => setImmediate(r));
@@ -505,8 +508,7 @@ describe("scanner targeted tests — error paths", () => {
     const lastWrite = fake.writes[fake.writes.length - 1];
     expect(lastWrite.readUInt16BE(2)).toBe(0x2101); // UNLOCK packet type
 
-    fake.emit("close");
-    await expect(sessionPromise).resolves.toBeUndefined();
+    await rejectsAssertion;
   });
 
   it("aborts on unexpected IS type received mid-session", async () => {
@@ -523,6 +525,8 @@ describe("scanner targeted tests — error paths", () => {
       },
       fake.asFactory(),
     );
+    // Attach the rejection handler before feeding the error-causing packet.
+    const rejectsAssertion = expect(sessionPromise).rejects.toThrow(/protocol error/i);
     fake.simulateConnect();
     fake.feed(buildIsPacket(0x8000));
     await new Promise((r) => setImmediate(r));
@@ -534,11 +538,10 @@ describe("scanner targeted tests — error paths", () => {
     const sawUnlock = postErrorWrites.some((w) => w.length >= 4 && w.readUInt16BE(2) === 0x2101);
     expect(sawUnlock).toBe(true);
 
-    fake.emit("close");
-    await expect(sessionPromise).resolves.toBeUndefined();
+    await rejectsAssertion;
   });
 
-  it("socket 'error' event triggers transitionToError and resolves the promise", async () => {
+  it("socket 'error' event triggers transitionToError and rejects the promise", async () => {
     const fake = new FakeTlsSocket();
     const sessionPromise = startScanSession(
       {
@@ -552,16 +555,17 @@ describe("scanner targeted tests — error paths", () => {
       },
       fake.asFactory(),
     );
+    // Attach the rejection handler before emitting the error so the
+    // rejection isn't momentarily unhandled (FakeTlsSocket.destroy() is sync).
+    const rejectsAssertion = expect(sessionPromise).rejects.toThrow(/TLS connection error/i);
     fake.simulateConnect();
     fake.feed(buildIsPacket(0x8000));
     await new Promise((r) => setImmediate(r));
     // Simulate a mid-scan socket error (e.g., printer reboots).
     fake.emit("error", Object.assign(new Error("EPIPE"), { code: "EPIPE" }));
     await new Promise((r) => setImmediate(r));
-    // Simulate the socket's subsequent close event.
-    fake.emit("close");
-    // The promise should resolve (not reject) after close.
-    await expect(sessionPromise).resolves.toBeUndefined();
+    // The promise should reject with a classified error message.
+    await rejectsAssertion;
     // Last write should be the UNLOCK packet, proving transitionToError ran.
     const lastWrite = fake.writes[fake.writes.length - 1];
     expect(lastWrite.readUInt16BE(2)).toBe(0x2101);
@@ -590,8 +594,13 @@ describe("scanner source detection from first @STAT reply", () => {
     if (!paraBodyWrite) {
       throw new Error("scanner hasn't written a PARA body yet");
     }
+    // Attach the rejection handler before feeding the fatal packet so the
+    // rejection isn't momentarily unhandled (FakeTlsSocket.destroy() is sync).
+    const settle = sessionPromise.catch(() => {
+      /* expected: async fatal triggers rejection */
+    });
     fake.feed(buildIsPacket(0x9000, Buffer.from([0xa0])));
-    await sessionPromise;
+    await settle;
     return paraBodyWrite;
   }
 
@@ -635,8 +644,12 @@ describe("scanner IMG-loop termination", () => {
     // name at bytes 20-23. @FIN = "FIN "; @IMG = "IMG ".
     const lastName = fake.writes[fake.writes.length - 1].subarray(20, 24).toString("ascii");
     expect(lastName).toBe("FIN ");
+    // Attach handler before feeding the fatal packet to avoid unhandled rejection.
+    const settle = sessionPromise.catch(() => {
+      /* expected: async fatal triggers rejection */
+    });
     fake.feed(buildIsPacket(0x9000, Buffer.from([0xa0])));
-    await sessionPromise;
+    await settle;
   });
 
   it("still treats #pen without #lft as a page boundary for ADF", async () => {
@@ -645,8 +658,12 @@ describe("scanner IMG-loop termination", () => {
     const { fake, sessionPromise } = await drivePastImgTerminator(outputDir, "STATx0000000");
     const lastName = fake.writes[fake.writes.length - 1].subarray(20, 24).toString("ascii");
     expect(lastName).toBe("IMG ");
+    // Attach handler before feeding the fatal packet to avoid unhandled rejection.
+    const settle = sessionPromise.catch(() => {
+      /* expected: async fatal triggers rejection */
+    });
     fake.feed(buildIsPacket(0x9000, Buffer.from([0xa0])));
-    await sessionPromise;
+    await settle;
   });
 });
 
@@ -779,5 +796,139 @@ describe("startScanSession failure-mode matrix", () => {
       fake.asFactory(),
     );
     await expect(scanPromise).rejects.toThrow(/temp dir/i);
+  });
+
+  it("rejects on timeout (no response in TIMEOUT_MS)", async () => {
+    // CRITICAL: install fake timers BEFORE startScanSession runs. The scanner
+    // schedules a setTimeout(TIMEOUT_MS) inside the connect callback fired by
+    // simulateConnect(); if useFakeTimers is called after, the real timer is
+    // already armed and advancing fake timers won't fire it.
+    vi.useFakeTimers();
+    try {
+      const fake = new FakeTlsSocket();
+      const scanPromise = startScanSession(
+        {
+          printerIp: "1.2.3.4",
+          port: 1865,
+          destId: 0x02,
+          outputDir: "/tmp",
+          tempDir: "/tmp",
+          duplex: false,
+          action: "jpg",
+          paperless: undefined,
+        },
+        fake.asFactory(),
+      );
+      fake.simulateConnect();
+      // Attach the rejection handler before advancing fake timers so the
+      // rejection isn't momentarily unhandled (FakeTlsSocket.destroy() is sync,
+      // so the close event fires inside advanceTimersByTimeAsync).
+      const rejectsAssertion = expect(scanPromise).rejects.toThrow(/timeout/i);
+      // TIMEOUT_MS is 30_000 in scanner.ts (line 113); 60_000 overshoots safely.
+      await vi.advanceTimersByTimeAsync(60_000);
+      await rejectsAssertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects on socket error mid-session", async () => {
+    const fake = new FakeTlsSocket();
+    const scanPromise = startScanSession(
+      {
+        printerIp: "1.2.3.4",
+        port: 1865,
+        destId: 0x02,
+        outputDir: "/tmp",
+        tempDir: "/tmp",
+        duplex: false,
+        action: "jpg",
+        paperless: undefined,
+      },
+      fake.asFactory(),
+    );
+    fake.simulateConnect();
+    // Attach handler before emitting the error — FakeTlsSocket.destroy() fires
+    // "close" synchronously, which rejects the promise inside the emit call.
+    const rejectsAssertion = expect(scanPromise).rejects.toThrow(/ECONNREFUSED/);
+    fake.emit("error", Object.assign(new Error("ECONNREFUSED"), { code: "ECONNREFUSED" }));
+    await rejectsAssertion;
+  });
+
+  it("rejects on async ScanCancel event mid-session", async () => {
+    const fake = new FakeTlsSocket();
+    const scanPromise = startScanSession(
+      {
+        printerIp: "1.2.3.4",
+        port: 1865,
+        destId: 0x02,
+        outputDir: "/tmp",
+        tempDir: "/tmp",
+        duplex: false,
+        action: "jpg",
+        paperless: undefined,
+      },
+      fake.asFactory(),
+    );
+    fake.simulateConnect();
+    // Attach handler before feeding — FakeTlsSocket.destroy() fires "close"
+    // synchronously, rejecting the promise inside fake.feed().
+    const cancelPacket = buildIsPacket(0x9000, Buffer.from([0x03]));
+    const rejectsAssertion = expect(scanPromise).rejects.toThrow(/ScanCancel/);
+    fake.feed(cancelPacket);
+    await rejectsAssertion;
+  });
+
+  it("rejects on async fatal event mid-session", async () => {
+    const fake = new FakeTlsSocket();
+    const scanPromise = startScanSession(
+      {
+        printerIp: "1.2.3.4",
+        port: 1865,
+        destId: 0x02,
+        outputDir: "/tmp",
+        tempDir: "/tmp",
+        duplex: false,
+        action: "jpg",
+        paperless: undefined,
+      },
+      fake.asFactory(),
+    );
+    fake.simulateConnect();
+    // ASYNC_FATAL in scanner.ts:124 contains 0x02 (Disconnect), 0x80 (Timeout),
+    // 0xa0 (ServerError). Use 0x02. (0x05 is "unknown" and falls through to
+    // log.warn with no rejection.)
+    const fatalPacket = buildIsPacket(0x9000, Buffer.from([0x02]));
+    // Attach handler before feeding — FakeTlsSocket.destroy() fires "close"
+    // synchronously, rejecting the promise inside fake.feed().
+    const rejectsAssertion = expect(scanPromise).rejects.toThrow(/fatal/i);
+    fake.feed(fatalPacket);
+    await rejectsAssertion;
+  });
+
+  it("rejects on per-state assertion failure (unexpected packet type)", async () => {
+    const fake = new FakeTlsSocket();
+    const scanPromise = startScanSession(
+      {
+        printerIp: "1.2.3.4",
+        port: 1865,
+        destId: 0x02,
+        outputDir: "/tmp",
+        tempDir: "/tmp",
+        duplex: false,
+        action: "jpg",
+        paperless: undefined,
+      },
+      fake.asFactory(),
+    );
+    fake.simulateConnect();
+    // Feed a packet whose type doesn't match the WELCOME state's expectation.
+    // WELCOME expects type 0x8000. Feed type 0xa999 to force ensure(...) to fail.
+    const wrongTypePacket = buildIsPacket(0xa999, Buffer.alloc(0));
+    // Attach handler before feeding — FakeTlsSocket.destroy() fires "close"
+    // synchronously, rejecting the promise inside fake.feed().
+    const rejectsAssertion = expect(scanPromise).rejects.toThrow(/protocol error/i);
+    fake.feed(wrongTypePacket);
+    await rejectsAssertion;
   });
 });

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -735,7 +735,49 @@ describe("startScanSession — printer cert pinning", () => {
     );
 
     fake.simulateConnect();
-    await done;
+    await expect(done).rejects.toThrow(/fingerprint mismatch/i);
     expect(fake.writes.length).toBe(0);
+  });
+});
+
+describe("startScanSession failure-mode matrix", () => {
+  it("rejects when the printer cert fingerprint does not match the pin", async () => {
+    const fake = new FakeTlsSocket();
+    fake.setPeerCertificate("AA:BB:CC"); // FakeTlsSocket.setPeerCertificate takes a string
+    const scanPromise = startScanSession(
+      {
+        printerIp: "1.2.3.4",
+        port: 1865,
+        destId: 0x02,
+        outputDir: "/tmp/out-doesnotmatter",
+        tempDir: "/tmp",
+        duplex: false,
+        action: "jpg",
+        paperless: undefined,
+        printerCertFingerprint: "DE:AD:BE:EF",
+      },
+      fake.asFactory(),
+    );
+    fake.simulateConnect();
+    await expect(scanPromise).rejects.toThrow(/fingerprint mismatch/i);
+  });
+
+  it("rejects when the session temp dir cannot be created", async () => {
+    const fake = new FakeTlsSocket();
+    // tempDir points at a path that mkdtempSync cannot resolve.
+    const scanPromise = startScanSession(
+      {
+        printerIp: "1.2.3.4",
+        port: 1865,
+        destId: 0x02,
+        outputDir: "/tmp/out-doesnotmatter",
+        tempDir: "/this/path/definitely/does/not/exist",
+        duplex: false,
+        action: "jpg",
+        paperless: undefined,
+      },
+      fake.asFactory(),
+    );
+    await expect(scanPromise).rejects.toThrow(/temp dir/i);
   });
 });

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -141,7 +141,6 @@ export function startScanSession(
       resolved = true;
       reject(err);
     };
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const failOnce = (err: Error): void => {
       if (errorReason) return; // first-error wins
       errorReason = err;
@@ -197,8 +196,9 @@ export function startScanSession(
     const resetTimeout = () => {
       if (timeoutTimer) clearTimeout(timeoutTimer);
       timeoutTimer = setTimeout(() => {
-        log.error(`Timeout in state ${state} — no response in ${TIMEOUT_MS}ms`);
-        transitionToError();
+        const msg = `Timeout in state ${state} — no response in ${TIMEOUT_MS}ms`;
+        log.error(msg);
+        failOnce(new Error(msg));
       }, TIMEOUT_MS);
     };
 
@@ -308,7 +308,7 @@ export function startScanSession(
       log.error(`TLS connection error in state ${state}`, err);
       clearTimeoutTimer();
       if (state !== "DONE") {
-        transitionToError();
+        failOnce(new Error(`TLS connection error in state ${state}: ${err.message}`));
       }
     });
 
@@ -370,10 +370,10 @@ export function startScanSession(
         log.info("Async event: Stop (0x04)");
       } else if (ASYNC_CANCEL.has(dispatch)) {
         log.warn(`Async event: ScanCancel (0x${dispatch.toString(16)}) — aborting`);
-        transitionToError();
+        failOnce(new Error(`Async ScanCancel (0x${dispatch.toString(16)}) during state ${state}`));
       } else if (ASYNC_FATAL.has(dispatch)) {
         log.error(`Async event: fatal (0x${dispatch.toString(16)}) — aborting`);
-        transitionToError();
+        failOnce(new Error(`Async fatal event 0x${dispatch.toString(16)} during state ${state}`));
       } else {
         log.warn(`Async event: unknown dispatch byte 0x${dispatch.toString(16)}`);
       }
@@ -454,7 +454,7 @@ export function startScanSession(
     function ensure(condition: boolean, message: string): boolean {
       if (!condition) {
         log.error(message);
-        transitionToError();
+        failOnce(new Error(`Protocol error in state ${state}: ${message}`));
         return false;
       }
       return true;

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -128,12 +128,24 @@ export function startScanSession(
   session: ScanSession,
   socketFactory: TlsSocketFactory = tls.connect,
 ): Promise<void> {
-  return new Promise<void>((resolve) => {
+  return new Promise<void>((resolve, reject) => {
+    let errorReason: Error | null = null;
     let resolved = false;
     const resolveOnce = (): void => {
       if (resolved) return;
       resolved = true;
       resolve();
+    };
+    const rejectOnce = (err: Error): void => {
+      if (resolved) return;
+      resolved = true;
+      reject(err);
+    };
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const failOnce = (err: Error): void => {
+      if (errorReason) return; // first-error wins
+      errorReason = err;
+      transitionToError(); // existing helper triggers the close cascade
     };
 
     let state: State = "CONNECTING";
@@ -152,7 +164,7 @@ export function startScanSession(
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.error(`Failed to create session temp dir under ${tempBase}: ${msg}. Aborting scan.`);
-      resolveOnce();
+      rejectOnce(new Error(`Failed to create session temp dir under ${tempBase}: ${msg}`));
       return; // never start the TLS session
     }
     log.debug(`Session temp dir: ${sessionTempDir}`);
@@ -213,10 +225,11 @@ export function startScanSession(
           const peer = socket.getPeerCertificate();
           const actual = peer?.fingerprint256;
           if (actual !== session.printerCertFingerprint) {
-            log.error(
+            const msg =
               `Printer cert fingerprint mismatch — expected ${session.printerCertFingerprint}, ` +
-                `got ${actual ?? "(none)"} — aborting scan`,
-            );
+              `got ${actual ?? "(none)"}`;
+            log.error(`${msg} — aborting scan`);
+            errorReason = new Error(msg);
             state = "ERROR";
             clearTimeoutTimer();
             try {
@@ -225,9 +238,7 @@ export function startScanSession(
               /* ignore — cleanup best-effort */
             }
             socket.destroy();
-            // Don't call transitionToError() — it sends an UNLOCK packet, but
-            // we never sent the LOCK (we're aborting at handshake). The
-            // socket's "close" handler resolves the outer promise.
+            // Close handler reads errorReason and rejects.
             return;
           }
           log.debug(`Printer cert fingerprint verified: ${actual}`);
@@ -304,7 +315,8 @@ export function startScanSession(
     socket.on("close", () => {
       clearTimeoutTimer();
       log.info("TLS connection closed");
-      resolveOnce();
+      if (errorReason) rejectOnce(errorReason);
+      else resolveOnce();
     });
 
     function processBuffer(): void {

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -824,8 +824,9 @@ export function startScanSession(
       // Surface any error markers from the printer.
       for (const key of tokens.keys()) {
         if (key.startsWith("ERR") || key.startsWith("err")) {
-          log.error(`IMG_META: printer error token #${key}${tokens.get(key)}`);
-          transitionToError();
+          const msg = `IMG_META: printer error token #${key}${tokens.get(key)}`;
+          log.error(msg);
+          failOnce(new Error(msg));
           return;
         }
       }

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -163,6 +163,7 @@ export function startScanSession(
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.error(`Failed to create session temp dir under ${tempBase}: ${msg}. Aborting scan.`);
+      // rejectOnce direct — no socket open yet, so no close cascade to drive.
       rejectOnce(new Error(`Failed to create session temp dir under ${tempBase}: ${msg}`));
       return; // never start the TLS session
     }
@@ -229,6 +230,9 @@ export function startScanSession(
               `Printer cert fingerprint mismatch — expected ${session.printerCertFingerprint}, ` +
               `got ${actual ?? "(none)"}`;
             log.error(`${msg} — aborting scan`);
+            // errorReason direct (not failOnce) — failOnce would call transitionToError,
+            // which sends UNLOCK; we never sent LOCK (abort at handshake), so we do the
+            // cleanup manually and let the close handler reject.
             errorReason = new Error(msg);
             state = "ERROR";
             clearTimeoutTimer();
@@ -268,6 +272,9 @@ export function startScanSession(
       state = "ERROR";
       if (inPostScan && imageChunks.length > 0) {
         log.warn(`Error during post-scan cleanup in ${priorState} — saving captured image anyway`);
+        // Cleanup-state error after the IMG loop succeeded is treated as success;
+        // clear any error captured during cleanup so the close handler resolves.
+        errorReason = null;
         finalizeScan();
         return;
       }
@@ -986,11 +993,18 @@ export function startScanSession(
       // Verified via Wireshark: the Windows driver FINs ~27 µs after the
       // UNLOCK ack; our earlier post-unlock blocking writeFileSync delayed
       // the FIN by ~1 ms, which was enough for the printer to RST first.
-      socket.end();
       if (imageChunks.length === 0) {
         log.error("Scan completed with zero image chunks");
+        // rejectOnce BEFORE socket.end(): on a real TLS socket end() is async, but
+        // FakeTlsSocket.end() emits "close" synchronously — the close handler
+        // would call resolveOnce() before we ever set errorReason. Reject up
+        // front; socket.end() afterwards just cleans up the socket (resolveOnce
+        // in the close handler will be a no-op via the `resolved` guard).
+        rejectOnce(new Error("Scan completed with zero image chunks"));
+        socket.end();
         return;
       }
+      socket.end();
       setImmediate(() => {
         flushCurrentPage();
         finalizeSession({
@@ -1004,8 +1018,11 @@ export function startScanSession(
           .catch((err: unknown) => {
             const msg = err instanceof Error ? err.message : String(err);
             log.error(`Unexpected finalizeScan failure: ${msg}`);
+            rejectOnce(new Error(`finalizeScan failure: ${msg}`));
           })
           .finally(() => {
+            // resolveOnce is a no-op if rejectOnce already ran (resolved guard);
+            // if finalize succeeded we resolve here.
             resolveOnce();
           });
       });


### PR DESCRIPTION
## Summary

Re-merge of PR #31 (auto-closed when its base \`feature/v0.3.0-wf3620-autodetect-cert\` was deleted by PR #30's merge). Brings the promise-contract reconciliation work to \`dev\`.

Five commits covering:
- D.1 — \`errorReason\` + \`failOnce\` + \`rejectOnce\` machinery; cert-mismatch + temp-dir migrations
- D.2 — timeout, socket error, async cancel/fatal, \`ensure()\` failure migrations + 5 new failure-mode-matrix tests
- D.3 — zero-image completion + \`finalizeSession\` failure migrations + post-scan-save fallback preservation guard
- D.4 — symmetric \`errorReason\` + \`failOnce\` shape in \`scanner-legacy.ts\` + 2 new matrix tests
- Review fix-up — two missed P1 sites caught by review (printer error tokens in IMG_META, legacy finalize-failure)

## Test impact

- 7 new failure-mode-matrix tests in \`scanner.test.ts\`
- 2 new matrix tests in \`scanner-legacy.test.ts\`
- 4 pre-existing tests updated (resolve→reject)
- All replay fixtures still byte-equivalent

Local count: 282 passing + 1 skipped (was 273 on dev post-#35).

## After merge

This will delete \`feature/v0.3.0-wf3620-autodetect-contract\` and auto-close PR #32 (which depends on it). Then I'll open a new PR for the FS F autodetection content.