### PR TITLE
M1: shared scan-session engine

### DIFF
--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -1,7 +1,10 @@
 // src/scan-session.test.ts
 
 import { describe, it, expect } from "vitest";
-import { createGraph, decision } from "./scan-session.js";
+import { EventEmitter } from "node:events";
+import { createGraph, decision, runScanSession } from "./scan-session.js";
+import type { SessionTransport } from "./scan-session.js";
+import { buildIsPacket } from "./protocol.js";
 
 describe("createGraph", () => {
   it("builds an empty graph with the given initial state", () => {
@@ -15,27 +18,73 @@ describe("createGraph", () => {
   });
 
   it("rejects building when initial state is undefined", () => {
-    const g = createGraph<{}>("START", 30_000);
+    const g = createGraph<Record<string, never>>("START", 30_000);
     expect(() => g.build()).toThrow(/Initial state 'START' not defined/);
   });
 
   it("rejects duplicate state names", () => {
-    const g = createGraph<{}>("S", 30_000);
+    const g = createGraph<Record<string, never>>("S", 30_000);
     g.state("S", { on: {} });
     expect(() => g.state("S", { on: {} })).toThrow(/Duplicate state/);
   });
 
   it('rejects defining the reserved "DONE" state', () => {
-    const g = createGraph<{}>("S", 30_000);
+    const g = createGraph<Record<string, never>>("S", 30_000);
     expect(() => g.state("DONE", { on: {} })).toThrow(/"DONE" is reserved/);
   });
 });
 
 describe("decision", () => {
   it("wraps a function as a DecisionDef", () => {
-    const def = decision<{}>(() => ({ next: "NEXT" }));
+    const def = decision<Record<string, never>>(() => ({ next: "NEXT" }));
     expect(def.__decision).toBe(true);
     const result = def.decide({}, { type: 0, payload: Buffer.alloc(0) });
     expect(result).toEqual({ next: "NEXT" });
+  });
+});
+
+class FakeTransport extends EventEmitter implements SessionTransport {
+  written: Buffer[] = [];
+  destroyed = false;
+  write(buf: Buffer): boolean {
+    this.written.push(buf);
+    return true;
+  }
+  end(): void {
+    this.emit("close");
+  }
+  destroy(err?: Error): void {
+    this.destroyed = true;
+    if (err) this.emit("error", err);
+    this.emit("close");
+  }
+  // EventEmitter already implements `on` with the right structural shape.
+}
+
+describe("runScanSession (engine pump)", () => {
+  it("dispatches a single static transition on receiving the expected IS packet", async () => {
+    const transport = new FakeTransport();
+    const factory = () => Promise.resolve(transport);
+    type Ctx = { reached: boolean };
+    const g = createGraph<Ctx>("WAITING", 1_000);
+    g.state("WAITING", { on: { 0xa000: { next: "DONE" } } });
+    // (DONE is reserved by the engine — do not call g.state("DONE", ...))
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: { reached: false },
+      transportFactory: factory,
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true, // test-only — exercises engine scaffolding without a flushPage
+    });
+
+    // Simulate the printer sending a 0xa000 packet
+    setImmediate(() => transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0))));
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
   });
 });

--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -1,0 +1,41 @@
+// src/scan-session.test.ts
+
+import { describe, it, expect } from "vitest";
+import { createGraph, decision } from "./scan-session.js";
+
+describe("createGraph", () => {
+  it("builds an empty graph with the given initial state", () => {
+    type Ctx = { count: number };
+    const g = createGraph<Ctx>("START", 30_000);
+    g.state("START", { on: {} });
+    const graph = g.build();
+    expect(graph.initial).toBe("START");
+    expect(graph.timeoutMs).toBe(30_000);
+    expect(graph.states.START).toBeDefined();
+  });
+
+  it("rejects building when initial state is undefined", () => {
+    const g = createGraph<{}>("START", 30_000);
+    expect(() => g.build()).toThrow(/Initial state 'START' not defined/);
+  });
+
+  it("rejects duplicate state names", () => {
+    const g = createGraph<{}>("S", 30_000);
+    g.state("S", { on: {} });
+    expect(() => g.state("S", { on: {} })).toThrow(/Duplicate state/);
+  });
+
+  it('rejects defining the reserved "DONE" state', () => {
+    const g = createGraph<{}>("S", 30_000);
+    expect(() => g.state("DONE", { on: {} })).toThrow(/"DONE" is reserved/);
+  });
+});
+
+describe("decision", () => {
+  it("wraps a function as a DecisionDef", () => {
+    const def = decision<{}>(() => ({ next: "NEXT" }));
+    expect(def.__decision).toBe(true);
+    const result = def.decide({}, { type: 0, payload: Buffer.alloc(0) });
+    expect(result).toEqual({ next: "NEXT" });
+  });
+});

--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -329,4 +329,50 @@ describe("runScanSession (engine pump)", () => {
 
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
+
+  it("injects EXIF Orientation=3 on back-side flushPage when action='jpg'", async () => {
+    const transport = new FakeTransport();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "engine-test-"));
+
+    const g = createGraph<Record<string, never>>("PAGE", 1_000);
+    g.state("PAGE", {
+      on: {
+        0xa000: {
+          next: "DONE",
+          flushPage: {
+            side: "back",
+            encode: () => Promise.resolve(Buffer.from([0xff, 0xd8, 0xff, 0xd9])),
+          },
+        },
+      },
+    });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: tempDir,
+      tempDir,
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    setImmediate(() => transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0))));
+    const result = await promise;
+    expect(result.ok).toBe(true);
+
+    // Find the temp file and verify it has the EXIF APP1 segment.
+    const files = fs.readdirSync(tempDir);
+    const sessionDir = files.find((f) => f.startsWith("epson2paperless-"));
+    expect(sessionDir).toBeDefined();
+    const pages = fs.readdirSync(path.join(tempDir, sessionDir!));
+    expect(pages.length).toBe(1);
+    const bytes = fs.readFileSync(path.join(tempDir, sessionDir!, pages[0]));
+    // Bytes 2-3 of the EXIF-injected output are FF E1 (APP1 marker).
+    expect(bytes[2]).toBe(0xff);
+    expect(bytes[3]).toBe(0xe1);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
 });

--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -505,4 +505,161 @@ describe("runScanSession (engine pump)", () => {
     const result = await promise;
     expect(result.ok).toBe(true);
   });
+
+  it("calls a global abort handler that returns Error and fails the session", async () => {
+    const transport = new FakeTransport();
+    const g = createGraph<Record<string, never>>("WAITING", 1_000).globalAbortHandlers({
+      0x9000: () => new Error("simulated async fatal"),
+    });
+    g.state("WAITING", { on: { 0xa000: { next: "DONE" } } });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    setImmediate(() => transport.emit("data", buildIsPacket(0x9000, Buffer.from([0x02]))));
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.message).toMatch(/simulated async fatal/);
+  });
+
+  it("calls a global abort handler that returns null and continues dispatch", async () => {
+    const transport = new FakeTransport();
+    let infoSeen = false;
+    const g = createGraph<Record<string, never>>("WAITING", 1_000).globalAbortHandlers({
+      0x9000: () => {
+        infoSeen = true;
+        return null; // info-only — no abort
+      },
+    });
+    g.state("WAITING", { on: { 0xa000: { next: "DONE" } } });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    // First send a 0x9000 info event (should be consumed by the handler, not advance state).
+    // Then send 0xa000 to advance to DONE.
+    setImmediate(() => {
+      transport.emit("data", buildIsPacket(0x9000, Buffer.from([0x01])));
+      setImmediate(() => transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0))));
+    });
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+    expect(infoSeen).toBe(true);
+  });
+
+  it("silently discards packets matched by globalIgnoreFilter", async () => {
+    const transport = new FakeTransport();
+    const g = createGraph<Record<string, never>>("WAITING", 1_000).globalIgnoreFilter(
+      // Filter out empty 0xa000 envelopes (simulates the ESC/I-2 wait-for-body pattern).
+      (packet) => packet.type === 0xa000 && packet.payload.length === 0,
+    );
+    g.state("WAITING", { on: { 0xa000: { next: "DONE" } } });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    setImmediate(() => {
+      // Empty 0xa000 — filter discards; state does NOT advance.
+      transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0)));
+      // Non-empty 0xa000 — passes the filter; state advances to DONE.
+      setImmediate(() => transport.emit("data", buildIsPacket(0xa000, Buffer.from([0xab]))));
+    });
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+  });
+
+  it("fails the session when a transition's validate returns false", async () => {
+    const transport = new FakeTransport();
+    const g = createGraph<Record<string, never>>("WAITING", 1_000);
+    g.state("WAITING", {
+      on: {
+        0x2000: {
+          // Simulates the ESC/I "ACK is 0x06 byte 0 of 0x2000 envelope" pattern.
+          validate: (payload) => payload[0] === 0x06,
+          next: "DONE",
+        },
+      },
+    });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    // Send a 0x2000 packet whose payload[0] is NOT 0x06 — validate fails.
+    setImmediate(() => transport.emit("data", buildIsPacket(0x2000, Buffer.from([0x15]))));
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason.message).toMatch(/Validation failed in state WAITING/);
+      expect(result.reason.message).toMatch(/0x2000/);
+    }
+  });
+
+  it("writes multi-buffer send arrays in order", async () => {
+    const transport = new FakeTransport();
+    const g = createGraph<Record<string, never>>("WAITING", 1_000);
+    g.state("WAITING", {
+      on: {
+        0xa000: {
+          next: "DONE",
+          send: [Buffer.from([0xaa]), Buffer.from([0xbb]), Buffer.from([0xcc])],
+        },
+      },
+    });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    setImmediate(() => transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0))));
+    const result = await promise;
+    expect(result.ok).toBe(true);
+
+    // The transport.written array should contain three buffers in order: 0xaa, 0xbb, 0xcc.
+    // (There may also be other writes from session setup; filter to single-byte writes.)
+    const singleByteWrites = transport.written
+      .filter((b) => b.length === 1)
+      .map((b) => b[0]);
+    expect(singleByteWrites).toEqual([0xaa, 0xbb, 0xcc]);
+  });
 });

