### PR TITLE
v0.3.1: protocol-diagnose mode for compatibility triage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ Noteworthy for dev:
 - `PRINTER_CERT_FINGERPRINT` — optional sha256 pin (32 colon-separated hex bytes) for the printer's TLS cert. When set, the scan session rejects any cert whose fingerprint doesn't match. Capture with `npm run printer-fingerprint`. ESC/I-2 path only — no effect on legacy (no TLS).
 - `PRINTER_PROTOCOL` (`auto` / `esci2` / `legacy`, default `auto`) — protocol generation selector. `auto` opens a TLS handshake and falls back to plain-TCP legacy on first-byte failure; `esci2` / `legacy` skip the probe.
 - `LEGACY_FORCE_SOURCE` (`adf-simplex` / `adf-duplex` / `flatbed`) — legacy path only. Overrides the FS W source byte when probe-based detection isn't enough. Zod-rejected when paired with `PRINTER_PROTOCOL=esci2`.
+- `DIAGNOSE_PROTOCOL=true` — compatibility-report aid. When the legacy `ESC @` init returns a non-ACK, sends one extra `FS Y` probe (the ET-4950 ESC/I-2 path's first command) and aborts with `[diagnose]` log lines tagged with the IS packet type and payload. Off by default; only useful when triaging an unknown printer that gets past welcome+lock.
 - `SHUTDOWN_TIMEOUT_MS` — how long graceful shutdown waits for in-flight scans before forcing exit (default 30000).
 
 ## Architecture (brief — full detail in `docs/HOW-IT-WORKS.md`)

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Configuration is via environment variables. Only `PRINTER_IP` is required.
 | `LANGUAGE`                 | `en`    | 2-letter locale sent to the printer; no observed user-visible effect.                                                                                                                                      |
 | `LEGACY_FORCE_SOURCE`      | —       | Diagnostic override for the legacy path when FS F autodetection misfires. Set to `flatbed`, `adf-simplex`, or `adf-duplex` to bypass the wire-byte detection.                                              |
 | `PRINTER_CERT_FINGERPRINT` | —       | Optional SHA-256 fingerprint of the printer's TLS cert (e.g. `AB:CD:…`). When set, scans abort if the peer cert doesn't match. **Requires `PRINTER_PROTOCOL=esci2`** (auto-detection cannot pin reliably). |
+| `DIAGNOSE_PROTOCOL`        | `false` | Compatibility-report aid. On a legacy `ESC @` non-ACK, sends one extra `FS Y` probe and aborts with annotated `[diagnose]` log lines. Leave off in normal use.                                             |
 | `SHUTDOWN_TIMEOUT_MS`      | `30000` | ms to wait for an in-flight scan to finish on `SIGINT`/`SIGTERM` before forcing shutdown.                                                                                                                  |
 
 </details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epson2paperless",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "epson2paperless",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "pdf-lib": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epson2paperless",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Epson Scan to Computer protocol emulator — delivers scans to Paperless-ngx",
   "main": "dist/index.js",
   "scripts": {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -302,6 +302,26 @@ describe("loadConfig", () => {
     process.env.LEGACY_FORCE_SOURCE = "flatbed";
     expect(() => loadConfig()).toThrow(/no effect/i);
   });
+
+  it("DIAGNOSE_PROTOCOL defaults to false", () => {
+    process.env.PRINTER_IP = "10.0.0.1";
+    delete process.env.DIAGNOSE_PROTOCOL;
+    expect(loadConfig().diagnoseProtocol).toBe(false);
+  });
+
+  it("DIAGNOSE_PROTOCOL accepts 'true'", () => {
+    process.env.PRINTER_IP = "10.0.0.1";
+    process.env.DIAGNOSE_PROTOCOL = "true";
+    expect(loadConfig().diagnoseProtocol).toBe(true);
+    delete process.env.DIAGNOSE_PROTOCOL;
+  });
+
+  it("DIAGNOSE_PROTOCOL anything other than 'true' is false", () => {
+    process.env.PRINTER_IP = "10.0.0.1";
+    process.env.DIAGNOSE_PROTOCOL = "yes";
+    expect(loadConfig().diagnoseProtocol).toBe(false);
+    delete process.env.DIAGNOSE_PROTOCOL;
+  });
 });
 
 describe("buildPaperlessOptions", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,12 @@ const configSchema = z
     previewAction: z.enum(["reject", "jpg", "pdf"]).default("reject"),
     legacyForceSource: z.enum(["flatbed", "adf-simplex", "adf-duplex"]).optional(),
     printerProtocol: z.enum(["auto", "esci2", "legacy"]).default("auto"),
+    // Diagnostic-only. When true and the legacy `ESC @` init returns a non-ACK,
+    // the legacy scanner sends one extra `FS Y` probe (the ET-4950 ESC/I-2 path's
+    // first command) before failing, and logs both replies in detail. Used to
+    // help classify unsupported printers that get past welcome+lock but reject
+    // `ESC @`. Should remain false in normal operation.
+    diagnoseProtocol: z.boolean().default(false),
     tempDir: z.string().default(""),
     shutdownTimeoutMs: z.coerce.number().int().min(100).default(30000),
     paperlessUrl: z.string().url("PAPERLESS_URL must be a valid URL").optional(),
@@ -101,6 +107,10 @@ export function loadConfig(): Config {
     legacyForceSource: process.env.LEGACY_FORCE_SOURCE || undefined,
     printerCertFingerprint: process.env.PRINTER_CERT_FINGERPRINT || undefined,
     printerProtocol: process.env.PRINTER_PROTOCOL || undefined,
+    diagnoseProtocol:
+      process.env.DIAGNOSE_PROTOCOL === undefined
+        ? undefined
+        : process.env.DIAGNOSE_PROTOCOL === "true",
   };
 
   return configSchema.parse(raw);

--- a/src/scanner-legacy-diagnose.test.ts
+++ b/src/scanner-legacy-diagnose.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { startScanSessionLegacy } from "./scanner-legacy.js";
+import { FakeTcpSocket } from "./test-support/fake-tcp-socket.js";
+import { buildIsPacket, parseIsPacket } from "./protocol.js";
+
+// Welcome and lock-ack helpers — same shape as the WF-3620 fixtures.
+const welcome = buildIsPacket(0x8000, Buffer.alloc(0));
+const lockAck = buildIsPacket(0xa100, Buffer.alloc(0));
+// Reply payload of a single byte 0x15 wrapped in the same IS-0xa000 sub-type
+// that ACKs use. Mirrors the ET-2750 report from issue #43.
+const nakReply = buildIsPacket(0xa000, Buffer.from([0x15]));
+const ackReply = buildIsPacket(0xa000, Buffer.from([0x06]));
+
+const ESC_AT = Buffer.from([0x1b, 0x40]);
+const FS_Y = Buffer.from([0x1c, 0x59]);
+
+function passthruCommand(buf: Buffer): Buffer {
+  // buildPassthruPacket prepends an 8-byte data header (cmd_size, reply_size)
+  // before the actual command bytes — extract those for assertions.
+  const pkt = parseIsPacket(buf);
+  if (!pkt || pkt.type !== 0x2000) throw new Error(`not a passthru packet: ${buf.toString("hex")}`);
+  return pkt.payload.subarray(8);
+}
+
+describe("scanner-legacy DIAGNOSE_PROTOCOL probe", () => {
+  it("sends FS Y after ESC @ NAK and rejects with a diagnostic message", async () => {
+    const fake = new FakeTcpSocket();
+    const promise = startScanSessionLegacy(
+      {
+        printerIp: "10.0.0.1",
+        port: 1865,
+        outputDir: "/tmp",
+        tempDir: "",
+        duplex: false,
+        forcedSource: "flatbed",
+        format: "pdf",
+        jpegQuality: 90,
+        diagnoseProtocol: true,
+      },
+      fake.asFactory(),
+    );
+
+    fake.simulateConnect();
+    fake.feed(welcome);
+    expect(parseIsPacket(fake.writes[0])?.type).toBe(0x2100); // lock packet
+    fake.feed(lockAck);
+    expect(passthruCommand(fake.writes[1]).equals(ESC_AT)).toBe(true);
+
+    // Printer NAKs ESC @ — diagnostic mode should send FS Y instead of failing.
+    fake.feed(nakReply);
+    expect(passthruCommand(fake.writes[2]).equals(FS_Y)).toBe(true);
+
+    // Printer ACKs FS Y — session still aborts, but with a diagnostic message.
+    fake.feed(ackReply);
+
+    await expect(promise).rejects.toThrow(/diagnostic probe complete/);
+  });
+
+  it("rejects with a diagnostic message even when FS Y is also NAK'd", async () => {
+    const fake = new FakeTcpSocket();
+    const promise = startScanSessionLegacy(
+      {
+        printerIp: "10.0.0.1",
+        port: 1865,
+        outputDir: "/tmp",
+        tempDir: "",
+        duplex: false,
+        forcedSource: "flatbed",
+        format: "pdf",
+        jpegQuality: 90,
+        diagnoseProtocol: true,
+      },
+      fake.asFactory(),
+    );
+
+    fake.simulateConnect();
+    fake.feed(welcome);
+    fake.feed(lockAck);
+    fake.feed(nakReply);
+    expect(passthruCommand(fake.writes[2]).equals(FS_Y)).toBe(true);
+
+    // Both legacy ESC @ and ESC/I-2 FS Y rejected — printer is in some other family.
+    fake.feed(nakReply);
+
+    await expect(promise).rejects.toThrow(/diagnostic probe complete/);
+  });
+
+  it("preserves existing behaviour when DIAGNOSE_PROTOCOL is off", async () => {
+    const fake = new FakeTcpSocket();
+    const promise = startScanSessionLegacy(
+      {
+        printerIp: "10.0.0.1",
+        port: 1865,
+        outputDir: "/tmp",
+        tempDir: "",
+        duplex: false,
+        forcedSource: "flatbed",
+        format: "pdf",
+        jpegQuality: 90,
+        // diagnoseProtocol omitted (defaults to undefined / false)
+      },
+      fake.asFactory(),
+    );
+
+    fake.simulateConnect();
+    fake.feed(welcome);
+    fake.feed(lockAck);
+    fake.feed(nakReply);
+
+    // No FS Y probe — only the lock packet and ESC @ should have been sent.
+    expect(fake.writes.length).toBe(2);
+    await expect(promise).rejects.toThrow(/expected ESC @ ack, got type=0xa000 payload=15/);
+  });
+});

--- a/src/scanner-legacy.ts
+++ b/src/scanner-legacy.ts
@@ -30,6 +30,10 @@ import {
   type Source,
   type Format,
 } from "./esci-legacy.js";
+// FS Y (0x1C 0x59) — first command in the ET-4950 ESC/I-2 init sequence
+// (see scanner.ts INIT1_FS_Y). Used here only by the DIAGNOSE_PROTOCOL probe
+// to classify printers that NAK `ESC @`.
+import { buildFsY } from "./esci.js";
 import { GAMMA_LUT_R, GAMMA_LUT_G, GAMMA_LUT_B } from "./esci-legacy-luts.js";
 import { encodeRawGbrToJpeg } from "./raw-to-jpeg.js";
 import { setJpegOrientation } from "./exif.js";
@@ -64,6 +68,13 @@ export interface LegacyScanSession {
   jpegQuality: number;
   paperless?: PaperlessUploadOptions;
   /**
+   * When true, a non-ACK reply to `ESC @` triggers one additional `FS Y` probe
+   * (the ET-4950 ESC/I-2 path's first command) before the session fails. Both
+   * replies are logged with full IS type + payload to aid protocol classification
+   * for unsupported printers. Set via the DIAGNOSE_PROTOCOL env var.
+   */
+  diagnoseProtocol?: boolean;
+  /**
    * Test-only hook fired once when STATUS_2 has decided the source (either
    * from the FS F byte via legacyDetectSource or from forcedSource). Lets
    * the replay-test matrix assert per-fixture detection without needing a
@@ -80,6 +91,10 @@ type State =
   | "WELCOME"
   | "LOCKING"
   | "INIT"
+  // Diagnostic-only: entered after `ESC @` is NAK'd when DIAGNOSE_PROTOCOL=true.
+  // We send `FS Y` (the ET-4950 ESC/I-2 init's first command) and log whatever
+  // comes back, then fail with a "diagnostic complete" message.
+  | "DIAGNOSE_INIT_PROBE"
   | "IDENTITY"
   | "STATUS_1A"
   | "STATUS_1B"
@@ -282,11 +297,40 @@ export function startScanSessionLegacy(
 
         case "INIT":
           // IS-0xa000 with payload = 0x06 (ACK for ESC @)
-          if (!isAck(pkt))
-            return fail(`expected ESC @ ack, got payload ${pkt.payload.toString("hex")}`);
+          if (!isAck(pkt)) {
+            const detail = `type=0x${pkt.type.toString(16)} payload=${pkt.payload.toString("hex")}`;
+            if (session.diagnoseProtocol) {
+              log.info(
+                `[diagnose] ESC @ returned non-ACK (${detail}) — sending FS Y probe to classify protocol`,
+              );
+              state = "DIAGNOSE_INIT_PROBE";
+              sendCmd(buildFsY(), 1);
+              return;
+            }
+            return fail(`expected ESC @ ack, got ${detail}`);
+          }
           state = "IDENTITY";
           sendCmd(buildFsI(), 80);
           return;
+
+        case "DIAGNOSE_INIT_PROBE": {
+          // Diagnostic-only terminal state. Whatever comes back, log it in
+          // detail and fail with a message instructing the user to share the
+          // [diagnose] log lines on the issue tracker.
+          const detail = `type=0x${pkt.type.toString(16)} payload=${pkt.payload.toString("hex")}`;
+          if (isAck(pkt)) {
+            log.info(
+              `[diagnose] FS Y returned ACK (${detail}) — printer likely speaks ESC/I-2 over plain TCP (ET-4950-style init, no TLS).`,
+            );
+          } else {
+            log.info(
+              `[diagnose] FS Y returned non-ACK (${detail}) — printer rejects both legacy ESC @ and ESC/I-2 FS Y; protocol family unknown.`,
+            );
+          }
+          return fail(
+            "diagnostic probe complete — please share the [diagnose] log lines on the GitHub issue",
+          );
+        }
 
         case "IDENTITY":
           // IS-0xa000 with 80-byte identity payload; we don't decode it

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -41,6 +41,11 @@ export function logStartupBanner(config: Config, modeMessage: string): void {
   log.info(
     `Protocol: ${config.printerProtocol}${config.printerProtocol === "auto" ? " (TLS-probe at first scan)" : ""}`,
   );
+  if (config.diagnoseProtocol) {
+    log.info(
+      "Protocol diagnostic mode: ENABLED (DIAGNOSE_PROTOCOL=true) — legacy ESC @ failures will trigger an FS Y probe and abort. Disable for normal scanning.",
+    );
+  }
   log.info(`JPEG quality: ${config.jpegQuality}`);
 }
 
@@ -126,5 +131,6 @@ export async function dispatchScanSession(args: DispatchArgs): Promise<void> {
     format: args.action,
     jpegQuality: args.config.jpegQuality,
     paperless: args.paperless,
+    diagnoseProtocol: args.config.diagnoseProtocol,
   });
 }


### PR DESCRIPTION
## Summary

- Adds `DIAGNOSE_PROTOCOL=true` env var. When the legacy `ESC @` init returns a non-ACK, the scanner sends one extra `FS Y` probe (the ET-4950 ESC/I-2 path's first command) and aborts with annotated `[diagnose]` log lines tagged with the IS packet type and payload.
- Strictly additive — defaults to false; happy-path behaviour for ET-4950 family and WF-3620 is unchanged.
- Bonus: legacy INIT error log now includes the IS packet type alongside the payload bytes (useful for any future compat report, not just ET-2750).
- Motivated by issue #43 (ET-2750), where the printer gets past welcome+lock but rejects `ESC @`. The probe lets us classify whether the dialect is ESC/I-2-over-plain-TCP or something else, without asking the reporter to install Wireshark.
- Version bump `0.3.0` → `0.3.1`.

## Test plan

- [x] `npm test` — 294 pass (288 existing + 3 new diagnose-probe + 3 new config), 1 skipped
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] New `src/scanner-legacy-diagnose.test.ts` covers: FS Y ACK branch, FS Y NAK branch, off-by-default behaviour
- [x] Local pre-push hook passed (mirrors CI gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)