### PR TITLE
refactor: simplify v0.3.0 comments + use IS_HEADER_SIZE

### DIFF
--- a/src/paperless-upload.ts
+++ b/src/paperless-upload.ts
@@ -65,10 +65,8 @@ export async function uploadAllToPaperless(
   opts: PaperlessUploadOptions,
 ): Promise<void> {
   log.info(`Uploading ${filePaths.length} file(s) to Paperless-ngx`);
-  // Per-upload catch logs and swallows; Promise.all is safe because no
-  // mapped promise rejects. Decision: log-and-continue on any single
-  // upload failure — see paperless-upload.ts:56-60 for the broader
-  // "scan complete = local file written" policy.
+  // Per-upload .catch swallows so Promise.all never rejects — log-and-continue
+  // on any single failure (scan-complete = local file written).
   await Promise.all(
     filePaths.map((p) =>
       uploadOne(p, opts).catch((err: unknown) => {

--- a/src/scanner-legacy.test.ts
+++ b/src/scanner-legacy.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import { fileURLToPath } from "node:url";
 import { PDFDocument } from "pdf-lib";
 import { startScanSessionLegacy, appendImageChunk } from "./scanner-legacy.js";
-import { parseIsPacket, buildIsPacket } from "./protocol.js";
+import { parseIsPacket, buildIsPacket, IS_HEADER_SIZE } from "./protocol.js";
 import { FakeTcpSocket } from "./test-support/fake-tcp-socket.js";
 import { loadFixture, driveFixture } from "./test-support/legacy-replay.js";
 
@@ -402,8 +402,7 @@ describe("FS F unknown-byte handling", () => {
     const mutated = fixture.map((event) => {
       if (event.dir !== "p>h" || !("hex" in event)) return event;
       const buf = Buffer.from(event.hex, "hex");
-      // IS header is exactly 12 bytes with type at bytes 2-3 and payloadSize at 6-9.
-      if (buf.length === 12) {
+      if (buf.length === IS_HEADER_SIZE) {
         const type = buf.readUInt16BE(2);
         const length = buf.readUInt32BE(6);
         if (type === 0xa000 && length === 16) {

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -996,11 +996,11 @@ export function startScanSession(
       // the FIN by ~1 ms, which was enough for the printer to RST first.
       if (imageChunks.length === 0) {
         log.error("Scan completed with zero image chunks");
-        // rejectOnce BEFORE socket.end(): on a real TLS socket end() is async, but
-        // FakeTlsSocket.end() emits "close" synchronously — the close handler
-        // would call resolveOnce() before we ever set errorReason. Reject up
-        // front; socket.end() afterwards just cleans up the socket (resolveOnce
-        // in the close handler will be a no-op via the `resolved` guard).
+        // Reject immediately rather than via the close handler: clearTimeoutTimer
+        // already ran, so a stuck socket.end() (peer doesn't ack the FIN) would
+        // leave the promise pending forever. socket.end() afterwards is just
+        // socket cleanup; the close handler's resolveOnce() is a no-op via the
+        // resolved guard.
         rejectOnce(new Error("Scan completed with zero image chunks"));
         socket.end();
         return;
@@ -1022,8 +1022,6 @@ export function startScanSession(
             rejectOnce(new Error(`finalizeScan failure: ${msg}`));
           })
           .finally(() => {
-            // resolveOnce is a no-op if rejectOnce already ran (resolved guard);
-            // if finalize succeeded we resolve here.
             resolveOnce();
           });
       });


### PR DESCRIPTION
## Summary

Tiny simplify pass over the v0.3.0 stack:

- \`paperless-upload.ts\` — tighten the \`Promise.all\` rationale comment.
- \`scanner.ts\` — trim the zero-image \`rejectOnce\` comment; drop the redundant \`resolveOnce\`-no-op aside.
- \`scanner-legacy.test.ts\` — replace a magic \`buf.length === 12\` check with \`IS_HEADER_SIZE\` (already exported from \`protocol.ts\`).

No behavioural change.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` — 288 passed + 1 skipped