--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -660,4 +660,121 @@ describe("runScanSession (engine pump)", () => {
     const singleByteWrites = transport.written.filter((b) => b.length === 1).map((b) => b[0]);
     expect(singleByteWrites).toEqual([0xaa, 0xbb, 0xcc]);
   });
+
+  // Fix 1: DONE no longer waits for transport close to settle the promise.
+  it("settles after DONE without waiting for transport close", async () => {
+    // FakeTransport.end() normally emits "close" synchronously. Override it
+    // to be a no-op to simulate a peer that never ACKs our FIN.
+    const transport = new FakeTransport();
+    transport.end = () => {
+      /* swallow — peer never closes */
+    };
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "engine-test-"));
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "engine-out-"));
+
+    const g = createGraph<Record<string, never>>("PAGE", 1_000);
+    g.state("PAGE", {
+      on: {
+        0xa000: {
+          next: "DONE",
+          flushPage: {
+            side: "front",
+            encode: () => Promise.resolve(Buffer.from([0xff, 0xd8, 0xff, 0xd9])),
+          },
+        },
+      },
+    });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir,
+      tempDir,
+      sessionTs: new Date(),
+      action: "jpg",
+    });
+
+    setImmediate(() => transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0))));
+    const result = await promise;
+    expect(result.ok).toBe(true);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  // Fix 2: Pump stops dispatching after an error settle.
+  it("stops the pump after an error settle even if more packets are buffered", async () => {
+    const transport = new FakeTransport();
+    let secondPacketDispatched = false;
+    const g = createGraph<Record<string, never>>("WAITING", 1_000).globalAbortHandlers({
+      0x9000: () => new Error("first packet aborts"),
+    });
+    g.state("WAITING", {
+      on: {
+        0xa000: {
+          next: "WAITING",
+          validate: (_payload) => {
+            // If the second packet is dispatched, this validator runs.
+            secondPacketDispatched = true;
+            return true;
+          },
+        },
+      },
+    });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    // Two packets in one tick: first triggers globalAbort error settle,
+    // second is buffered. The pump must NOT dispatch the second.
+    setImmediate(() => {
+      transport.emit("data", buildIsPacket(0x9000, Buffer.from([0x02])));
+      transport.emit("data", buildIsPacket(0xa000, Buffer.from([0x06])));
+    });
+
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.message).toMatch(/first packet aborts/);
+    expect(secondPacketDispatched).toBe(false);
+  });
+
+  // Fix 3: Hook exceptions route through settle as { ok: false }.
+  it("settles { ok: false } when a hook throws synchronously", async () => {
+    const transport = new FakeTransport();
+    const g = createGraph<Record<string, never>>("WAITING", 1_000);
+    g.state(
+      "WAITING",
+      decision(() => {
+        throw new Error("bad payload parse");
+      }),
+    );
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    setImmediate(() => transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0))));
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason.message).toMatch(/Engine error in state WAITING/);
+      expect(result.reason.message).toMatch(/bad payload parse/);
+    }
+  });
 });

--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -333,6 +333,7 @@ describe("runScanSession (engine pump)", () => {
   it("injects EXIF Orientation=3 on back-side flushPage when action='jpg'", async () => {
     const transport = new FakeTransport();
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "engine-test-"));
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "engine-out-"));
 
     const g = createGraph<Record<string, never>>("PAGE", 1_000);
     g.state("PAGE", {
@@ -351,28 +352,98 @@ describe("runScanSession (engine pump)", () => {
       graph: g.build(),
       initialCtx: {},
       transportFactory: () => Promise.resolve(transport),
-      outputDir: tempDir,
+      outputDir,
       tempDir,
       sessionTs: new Date(),
       action: "jpg",
-      allowZeroPages: true,
+      // No allowZeroPages — there IS a flushPage in this run.
     });
 
     setImmediate(() => transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0))));
     const result = await promise;
     expect(result.ok).toBe(true);
 
-    // Find the temp file and verify it has the EXIF APP1 segment.
-    const files = fs.readdirSync(tempDir);
-    const sessionDir = files.find((f) => f.startsWith("epson2paperless-"));
-    expect(sessionDir).toBeDefined();
-    const pages = fs.readdirSync(path.join(tempDir, sessionDir!));
-    expect(pages.length).toBe(1);
-    const bytes = fs.readFileSync(path.join(tempDir, sessionDir!, pages[0]));
+    // finalizeSession promotes the temp page to outputDir as scan_*.jpg.
+    // Verify the promoted file has the EXIF APP1 segment (bytes 2-3 = FF E1).
+    const outputs = fs.readdirSync(outputDir);
+    expect(outputs.length).toBe(1);
+    const bytes = fs.readFileSync(path.join(outputDir, outputs[0]));
     // Bytes 2-3 of the EXIF-injected output are FF E1 (APP1 marker).
     expect(bytes[2]).toBe(0xff);
     expect(bytes[3]).toBe(0xe1);
 
     fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it("rejects with 'zero image chunks' when DONE is reached without any flushPage (production path)", async () => {
+    const transport = new FakeTransport();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "engine-test-"));
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "engine-out-"));
+
+    // Graph reaches DONE without flushing a page. Production callers must NOT
+    // set allowZeroPages — note its absence below.
+    const g = createGraph<Record<string, never>>("WAIT", 1_000);
+    g.state("WAIT", { on: { 0xa000: { next: "DONE" } } });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir,
+      tempDir,
+      sessionTs: new Date(),
+      action: "jpg",
+      // allowZeroPages: NOT set — engine should reject.
+    });
+
+    setImmediate(() => transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0))));
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.message).toMatch(/zero image chunks/);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it("calls finalizeSession on reaching DONE — produces a JPG in outputDir", async () => {
+    const transport = new FakeTransport();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "engine-test-"));
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "engine-out-"));
+
+    const g = createGraph<Record<string, never>>("PAGE", 1_000);
+    g.state("PAGE", {
+      on: {
+        0xa000: {
+          next: "DONE",
+          flushPage: {
+            side: "front",
+            encode: () => Promise.resolve(Buffer.from([0xff, 0xd8, 0xff, 0xd9])),
+          },
+        },
+      },
+    });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir,
+      tempDir,
+      sessionTs: new Date(),
+      action: "jpg",
+      // No allowZeroPages — and that's fine because there IS a flushPage in this run.
+    });
+
+    setImmediate(() => transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0))));
+    const result = await promise;
+    expect(result.ok).toBe(true);
+
+    // Output dir should contain a scan_*.jpg promoted by finalizeSession.
+    const outputs = fs.readdirSync(outputDir);
+    expect(outputs.some((f) => /^scan_.*\.jpg$/.test(f))).toBe(true);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(outputDir, { recursive: true, force: true });
   });
 });

--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -87,4 +87,64 @@ describe("runScanSession (engine pump)", () => {
     const result = await promise;
     expect(result.ok).toBe(true);
   });
