### PR TITLE
docs(readme): move LEGACY_FORCE_SOURCE under Advanced

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Configuration is via environment variables. Only `PRINTER_IP` is required.
 | `LOG_LEVEL`        |          | `info`           | `debug` / `info` / `warn` / `error`.                                                                                                                    |
 | `LOG_FORMAT`       |          | `text`           | `text` (human-readable) or `json` (ndjson, one record per line — for `docker logs` + Loki / `jq`).                                                      |
 | `PREVIEW_ACTION`   |          | `reject`         | What to do when the panel's Action is "Preview on Computer": `reject` silently ignores the scan; `jpg` or `pdf` treats it as if that format was chosen. |
-| `PRINTER_PROTOCOL` |          | `auto`           | `auto` (TLS-probe each session), `esci2` (force ET-4950 mode), `legacy` (force WF-3620 mode).                                                           |
+| `PRINTER_PROTOCOL` |          | `auto`           | `auto` (TLS-probe each session), `esci2` (force ESC/I-2 over TLS), `legacy` (force plain-TCP ESC/I).                                                    |
 | `JPEG_QUALITY`     |          | `90`             | JPEG encoder quality 1–100 for the legacy (WF-3620) path.                                                                                               |
 | `TEMP_DIR`         |          | (system default) | Where per-scan temp files go. Leave empty for the OS default (`os.tmpdir()`). Override for Docker if `/tmp` is in memory.                               |
 | `HEALTH_PORT`      |          | `3000`           | HTTP port for the `/health` endpoint.                                                                                                                   |

--- a/README.md
+++ b/README.md
@@ -78,19 +78,18 @@ Within about 60 seconds, your destination (default `Paperless`) appears in the p
 
 Configuration is via environment variables. Only `PRINTER_IP` is required.
 
-| Variable              | Required | Default          | What it does                                                                                                                                                                                 |
-| --------------------- | -------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `PRINTER_IP`          | ✅       | —                | The printer's IPv4 address.                                                                                                                                                                  |
-| `SCAN_DEST_NAME`      |          | `Paperless`      | The label the printer shows on its panel.                                                                                                                                                    |
-| `OUTPUT_DIR`          |          | `/output`        | Where scans are written (JPG or PDF, depending on panel). Created automatically.                                                                                                             |
-| `LOG_LEVEL`           |          | `info`           | `debug` / `info` / `warn` / `error`.                                                                                                                                                         |
-| `LOG_FORMAT`          |          | `text`           | `text` (human-readable) or `json` (ndjson, one record per line — for `docker logs` + Loki / `jq`).                                                                                           |
-| `PREVIEW_ACTION`      |          | `reject`         | What to do when the panel's Action is "Preview on Computer": `reject` silently ignores the scan; `jpg` or `pdf` treats it as if that format was chosen.                                      |
-| `PRINTER_PROTOCOL`    |          | `auto`           | `auto` (TLS-probe each session), `esci2` (force ET-4950 mode), `legacy` (force WF-3620 mode).                                                                                                |
-| `JPEG_QUALITY`        |          | `90`             | JPEG encoder quality 1–100 for the legacy (WF-3620) path.                                                                                                                                    |
-| `LEGACY_FORCE_SOURCE` |          | —                | Diagnostic override for the legacy path when FS F autodetection misfires. Set to `flatbed`, `adf-simplex`, or `adf-duplex` to bypass the wire-byte detection. Normal users do not need this. |
-| `TEMP_DIR`            |          | (system default) | Where per-scan temp files go. Leave empty for the OS default (`os.tmpdir()`). Override for Docker if `/tmp` is in memory.                                                                    |
-| `HEALTH_PORT`         |          | `3000`           | HTTP port for the `/health` endpoint.                                                                                                                                                        |
+| Variable           | Required | Default          | What it does                                                                                                                                            |
+| ------------------ | -------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PRINTER_IP`       | ✅       | —                | The printer's IPv4 address.                                                                                                                             |
+| `SCAN_DEST_NAME`   |          | `Paperless`      | The label the printer shows on its panel.                                                                                                               |
+| `OUTPUT_DIR`       |          | `/output`        | Where scans are written (JPG or PDF, depending on panel). Created automatically.                                                                        |
+| `LOG_LEVEL`        |          | `info`           | `debug` / `info` / `warn` / `error`.                                                                                                                    |
+| `LOG_FORMAT`       |          | `text`           | `text` (human-readable) or `json` (ndjson, one record per line — for `docker logs` + Loki / `jq`).                                                      |
+| `PREVIEW_ACTION`   |          | `reject`         | What to do when the panel's Action is "Preview on Computer": `reject` silently ignores the scan; `jpg` or `pdf` treats it as if that format was chosen. |
+| `PRINTER_PROTOCOL` |          | `auto`           | `auto` (TLS-probe each session), `esci2` (force ET-4950 mode), `legacy` (force WF-3620 mode).                                                           |
+| `JPEG_QUALITY`     |          | `90`             | JPEG encoder quality 1–100 for the legacy (WF-3620) path.                                                                                               |
+| `TEMP_DIR`         |          | (system default) | Where per-scan temp files go. Leave empty for the OS default (`os.tmpdir()`). Override for Docker if `/tmp` is in memory.                               |
+| `HEALTH_PORT`      |          | `3000`           | HTTP port for the `/health` endpoint.                                                                                                                   |
 
 <details>
 <summary>Advanced (leave as default unless you know why)</summary>
@@ -99,6 +98,7 @@ Configuration is via environment variables. Only `PRINTER_IP` is required.
 | -------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `SCAN_DEST_ID`             | `0x02`  | Destination ID byte sent in keepalive packets.                                                                                                                                                             |
 | `LANGUAGE`                 | `en`    | 2-letter locale sent to the printer; no observed user-visible effect.                                                                                                                                      |
+| `LEGACY_FORCE_SOURCE`      | —       | Diagnostic override for the legacy path when FS F autodetection misfires. Set to `flatbed`, `adf-simplex`, or `adf-duplex` to bypass the wire-byte detection.                                              |
 | `PRINTER_CERT_FINGERPRINT` | —       | Optional SHA-256 fingerprint of the printer's TLS cert (e.g. `AB:CD:…`). When set, scans abort if the peer cert doesn't match. **Requires `PRINTER_PROTOCOL=esci2`** (auto-detection cannot pin reliably). |
 | `SHUTDOWN_TIMEOUT_MS`      | `30000` | ms to wait for an in-flight scan to finish on `SIGINT`/`SIGTERM` before forcing shutdown.                                                                                                                  |
 


### PR DESCRIPTION
## Summary

The \`LEGACY_FORCE_SOURCE\` row in the main env-var table currently ends with "Normal users do not need this." That's a natural fit for the **Advanced (leave as default unless you know why)** section instead — moving it lets us drop the trailing sentence (the section header conveys the same information).

Side effect: prettier re-tightens the main table's column widths now that \`LEGACY_FORCE_SOURCE\` (the longest variable name) is no longer there.

## Test plan

- [ ] CI green (docs-only)
- [ ] Reads naturally in the rendered preview