+
+  it("calls a decision function and follows its returned next state", async () => {
+    const transport = new FakeTransport();
+    type Ctx = { sourceByte: number | null };
+    const g = createGraph<Ctx>("WAITING", 1_000);
+    g.state(
+      "WAITING",
+      decision((ctx, packet) => {
+        ctx.sourceByte = packet.payload[0];
+        return { next: packet.payload[0] === 0x81 ? "FLATBED" : "ADF" };
+      }),
+    );
+    g.state("FLATBED", { on: {} });
+    g.state("ADF", { on: { 0xa000: { next: "DONE" } } });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: { sourceByte: null },
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    setImmediate(() => {
+      transport.emit("data", buildIsPacket(0xa200, Buffer.from([0x01]))); // ADF
+      setImmediate(() => transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0))));
+    });
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+  });
+
+  it("settles { ok: false, reason } when a decision returns { error }", async () => {
+    const transport = new FakeTransport();
+    const g = createGraph<Record<string, never>>("WAITING", 1_000);
+    g.state(
+      "WAITING",
+      decision(() => ({ error: new Error("boom") })),
+    );
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    setImmediate(() => transport.emit("data", buildIsPacket(0xa200, Buffer.from([0x01]))));
+
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.message).toBe("boom");
+  });
 });

--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -176,4 +176,49 @@ describe("runScanSession (engine pump)", () => {
     const result = await promise;
     expect(result.ok).toBe(true);
   });
+
+  it("fires the rolling timeout if no packet arrives within timeoutMs", async () => {
+    const transport = new FakeTransport();
+    const g = createGraph<Record<string, never>>("WAITING", 50); // 50ms timeout
+    g.state("WAITING", { on: { 0xa000: { next: "DONE" } } });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    // Don't send any data
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason.message).toMatch(/Timeout in state WAITING/);
+  });
+
+  it("clears the rolling timeout when the expected packet arrives", async () => {
+    const transport = new FakeTransport();
+    const g = createGraph<Record<string, never>>("WAITING", 50);
+    g.state("WAITING", { on: { 0xa000: { next: "DONE" } } });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    // Send before timeout
+    setTimeout(() => transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0))), 20);
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+  });
 });

--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -446,4 +446,63 @@ describe("runScanSession (engine pump)", () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
     fs.rmSync(outputDir, { recursive: true, force: true });
   });
+
+  it("resolves a (ctx) => Buffer send at dispatch time using current ctx", async () => {
+    const transport = new FakeTransport();
+    type Ctx = { token: number };
+    const g = createGraph<Ctx>("WAITING", 1_000);
+    g.state("WAITING", {
+      on: {
+        0xa000: {
+          next: "DONE",
+          send: (ctx) => Buffer.from([ctx.token]),
+        },
+      },
+    });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: { token: 0x42 },
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    setImmediate(() => transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0))));
+    const result = await promise;
+    expect(result.ok).toBe(true);
+
+    // Among transport.written, find a buffer with byte 0x42
+    expect(transport.written.some((b) => b.length === 1 && b[0] === 0x42)).toBe(true);
+  });
+
+  it("supports a decision state with onEnter (sends bytes before deciding)", async () => {
+    const transport = new FakeTransport();
+    const g = createGraph<Record<string, never>>("WAITING", 1_000);
+    g.state("WAITING", {
+      ...decision(() => ({ next: "DONE" })),
+      onEnter: () => Buffer.from([0xff]),
+    });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    await new Promise((r) => setImmediate(r));
+    expect(transport.written.some((b) => b.length === 1 && b[0] === 0xff)).toBe(true);
+
+    setImmediate(() => transport.emit("data", buildIsPacket(0xa200, Buffer.alloc(0))));
+    const result = await promise;
+    expect(result.ok).toBe(true);
+  });
 });

--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -147,4 +147,33 @@ describe("runScanSession (engine pump)", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason.message).toBe("boom");
   });
+
+  it("fires onEnter when entering the initial state and sends its bytes", async () => {
+    const transport = new FakeTransport();
+    const g = createGraph<Record<string, never>>("WELCOME", 1_000);
+    g.state("WELCOME", {
+      on: { 0xa000: { next: "DONE" } },
+      onEnter: () => Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+    });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    // Wait one microtask for transportFactory to resolve and onEnter to fire
+    await new Promise((r) => setImmediate(r));
+    expect(transport.written.length).toBe(1);
+    expect(transport.written[0].equals(Buffer.from([0xde, 0xad, 0xbe, 0xef]))).toBe(true);
+
+    transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0)));
+    const result = await promise;
+    expect(result.ok).toBe(true);
+  });
 });

--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -2,6 +2,9 @@
 
 import { describe, it, expect } from "vitest";
 import { EventEmitter } from "node:events";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { createGraph, decision, runScanSession } from "./scan-session.js";
 import type { SessionTransport } from "./scan-session.js";
 import { buildIsPacket } from "./protocol.js";
@@ -220,5 +223,110 @@ describe("runScanSession (engine pump)", () => {
 
     const result = await promise;
     expect(result.ok).toBe(true);
+  });
+
+  it("awaits flushPage.encode before sending the next command", async () => {
+    const transport = new FakeTransport();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "engine-test-"));
+
+    let encodeStartedAt = 0;
+    let sendObservedAt = 0;
+    const encodePromise = new Promise<Buffer>((resolve) => {
+      setTimeout(() => {
+        // Minimal valid JPEG: SOI + EOI
+        resolve(Buffer.from([0xff, 0xd8, 0xff, 0xd9]));
+      }, 30);
+    });
+
+    const g = createGraph<Record<string, never>>("PAGE", 1_000);
+    g.state("PAGE", {
+      on: {
+        0xa000: {
+          next: "DONE",
+          send: Buffer.from([0xca, 0xfe]),
+          flushPage: {
+            side: "front",
+            encode: () => {
+              encodeStartedAt = Date.now();
+              return encodePromise;
+            },
+          },
+        },
+      },
+    });
+
+    // Wrap transport.write to record when our send was observed
+    const origWrite = transport.write.bind(transport);
+    transport.write = (buf: Buffer) => {
+      if (buf.equals(Buffer.from([0xca, 0xfe]))) sendObservedAt = Date.now();
+      return origWrite(buf);
+    };
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: tempDir,
+      tempDir,
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    setImmediate(() => transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0))));
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+    // The send must happen AFTER encode resolved
+    expect(sendObservedAt).toBeGreaterThanOrEqual(encodeStartedAt + 30);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("buffers inbound data during a flushPage barrier and dispatches after resume", async () => {
+    // Verifies: while flushPage is pending, the next packet from the printer is
+    // buffered. Once flush resolves, that packet gets dispatched.
+    const transport = new FakeTransport();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "engine-test-"));
+
+    const g = createGraph<{ pages: number }>("AWAIT_PAGE", 1_000);
+    g.state("AWAIT_PAGE", {
+      on: {
+        0xa000: {
+          next: "AFTER_FLUSH",
+          flushPage: {
+            side: "front",
+            encode: async () => {
+              await new Promise((r) => setTimeout(r, 30));
+              return Buffer.from([0xff, 0xd8, 0xff, 0xd9]);
+            },
+          },
+        },
+      },
+    });
+    g.state("AFTER_FLUSH", { on: { 0xa000: { next: "DONE" } } });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: { pages: 0 },
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: tempDir,
+      tempDir,
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    // First 0xa000 triggers flush; immediately after, send a SECOND 0xa000.
+    // The second one should be buffered and dispatched only after flush resolves.
+    setImmediate(() => {
+      transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0)));
+      transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0)));
+    });
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 });

--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -657,9 +657,7 @@ describe("runScanSession (engine pump)", () => {
 
     // The transport.written array should contain three buffers in order: 0xaa, 0xbb, 0xcc.
     // (There may also be other writes from session setup; filter to single-byte writes.)
-    const singleByteWrites = transport.written
-      .filter((b) => b.length === 1)
-      .map((b) => b[0]);
+    const singleByteWrites = transport.written.filter((b) => b.length === 1).map((b) => b[0]);
     expect(singleByteWrites).toEqual([0xaa, 0xbb, 0xcc]);
   });
 });

--- a/src/scan-session.ts
+++ b/src/scan-session.ts
@@ -1,0 +1,201 @@
+// src/scan-session.ts
+
+import type { PaperlessUploadOptions } from "./paperless-upload.js";
+
+// =============================================================================
+// Transport
+// =============================================================================
+
+export type SessionTransportFactory = () => Promise<SessionTransport>;
+
+export interface SessionTransport {
+  write(buf: Buffer): boolean | void;
+  /** Polite close after normal completion. */
+  end(): void;
+  /** Fail-fast destroy for error paths. */
+  destroy(err?: Error): void;
+
+  on(event: "data", cb: (chunk: Buffer) => void): this;
+  on(event: "error", cb: (err: Error) => void): this;
+  on(event: "close", cb: (hadError?: boolean) => void): this;
+}
+
+// =============================================================================
+// Graph
+// =============================================================================
+
+export interface Graph<Ctx> {
+  initial: string;
+  states: Record<string, GraphState<Ctx>>;
+  /** Per-scanner default rolling timeout, in ms. */
+  timeoutMs: number;
+  /**
+   * Pre-state-dispatch abort handlers, keyed by IS packet type. Used for
+   * protocol meta-events (e.g. ESC/I-2 0x9000). Returns Error to fail;
+   * returns null to ignore.
+   */
+  globalAbortHandlers?: Record<
+    number,
+    (ctx: Ctx, packet: { type: number; payload: Buffer }) => Error | null
+  >;
+  /**
+   * Pre-dispatch packet filter — returns true to discard. Used for the
+   * "wait for body" empty-envelope pattern (ESC/I-2 empty 0xa000).
+   */
+  globalIgnoreFilter?: (packet: { type: number; payload: Buffer }) => boolean;
+}
+
+/** Single write spec — concrete bytes or a ctx-thunk resolved at dispatch time. */
+export type SendSpec<Ctx> = Buffer | ((ctx: Ctx) => Buffer);
+
+export type GraphState<Ctx> =
+  | { kind: "static"; on: Record<number, StaticTransition<Ctx>> }
+  | { kind: "decision"; decide: DecisionFn<Ctx> };
+
+export interface StaticTransition<Ctx> {
+  next: string;
+  /**
+   * Bytes to write when this transition fires. Single-value form for
+   * one-shot commands; array form for back-to-back multi-write patterns
+   * where wire ordering matters (e.g. legacy ESC e: opcode and parameter
+   * packet sent back-to-back, host then waits for two ACKs — delaying
+   * the parameter write changes wire order and breaks replay tests).
+   * Engine writes are sequential in array order; thunks resolve against
+   * current ctx at dispatch time.
+   */
+  send?: SendSpec<Ctx> | SendSpec<Ctx>[];
+  /**
+   * Payload validator. The graph's `on:` table is keyed by IS packet
+   * *type*; for protocols that further validate a payload byte (notably
+   * ESC/I: every passthru reply is a `0x2000` envelope whose payload
+   * byte 0 carries the protocol-level ACK / NAK), the transition
+   * specifies a validator. Engine semantics: packet type matches → run
+   * `validate(payload)`; true → apply; false → fail the session with a
+   * state-tagged error. Use `globalIgnoreFilter` for "discard this
+   * packet quietly" semantics — `validate` is for hard protocol errors.
+   */
+  validate?: (payload: Buffer) => boolean;
+  flushPage?: PageFlush;
+}
+
+export type DecisionFn<Ctx> = (
+  ctx: Ctx,
+  packet: { type: number; payload: Buffer },
+) => TransitionResult<Ctx>;
+
+/**
+ * Decision-fn return shape. Generic over Ctx so decisions can return
+ * the same SendSpec types static transitions accept (concrete Buffer,
+ * (ctx) => Buffer thunk, or arrays of either). The engine's resolveSend
+ * + writeAll handle all shapes uniformly, so unifying the type here
+ * keeps decision call sites aligned with static-transition call sites.
+ */
+export type TransitionResult<Ctx> =
+  | { next: string; send?: SendSpec<Ctx> | SendSpec<Ctx>[]; flushPage?: PageFlush }
+  | { error: Error };
+
+export interface PageFlush {
+  /** Returns finished JPEG bytes. */
+  encode: () => Promise<Buffer>;
+  side: "front" | "back";
+}
+
+// =============================================================================
+// Builder (authoring-only)
+// =============================================================================
+
+export interface GraphBuilder<Ctx> {
+  state(name: string, def: StateDef<Ctx>): this;
+  /** Set the graph's global abort handlers (preempt state dispatch). */
+  globalAbortHandlers(
+    handlers: Record<number, (ctx: Ctx, packet: { type: number; payload: Buffer }) => Error | null>,
+  ): this;
+  /** Set the graph's pre-dispatch packet filter. */
+  globalIgnoreFilter(filter: (packet: { type: number; payload: Buffer }) => boolean): this;
+  build(): Graph<Ctx>;
+}
+
+export type StateDef<Ctx> = { on: Record<number, StaticTransition<Ctx>> } | DecisionDef<Ctx>;
+
+export interface DecisionDef<Ctx> {
+  __decision: true;
+  decide: DecisionFn<Ctx>;
+}
+
+export function createGraph<Ctx>(initial: string, timeoutMs: number): GraphBuilder<Ctx> {
+  const states: Record<string, GraphState<Ctx>> = {};
+  let abortHandlers: Graph<Ctx>["globalAbortHandlers"];
+  let ignoreFilter: Graph<Ctx>["globalIgnoreFilter"];
+  return {
+    state(name, def) {
+      if (name === "DONE") {
+        throw new Error(
+          '"DONE" is reserved as the engine terminal state; do not define a g.state("DONE", ...)',
+        );
+      }
+      if (states[name]) throw new Error(`Duplicate state name: ${name}`);
+      if ("__decision" in def) {
+        states[name] = { kind: "decision", decide: def.decide };
+      } else {
+        states[name] = { kind: "static", on: def.on };
+      }
+      return this;
+    },
+    globalAbortHandlers(handlers) {
+      abortHandlers = handlers;
+      return this;
+    },
+    globalIgnoreFilter(filter) {
+      ignoreFilter = filter;
+      return this;
+    },
+    build() {
+      if (!states[initial]) throw new Error(`Initial state '${initial}' not defined`);
+      return Object.freeze({
+        initial,
+        states: Object.freeze(states),
+        timeoutMs,
+        globalAbortHandlers: abortHandlers,
+        globalIgnoreFilter: ignoreFilter,
+      }) as Graph<Ctx>;
+    },
+  };
+}
+
+export function decision<Ctx>(decide: DecisionFn<Ctx>): DecisionDef<Ctx> {
+  return { __decision: true, decide };
+}
+
+// =============================================================================
+// Engine
+// =============================================================================
+
+export interface RunScanSessionOpts<Ctx> {
+  graph: Graph<Ctx>;
+  initialCtx: Ctx;
+  transportFactory: SessionTransportFactory;
+  outputDir: string;
+  tempDir: string;
+  sessionTs: Date;
+  action: "jpg" | "pdf";
+  paperless?: PaperlessUploadOptions;
+  /**
+   * Test-only: allow reaching DONE without any flushPage having fired.
+   * Production paths must never set this — zero-page completion is a
+   * real failure mode (printer-side error that aborted before pixel
+   * transfer started). Carries over the v0.3.0 §3.3 zero-image-rejection
+   * contract.
+   */
+  allowZeroPages?: boolean;
+}
+
+export type RunScanSessionResult<Ctx> =
+  | { ok: true; finalCtx: Ctx }
+  | { ok: false; reason: Error; finalCtx?: Ctx };
+
+export async function runScanSession<Ctx>(
+  _opts: RunScanSessionOpts<Ctx>,
+): Promise<RunScanSessionResult<Ctx>> {
+  // Implemented in subsequent tasks.
+  throw new Error("runScanSession not yet implemented");
+}

--- a/src/scan-session.ts
+++ b/src/scan-session.ts
@@ -228,9 +228,6 @@ export async function runScanSession<Ctx>(
   let currentState = "";
   // Set during a flushPage barrier — pauses the pump while encode/persist runs.
   let paused = false;
-  // _errorReason is set in two places (transport.on("error") and the
-  // global-abort-handler path) and read in the flushPage error path.
-  let _errorReason: Error | null = null;
   let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
 
   const recvChunks: Buffer[] = [];
@@ -248,7 +245,6 @@ export async function runScanSession<Ctx>(
         const reason = new Error(
           `Timeout in state ${currentState} — no response in ${graph.timeoutMs}ms`,
         );
-        _errorReason = reason;
         settle({ ok: false, reason, finalCtx: ctx });
       }, graph.timeoutMs);
     }
@@ -276,7 +272,7 @@ export async function runScanSession<Ctx>(
      * Advances to a new state, fires its onEnter hook (which may write the
      * initial command for that state), and handles the DONE terminal.
      * Called synchronously on initial entry and after every transition.
-     * T15 will add timeout re-arming here.
+     * Re-arms the rolling timeout on each state entry.
      */
     function enterState(name: string): void {
       currentState = name;
@@ -293,7 +289,6 @@ export async function runScanSession<Ctx>(
     }
 
     transport.on("error", (err) => {
-      _errorReason = err;
       settle({ ok: false, reason: err, finalCtx: ctx });
     });
 
@@ -453,7 +448,6 @@ export async function runScanSession<Ctx>(
       if (handler) {
         const err = handler(ctx, packet);
         if (err) {
-          _errorReason = err;
           settle({ ok: false, reason: err, finalCtx: ctx });
           return;
         }
@@ -489,7 +483,6 @@ export async function runScanSession<Ctx>(
         // decision
         const result = state.decide(ctx, packet);
         if ("error" in result) {
-          _errorReason = result.error;
           settle({ ok: false, reason: result.error, finalCtx: ctx });
           return;
         }
@@ -550,7 +543,6 @@ export async function runScanSession<Ctx>(
           await fs.promises.writeFile(path.join(sessionTempDir, filename), outputBytes);
         } catch (err) {
           const reason = err instanceof Error ? err : new Error(String(err));
-          _errorReason = reason;
           settle({ ok: false, reason, finalCtx: ctx });
           return;
         }
@@ -560,8 +552,8 @@ export async function runScanSession<Ctx>(
         writeAll(resolveSend(stagedSend));
         enterState(stagedNext);
         // Do NOT call tryDispatch() recursively. The outer pump loop is awaiting
-        // this very applyTransition call — once we return, its next iteration
-        // picks up any buffered packets and dispatches them with the new state.
+        // this very applyTransition call — the next loop pass picks up any
+        // buffered packets and dispatches them with the new state.
         return;
       }
 

--- a/src/scan-session.ts
+++ b/src/scan-session.ts
@@ -1,5 +1,8 @@
 // src/scan-session.ts
 
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { IS_HEADER_SIZE } from "./protocol.js";
 import type { PaperlessUploadOptions } from "./paperless-upload.js";
 
@@ -223,16 +226,18 @@ export async function runScanSession<Ctx>(
   }
 
   let currentState = "";
-  // Set during a flushPage barrier (Task 16) — for now always false; the pump
-  // checks it preemptively so the wiring is in place when T16 lands.
-  const paused = false;
-  // errorReason is set in two places (transport.on("error") and the
-  // global-abort-handler path) and read in T16's flushPage error path.
+  // Set during a flushPage barrier — pauses the pump while encode/persist runs.
+  let paused = false;
+  // _errorReason is set in two places (transport.on("error") and the
+  // global-abort-handler path) and read in the flushPage error path.
   let _errorReason: Error | null = null;
   let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
 
   const recvChunks: Buffer[] = [];
   let recvBytes = 0;
+  let pageIndex = 0;
+  const backPageIndices: number[] = [];
+  let sessionTempDir: string | null = null;
 
   return new Promise<RunScanSessionResult<Ctx>>((resolve) => {
     let settled = false;
@@ -457,23 +462,77 @@ export async function runScanSession<Ctx>(
       }
     }
 
+    async function createSessionTempDir(baseDir: string): Promise<string> {
+      const base = baseDir || os.tmpdir();
+      return fs.promises.mkdtemp(path.join(base, "epson2paperless-"));
+    }
+
     /**
-     * Applies a resolved transition: writes any bytes, advances currentState,
-     * and triggers transport.end() on DONE. Accepts both StaticTransition
-     * (function-form send) and TransitionResult (decision return; concrete
-     * bytes only) — resolveSend handles both shapes uniformly.
-     * Async to support flushPage barriers in T16 (no await yet — stub is
-     * intentionally sync-body-only until T16 adds the flushPage barrier).
+     * Applies a resolved transition: handles the flushPage barrier (encode +
+     * persist while pump is paused), then writes any staged send bytes and
+     * advances currentState. On the non-flush path writes and enters state
+     * immediately. Accepts both StaticTransition and TransitionResult shapes —
+     * resolveSend handles both uniformly.
      */
-    // eslint-disable-next-line @typescript-eslint/require-await
     async function applyTransition(t: {
       next: string;
       send?: SendSpec<Ctx> | SendSpec<Ctx>[] | Buffer | Buffer[];
       flushPage?: PageFlush;
     }): Promise<void> {
+      if (t.flushPage) {
+        // Spec §3.5 barrier order:
+        // pause → encode/persist → unpause → write staged send → enter staged next.
+        const stagedNext = t.next;
+        const stagedSend = t.send;
+
+        paused = true;
+        clearTimeoutTimer(); // suspend timeout during barrier (spec §3.6)
+
+        pageIndex += 1;
+        const myPageIndex = pageIndex;
+
+        try {
+          const jpegBytes = await t.flushPage.encode();
+
+          // Track back-page index regardless of action (PDF mode needs it for
+          // pdf-lib /Rotate=180 in finalizeSession).
+          if (t.flushPage.side === "back") {
+            backPageIndices.push(myPageIndex);
+          }
+
+          // EXIF action-gating (spec §3.5 step 5).
+          let outputBytes = jpegBytes;
+          if (t.flushPage.side === "back" && opts.action === "jpg") {
+            const { setJpegOrientation } = await import("./exif.js");
+            outputBytes = setJpegOrientation(jpegBytes, 3);
+          }
+
+          // Write to temp file.
+          if (!sessionTempDir) {
+            sessionTempDir = await createSessionTempDir(opts.tempDir);
+          }
+          const filename = `page_${String(myPageIndex).padStart(2, "0")}.jpg`;
+          await fs.promises.writeFile(path.join(sessionTempDir, filename), outputBytes);
+        } catch (err) {
+          const reason = err instanceof Error ? err : new Error(String(err));
+          _errorReason = reason;
+          settle({ ok: false, reason, finalCtx: ctx });
+          return;
+        }
+
+        paused = false;
+        // Apply staged send after barrier resolves (spec §3.5 step 8).
+        writeAll(resolveSend(stagedSend));
+        enterState(stagedNext);
+        // Do NOT call tryDispatch() recursively. The outer pump loop is awaiting
+        // this very applyTransition call — once we return, its next iteration
+        // picks up any buffered packets and dispatches them with the new state.
+        return;
+      }
+
+      // Non-flush path — write and enter state immediately.
       writeAll(resolveSend(t.send));
       enterState(t.next);
-      // flushPage handled in T16
     }
 
     // Enter the initial state. This fires onEnter for the initial state

--- a/src/scan-session.ts
+++ b/src/scan-session.ts
@@ -50,8 +50,16 @@ export interface Graph<Ctx> {
 export type SendSpec<Ctx> = Buffer | ((ctx: Ctx) => Buffer);
 
 export type GraphState<Ctx> =
-  | { kind: "static"; on: Record<number, StaticTransition<Ctx>> }
-  | { kind: "decision"; decide: DecisionFn<Ctx> };
+  | {
+      kind: "static";
+      on: Record<number, StaticTransition<Ctx>>;
+      onEnter?: (ctx: Ctx) => Buffer | null;
+    }
+  | {
+      kind: "decision";
+      decide: DecisionFn<Ctx>;
+      onEnter?: (ctx: Ctx) => Buffer | null;
+    };
 
 export interface StaticTransition<Ctx> {
   next: string;
@@ -116,11 +124,14 @@ export interface GraphBuilder<Ctx> {
   build(): Graph<Ctx>;
 }
 
-export type StateDef<Ctx> = { on: Record<number, StaticTransition<Ctx>> } | DecisionDef<Ctx>;
+export type StateDef<Ctx> =
+  | { on: Record<number, StaticTransition<Ctx>>; onEnter?: (ctx: Ctx) => Buffer | null }
+  | DecisionDef<Ctx>;
 
 export interface DecisionDef<Ctx> {
   __decision: true;
   decide: DecisionFn<Ctx>;
+  onEnter?: (ctx: Ctx) => Buffer | null;
 }
 
 export function createGraph<Ctx>(initial: string, timeoutMs: number): GraphBuilder<Ctx> {
@@ -136,9 +147,9 @@ export function createGraph<Ctx>(initial: string, timeoutMs: number): GraphBuild
       }
       if (states[name]) throw new Error(`Duplicate state name: ${name}`);
       if ("__decision" in def) {
-        states[name] = { kind: "decision", decide: def.decide };
+        states[name] = { kind: "decision", decide: def.decide, onEnter: def.onEnter };
       } else {
-        states[name] = { kind: "static", on: def.on };
+        states[name] = { kind: "static", on: def.on, onEnter: def.onEnter };
       }
       return this;
     },
@@ -211,7 +222,7 @@ export async function runScanSession<Ctx>(
     return { ok: false, reason, finalCtx: ctx };
   }
 
-  let currentState = graph.initial;
+  let currentState = "";
   // Set during a flushPage barrier (Task 16) — for now always false; the pump
   // checks it preemptively so the wiring is in place when T16 lands.
   const paused = false;
@@ -234,6 +245,26 @@ export async function runScanSession<Ctx>(
       }
       resolve(result);
     };
+
+    /**
+     * Advances to a new state, fires its onEnter hook (which may write the
+     * initial command for that state), and handles the DONE terminal.
+     * Called synchronously on initial entry and after every transition.
+     * T15 will add timeout re-arming here.
+     */
+    function enterState(name: string): void {
+      currentState = name;
+      if (currentState === "DONE") {
+        transport.end(); // triggers close → resolve ok in close handler
+        return;
+      }
+      const state = graph.states[currentState];
+      if (state.onEnter) {
+        const bytes = state.onEnter(ctx);
+        if (bytes) transport.write(bytes);
+      }
+      // Re-arm timeout (T15 will add the timeout call here)
+    }
 
     transport.on("error", (err) => {
       _errorReason = err;
@@ -420,11 +451,14 @@ export async function runScanSession<Ctx>(
       flushPage?: PageFlush;
     }): Promise<void> {
       writeAll(resolveSend(t.send));
-      currentState = t.next;
-      if (currentState === "DONE") {
-        transport.end(); // triggers close → resolve ok in close handler
-      }
+      enterState(t.next);
       // flushPage handled in T16
     }
+
+    // Enter the initial state. This fires onEnter for the initial state
+    // (which may write the first command) synchronously inside the Promise
+    // body, after all listeners are wired, so the first setImmediate
+    // microtask queued by tests sees the writes.
+    enterState(graph.initial);
   });
 }

--- a/src/scan-session.ts
+++ b/src/scan-session.ts
@@ -256,7 +256,7 @@ export async function runScanSession<Ctx>(
     transport.on("data", (chunk: Buffer) => {
       recvChunks.push(chunk);
       recvBytes += chunk.length;
-      tryDispatch();
+      void tryDispatch();
     });
 
     /**
@@ -286,7 +286,7 @@ export async function runScanSession<Ctx>(
      * barrier (Task 16) — and breaks out so multiple buffered packets in
      * a single TCP chunk don't dispatch concurrently with a flush.
      */
-    function tryDispatch(): void {
+    async function tryDispatch(): Promise<void> {
       if (dispatching) return;
       dispatching = true;
       try {
@@ -294,7 +294,7 @@ export async function runScanSession<Ctx>(
           if (paused) return;
           const packet = tryParseHead();
           if (!packet) return;
-          dispatchPacket(packet);
+          await dispatchPacket(packet);
           if (paused) return;
         }
       } finally {
@@ -347,7 +347,7 @@ export async function runScanSession<Ctx>(
       return { type, payload, totalSize };
     }
 
-    function dispatchPacket(packet: { type: number; payload: Buffer }): void {
+    async function dispatchPacket(packet: { type: number; payload: Buffer }): Promise<void> {
       // Step 1: globalIgnoreFilter — silently discard packets the protocol
       // wants to filter pre-dispatch (e.g. ESC/I-2 empty 0xa000 envelopes).
       if (graph.globalIgnoreFilter && graph.globalIgnoreFilter(packet)) {
@@ -392,14 +392,39 @@ export async function runScanSession<Ctx>(
           });
           return;
         }
-        // Apply send (multi-write capable) + next. flushPage handling lands in T16.
-        writeAll(resolveSend(transition.send));
-        currentState = transition.next;
-        if (currentState === "DONE") {
-          transport.end(); // triggers close → resolve ok in close handler
+        await applyTransition(transition);
+      } else {
+        // decision
+        const result = state.decide(ctx, packet);
+        if ("error" in result) {
+          _errorReason = result.error;
+          settle({ ok: false, reason: result.error, finalCtx: ctx });
+          return;
         }
+        await applyTransition(result);
       }
-      // decision branch added in T13
+    }
+
+    /**
+     * Applies a resolved transition: writes any bytes, advances currentState,
+     * and triggers transport.end() on DONE. Accepts both StaticTransition
+     * (function-form send) and TransitionResult (decision return; concrete
+     * bytes only) — resolveSend handles both shapes uniformly.
+     * Async to support flushPage barriers in T16 (no await yet — stub is
+     * intentionally sync-body-only until T16 adds the flushPage barrier).
+     */
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async function applyTransition(t: {
+      next: string;
+      send?: SendSpec<Ctx> | SendSpec<Ctx>[] | Buffer | Buffer[];
+      flushPage?: PageFlush;
+    }): Promise<void> {
+      writeAll(resolveSend(t.send));
+      currentState = t.next;
+      if (currentState === "DONE") {
+        transport.end(); // triggers close → resolve ok in close handler
+      }
+      // flushPage handled in T16
     }
   });
 }

--- a/src/scan-session.ts
+++ b/src/scan-session.ts
@@ -1,5 +1,6 @@
 // src/scan-session.ts
 
+import { IS_HEADER_SIZE } from "./protocol.js";
 import type { PaperlessUploadOptions } from "./paperless-upload.js";
 
 // =============================================================================
@@ -157,7 +158,7 @@ export function createGraph<Ctx>(initial: string, timeoutMs: number): GraphBuild
         timeoutMs,
         globalAbortHandlers: abortHandlers,
         globalIgnoreFilter: ignoreFilter,
-      }) as Graph<Ctx>;
+      });
     },
   };
 }
@@ -194,8 +195,211 @@ export type RunScanSessionResult<Ctx> =
   | { ok: false; reason: Error; finalCtx?: Ctx };
 
 export async function runScanSession<Ctx>(
-  _opts: RunScanSessionOpts<Ctx>,
+  opts: RunScanSessionOpts<Ctx>,
 ): Promise<RunScanSessionResult<Ctx>> {
-  // Implemented in subsequent tasks.
-  throw new Error("runScanSession not yet implemented");
+  const { graph, initialCtx, transportFactory } = opts;
+  const ctx = { ...initialCtx }; // engine owns mutability
+
+  // Factory failures (TLS handshake, cert-fingerprint mismatch, plain TCP
+  // connect refusal) must surface as { ok: false, reason } to keep the
+  // engine's Result contract honest.
+  let transport: SessionTransport;
+  try {
+    transport = await transportFactory();
+  } catch (err) {
+    const reason = err instanceof Error ? err : new Error(String(err));
+    return { ok: false, reason, finalCtx: ctx };
+  }
+
+  let currentState = graph.initial;
+  // Set during a flushPage barrier (Task 16) — for now always false; the pump
+  // checks it preemptively so the wiring is in place when T16 lands.
+  const paused = false;
+  // errorReason is set in two places (transport.on("error") and the
+  // global-abort-handler path) and read in T16's flushPage error path.
+  let _errorReason: Error | null = null;
+
+  const recvChunks: Buffer[] = [];
+  let recvBytes = 0;
+
+  return new Promise<RunScanSessionResult<Ctx>>((resolve) => {
+    let settled = false;
+    const settle = (result: RunScanSessionResult<Ctx>) => {
+      if (settled) return; // idempotent — close handler may also call this
+      settled = true;
+      try {
+        transport.destroy();
+      } catch {
+        /* swallow — destroy may throw on already-closed sockets */
+      }
+      resolve(result);
+    };
+
+    transport.on("error", (err) => {
+      _errorReason = err;
+      settle({ ok: false, reason: err, finalCtx: ctx });
+    });
+
+    transport.on("close", () => {
+      if (settled) return;
+      if (currentState === "DONE") {
+        settle({ ok: true, finalCtx: ctx });
+      } else {
+        settle({
+          ok: false,
+          reason: new Error(`Transport closed in state ${currentState}`),
+          finalCtx: ctx,
+        });
+      }
+    });
+
+    transport.on("data", (chunk: Buffer) => {
+      recvChunks.push(chunk);
+      recvBytes += chunk.length;
+      tryDispatch();
+    });
+
+    /**
+     * Resolves a transition `send` field — Buffer | function | array of
+     * either — against the current ctx into a flat array of byte buffers
+     * to write in order. Empty array means "no writes."
+     */
+    function resolveSend(send: SendSpec<Ctx> | SendSpec<Ctx>[] | Buffer | undefined): Buffer[] {
+      if (!send) return [];
+      const items = Array.isArray(send) ? send : [send];
+      return items.map((s) => (typeof s === "function" ? s(ctx) : s));
+    }
+
+    function writeAll(buffers: Buffer[]): void {
+      for (const buf of buffers) transport.write(buf);
+    }
+
+    let dispatching = false;
+
+    /**
+     * Async pump loop. Reentrancy is prevented by the `dispatching` guard:
+     * concurrent calls (from `'data'` events that fire while the loop is
+     * awaiting an applyTransition) short-circuit; the active loop drains
+     * any chunks they buffered on its next iteration.
+     *
+     * The loop checks `paused` at every step — set during a flushPage
+     * barrier (Task 16) — and breaks out so multiple buffered packets in
+     * a single TCP chunk don't dispatch concurrently with a flush.
+     */
+    function tryDispatch(): void {
+      if (dispatching) return;
+      dispatching = true;
+      try {
+        while (true) {
+          if (paused) return;
+          const packet = tryParseHead();
+          if (!packet) return;
+          dispatchPacket(packet);
+          if (paused) return;
+        }
+      } finally {
+        dispatching = false;
+      }
+    }
+
+    /**
+     * Parse one IS packet at the head of recvChunks if a complete one is
+     * present. Reads payloadSize directly from header bytes 6-9 (rather
+     * than calling parseIsPacket on a partial buffer, which would return
+     * null for any packet whose payload exceeds the peek window).
+     */
+    function tryParseHead(): { type: number; payload: Buffer; totalSize: number } | null {
+      if (recvBytes < IS_HEADER_SIZE) return null;
+
+      // Ensure first chunk has at least IS_HEADER_SIZE bytes so we can read
+      // the header fields without re-concatenating each time.
+      if (recvChunks[0].length < IS_HEADER_SIZE) {
+        const merged = Buffer.concat(recvChunks, recvBytes);
+        recvChunks.length = 0;
+        recvChunks.push(merged);
+      }
+
+      const head = recvChunks[0];
+      // Validate magic
+      if (head[0] !== 0x49 /* 'I' */ || head[1] !== 0x53 /* 'S' */) {
+        settle({
+          ok: false,
+          reason: new Error(
+            `Invalid IS magic at packet head: 0x${head[0]?.toString(16)} 0x${head[1]?.toString(16)}`,
+          ),
+          finalCtx: ctx,
+        });
+        return null;
+      }
+      const type = head.readUInt16BE(2);
+      const payloadSize = head.readUInt32BE(6);
+      const totalSize = IS_HEADER_SIZE + payloadSize;
+
+      if (recvBytes < totalSize) return null; // need more bytes
+
+      // We have the full packet — materialize and peel
+      const merged = recvChunks.length === 1 ? recvChunks[0] : Buffer.concat(recvChunks, recvBytes);
+      recvChunks.length = 0;
+      const payload = merged.subarray(IS_HEADER_SIZE, totalSize);
+      const remainder = merged.subarray(totalSize);
+      recvBytes = remainder.length;
+      if (remainder.length > 0) recvChunks.push(remainder);
+      return { type, payload, totalSize };
+    }
+
+    function dispatchPacket(packet: { type: number; payload: Buffer }): void {
+      // Step 1: globalIgnoreFilter — silently discard packets the protocol
+      // wants to filter pre-dispatch (e.g. ESC/I-2 empty 0xa000 envelopes).
+      if (graph.globalIgnoreFilter && graph.globalIgnoreFilter(packet)) {
+        return;
+      }
+
+      // Step 2: globalAbortHandlers — protocol meta-events that preempt
+      // state-specific dispatch (e.g. ESC/I-2 0x9000 fatal/cancel/info).
+      // Returns Error → fail; null → continue (info-only event).
+      const handler = graph.globalAbortHandlers?.[packet.type];
+      if (handler) {
+        const err = handler(ctx, packet);
+        if (err) {
+          _errorReason = err;
+          settle({ ok: false, reason: err, finalCtx: ctx });
+          return;
+        }
+        return; // null → handler consumed the packet, no state change
+      }
+
+      // Step 3: state-specific dispatch
+      const state = graph.states[currentState];
+      if (state.kind === "static") {
+        const transition = state.on[packet.type];
+        if (!transition) {
+          settle({
+            ok: false,
+            reason: new Error(
+              `Unexpected packet type 0x${packet.type.toString(16).padStart(4, "0")} in state ${currentState}`,
+            ),
+            finalCtx: ctx,
+          });
+          return;
+        }
+        if (transition.validate && !transition.validate(packet.payload)) {
+          settle({
+            ok: false,
+            reason: new Error(
+              `Validation failed in state ${currentState} for packet type 0x${packet.type.toString(16).padStart(4, "0")}`,
+            ),
+            finalCtx: ctx,
+          });
+          return;
+        }
+        // Apply send (multi-write capable) + next. flushPage handling lands in T16.
+        writeAll(resolveSend(transition.send));
+        currentState = transition.next;
+        if (currentState === "DONE") {
+          transport.end(); // triggers close → resolve ok in close handler
+        }
+      }
+      // decision branch added in T13
+    }
+  });
 }

--- a/src/scan-session.ts
+++ b/src/scan-session.ts
@@ -229,15 +229,36 @@ export async function runScanSession<Ctx>(
   // errorReason is set in two places (transport.on("error") and the
   // global-abort-handler path) and read in T16's flushPage error path.
   let _errorReason: Error | null = null;
+  let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
 
   const recvChunks: Buffer[] = [];
   let recvBytes = 0;
 
   return new Promise<RunScanSessionResult<Ctx>>((resolve) => {
     let settled = false;
+
+    function armTimeout(): void {
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      timeoutTimer = setTimeout(() => {
+        const reason = new Error(
+          `Timeout in state ${currentState} — no response in ${graph.timeoutMs}ms`,
+        );
+        _errorReason = reason;
+        settle({ ok: false, reason, finalCtx: ctx });
+      }, graph.timeoutMs);
+    }
+
+    function clearTimeoutTimer(): void {
+      if (timeoutTimer) {
+        clearTimeout(timeoutTimer);
+        timeoutTimer = null;
+      }
+    }
+
     const settle = (result: RunScanSessionResult<Ctx>) => {
       if (settled) return; // idempotent — close handler may also call this
       settled = true;
+      clearTimeoutTimer(); // (T15)
       try {
         transport.destroy();
       } catch {
@@ -263,7 +284,7 @@ export async function runScanSession<Ctx>(
         const bytes = state.onEnter(ctx);
         if (bytes) transport.write(bytes);
       }
-      // Re-arm timeout (T15 will add the timeout call here)
+      armTimeout(); // (T15)
     }
 
     transport.on("error", (err) => {

--- a/src/scan-session.ts
+++ b/src/scan-session.ts
@@ -273,11 +273,22 @@ export async function runScanSession<Ctx>(
      * initial command for that state), and handles the DONE terminal.
      * Called synchronously on initial entry and after every transition.
      * Re-arms the rolling timeout on each state entry.
+     *
+     * On entering DONE: calls transport.end() (polite FIN) and schedules
+     * finalize/zero-page-rejection via setImmediate — does NOT wait for
+     * the 'close' event, mirroring the ESC/I-2 scanner's "logical completion"
+     * pattern. The close handler then only handles unexpected closes.
      */
     function enterState(name: string): void {
       currentState = name;
       if (currentState === "DONE") {
-        transport.end(); // triggers close → resolve ok in close handler
+        transport.end(); // polite close request; peer may ACK late or never
+        // Schedule logical finalize independently — do NOT block on socket
+        // close. setImmediate gives any in-flight microtasks (e.g. flushPage's
+        // last file-write) a tick to settle before we run finalize.
+        setImmediate(() => {
+          void doFinalize();
+        });
         return;
       }
       const state = graph.states[currentState];
@@ -288,20 +299,12 @@ export async function runScanSession<Ctx>(
       armTimeout(); // (T15)
     }
 
-    transport.on("error", (err) => {
-      settle({ ok: false, reason: err, finalCtx: ctx });
-    });
-
-    transport.on("close", () => {
-      if (settled) return;
-      if (currentState !== "DONE") {
-        settle({
-          ok: false,
-          reason: new Error(`Transport closed in state ${currentState}`),
-          finalCtx: ctx,
-        });
-        return;
-      }
+    /**
+     * Logical completion handler — runs after DONE is entered (via setImmediate).
+     * Handles zero-page rejection and finalizeSession. Idempotent via `settled`.
+     */
+    async function doFinalize(): Promise<void> {
+      if (settled) return; // already settled (race with unexpected close)
 
       // Zero-page rejection (spec §3.6). A graph reaching DONE without any
       // flushPage having fired is a real failure mode in production — typically
@@ -316,28 +319,45 @@ export async function runScanSession<Ctx>(
         return;
       }
 
-      // Run finalize (async). Wrap in an IIFE so the synchronous listener body
-      // doesn't return a Promise (avoids floating-promise lint issues).
-      void (async () => {
-        if (sessionTempDir) {
-          try {
-            const { finalizeSession } = await import("./output-tail.js");
-            await finalizeSession({
-              sessionTempDir,
-              outputDir: opts.outputDir,
-              sessionTs: opts.sessionTs,
-              action: opts.action,
-              backPageIndices,
-              paperless: opts.paperless,
-            });
-          } catch (err) {
-            const reason = err instanceof Error ? err : new Error(String(err));
-            settle({ ok: false, reason, finalCtx: ctx });
-            return;
-          }
+      if (sessionTempDir) {
+        try {
+          const { finalizeSession } = await import("./output-tail.js");
+          await finalizeSession({
+            sessionTempDir,
+            outputDir: opts.outputDir,
+            sessionTs: opts.sessionTs,
+            action: opts.action,
+            backPageIndices,
+            paperless: opts.paperless,
+          });
+        } catch (err) {
+          const reason = err instanceof Error ? err : new Error(String(err));
+          settle({ ok: false, reason, finalCtx: ctx });
+          return;
         }
-        settle({ ok: true, finalCtx: ctx });
-      })();
+      }
+      settle({ ok: true, finalCtx: ctx });
+    }
+
+    transport.on("error", (err) => {
+      settle({ ok: false, reason: err, finalCtx: ctx });
+    });
+
+    // Close handler — only handles unexpected closes. The DONE path settles
+    // via doFinalize (scheduled by enterState via setImmediate) independently
+    // of socket close. Two reasons this handler is a no-op on the DONE path:
+    // 1. If close fires after doFinalize has run, settled === true → return.
+    // 2. If close fires synchronously during transport.end() (e.g. FakeTransport
+    //    emits close in end()), currentState === "DONE" → return; doFinalize
+    //    will still run on the next tick and settle the promise.
+    transport.on("close", () => {
+      if (settled) return;
+      if (currentState === "DONE") return; // doFinalize handles this path
+      settle({
+        ok: false,
+        reason: new Error(`Transport closed unexpectedly in state ${currentState}`),
+        finalCtx: ctx,
+      });
     });
 
     transport.on("data", (chunk: Buffer) => {
@@ -369,20 +389,39 @@ export async function runScanSession<Ctx>(
      * awaiting an applyTransition) short-circuit; the active loop drains
      * any chunks they buffered on its next iteration.
      *
-     * The loop checks `paused` at every step — set during a flushPage
-     * barrier (Task 16) — and breaks out so multiple buffered packets in
-     * a single TCP chunk don't dispatch concurrently with a flush.
+     * The loop checks `paused`, `settled`, and `currentState === "DONE"` at
+     * every step — set during a flushPage barrier or after the session is
+     * finalized — so a buffered second packet in the same TCP chunk doesn't
+     * keep dispatching after the session has already completed or errored.
+     *
+     * Hook exceptions (from validate, decision, onEnter, send thunks, etc.)
+     * are caught here and routed through settle so they surface as
+     * { ok: false, reason } rather than unhandled Promise rejections.
      */
     async function tryDispatch(): Promise<void> {
       if (dispatching) return;
       dispatching = true;
       try {
         while (true) {
-          if (paused) return;
+          if (paused || settled || currentState === "DONE") return;
           const packet = tryParseHead();
           if (!packet) return;
-          await dispatchPacket(packet);
-          if (paused) return;
+          try {
+            await dispatchPacket(packet);
+          } catch (err) {
+            // Hook threw — route through settle rather than letting the
+            // rejection escape through the `void tryDispatch()` call site.
+            const reason = err instanceof Error ? err : new Error(String(err));
+            if (!settled) {
+              settle({
+                ok: false,
+                reason: new Error(`Engine error in state ${currentState}: ${reason.message}`),
+                finalCtx: ctx,
+              });
+            }
+            return;
+          }
+          if (paused || settled || currentState === "DONE") return;
         }
       } finally {
         dispatching = false;
@@ -566,6 +605,22 @@ export async function runScanSession<Ctx>(
     // (which may write the first command) synchronously inside the Promise
     // body, after all listeners are wired, so the first setImmediate
     // microtask queued by tests sees the writes.
-    enterState(graph.initial);
+    //
+    // Wrap in try/catch: if the initial onEnter hook throws, we route through
+    // settle rather than letting the Promise reject (which would violate the
+    // RunScanSessionResult contract and become an unhandled rejection at the
+    // call site, since callers await the result, not a thrown error).
+    try {
+      enterState(graph.initial);
+    } catch (err) {
+      const reason = err instanceof Error ? err : new Error(String(err));
+      settle({
+        ok: false,
+        reason: new Error(
+          `Engine error entering initial state ${graph.initial}: ${reason.message}`,
+        ),
+        finalCtx: ctx,
+      });
+    }
   });
 }

--- a/src/scan-session.ts
+++ b/src/scan-session.ts
@@ -299,15 +299,50 @@ export async function runScanSession<Ctx>(
 
     transport.on("close", () => {
       if (settled) return;
-      if (currentState === "DONE") {
-        settle({ ok: true, finalCtx: ctx });
-      } else {
+      if (currentState !== "DONE") {
         settle({
           ok: false,
           reason: new Error(`Transport closed in state ${currentState}`),
           finalCtx: ctx,
         });
+        return;
       }
+
+      // Zero-page rejection (spec §3.6). A graph reaching DONE without any
+      // flushPage having fired is a real failure mode in production — typically
+      // a printer-side error that aborted before pixel transfer started, or a
+      // protocol mis-script. Test-only escape via opts.allowZeroPages.
+      if (pageIndex === 0 && !opts.allowZeroPages) {
+        settle({
+          ok: false,
+          reason: new Error("Scan completed with zero image chunks"),
+          finalCtx: ctx,
+        });
+        return;
+      }
+
+      // Run finalize (async). Wrap in an IIFE so the synchronous listener body
+      // doesn't return a Promise (avoids floating-promise lint issues).
+      void (async () => {
+        if (sessionTempDir) {
+          try {
+            const { finalizeSession } = await import("./output-tail.js");
+            await finalizeSession({
+              sessionTempDir,
+              outputDir: opts.outputDir,
+              sessionTs: opts.sessionTs,
+              action: opts.action,
+              backPageIndices,
+              paperless: opts.paperless,
+            });
+          } catch (err) {
+            const reason = err instanceof Error ? err : new Error(String(err));
+            settle({ ok: false, reason, finalCtx: ctx });
+            return;
+          }
+        }
+        settle({ ok: true, finalCtx: ctx });
+      })();
     });
 
     transport.on("data", (chunk: Buffer) => {


### PR DESCRIPTION
## Summary

Second milestone of the v0.4.0 architecture rebuild ([spec](docs/superpowers/specs/2026-05-06-v0.4.0-architecture-design.md), [plan](docs/superpowers/plans/2026-05-06-v0.4.0-architecture.md)). Adds `src/scan-session.ts` — a generic, transport-blind scan-session engine that consumes a plain-data graph and runs it against a `SessionTransport`. **No protocol code consumes this yet** — that lands in M2 (esci2) and M3 (esci).

## Engine surface

```ts
export async function runScanSession<Ctx>(
  opts: RunScanSessionOpts<Ctx>,
): Promise<RunScanSessionResult<Ctx>>;
```

- **Plain-data Graph<Ctx>** with static + decision states. `createGraph` builder is authoring-only; `build()` returns a frozen graph the engine walks.
- **SessionTransport** — narrow `write` / `end` / `destroy` / `on('data'|'error'|'close')` interface. Both `tls.TLSSocket` and `net.Socket` satisfy it structurally; tests use a tiny EventEmitter-based fake.
- **Pump:** deferred-concat recv buffer; reads `payloadSize` directly from header bytes 6-9 (avoids the partial-buffer parseIsPacket stall). Async `tryDispatch` loop with `dispatching` reentrancy guard + `paused` checks at top of loop and after each await.
- **Static dispatch:** fail-fast on unmatched packet types. Optional `validate(payload)` hook fails session on false. Multi-write `send: SendSpec[]` for back-to-back ordered writes.
- **Decision dispatch:** `decision(fn)` states return `TransitionResult<Ctx>`; `{ error }` routes through settle.
- **onEnter hook** fires on state entry, allows send-then-await patterns (e.g. lock packet on connect).
- **Rolling timeout** — state-named diagnostic, suspended during flushPage barrier.
- **flushPage barrier:** stage next + send → pause → await encode → backPageIndices append + EXIF gate (jpg only) → write `page_NN.jpg` → unpause → apply staged send → enter staged next. Buffered packets dispatched after resume by the outer pump's natural continuation.
- **Action-gated EXIF:** Orientation=3 injection on back JPGs only; PDF mode skips. Silently fixes the unconditional injection at scanner-legacy.ts:785 that double-rotated PDF back pages.
- **Terminal DONE:** reserved name; engine wires `finalizeSession` from `output-tail.ts` on close.
- **Zero-page rejection:** `pageIndex === 0` on DONE without `allowZeroPages` settles `{ ok: false; reason: "Scan completed with zero image chunks" }`.
- **Idempotent settle:** `settled: boolean` guard; close handler short-circuits.
- **Factory failures:** `await transportFactory()` wrapped in try/catch returning `{ ok: false, reason, finalCtx }`.
- **`globalAbortHandlers` + `globalIgnoreFilter`** for protocol meta-events (e.g. ESC/I-2 0x9000 fatal/cancel/info, empty 0xa000 wait-for-body).

## Test plan

- [x] 23 unit tests in `src/scan-session.test.ts` covering every feature above. Engine behaves correctly under all spec'd paths.
- [x] `npm test` — **321 passed + 1 skipped** (was 298 + 1; +23 from M1).
- [x] `npm run lint` — clean.
- [x] `npm run format:check` — clean.
- [x] `npm run build && find dist -type d -name test-support` — clean dist.
- [x] `src/scan-session.ts` is **571 LOC**. The plan's "~250-350" estimate was light for a fully-typed surface; the actual engine logic is ~250 LOC, the rest is type definitions, builder code, and TSDoc.

## Followups

M2 (esci2 scanner refactored onto engine) lands next on `m2/esci2-onto-engine`. M3 (esci scanner rewritten) follows in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)