### PR TITLE
[codex] Polish code simplifier findings

### DIFF
--- a/src/esci2/graph.ts
+++ b/src/esci2/graph.ts
@@ -52,12 +52,11 @@ export const ESCI2_TIMEOUT_MS = 30_000;
 export const ESCI2_REPLY_SIZE = 64;
 const LEGACY_REPLY_SIZE = 1;
 const INIT_POLL_ITERATIONS = 3;
-// scanner.ts:120: 2000 zero-length retries gives ~40s of headroom for slow scan starts.
+// 2000 zero-length retries gives ~40s of headroom for slow scan starts.
 const MAX_ZERO_IMG_RETRIES = 2000;
 
 /**
  * Async-event dispatch bytes (type 0x9000 body[0]).
- * Verified against current src/esci2/scanner.ts:124-126.
  */
 const ASYNC_FATAL_BYTES = new Set([
   0x02, // Disconnect
@@ -126,14 +125,13 @@ function expectIsType(
 
 const g = createGraph<Esci2Ctx>("WELCOME", ESCI2_TIMEOUT_MS)
   // Empty 0xa000 envelopes are "wait for body" pre-data signals on the
-  // ESC/I-2 wire (current scanner.ts:393-396 silently logs and waits).
+  // ESC/I-2 wire.
   // Filter them out pre-dispatch so consumer states see only non-empty
   // 0xa000 packets.
   .globalIgnoreFilter((packet) => packet.type === 0xa000 && packet.payload.length === 0)
   // 0x9000 is the protocol-level async event channel: fatal/cancel
   // payloads abort the session regardless of state; ScanStart/Stop and
-  // unknown bytes are info-only (return null to ignore). Mirrors
-  // scanner.ts:345-387's existing handleAsyncEvent.
+  // unknown bytes are info-only (return null to ignore).
   .globalAbortHandlers({
     0x9000: (_ctx, packet) => {
       const dispatch = packet.payload.length > 0 ? packet.payload[0] : -1;
@@ -190,7 +188,6 @@ awaitAck(
 );
 
 // INIT2_FIN: 0xa000 FIN-ack → reset initPollIteration, send FS Y → INIT_POLL_FS_Y.
-// scanner.ts onInit2Fin: receives 0xa000, sets initPollIteration=0, sends buildPassthruPacket(buildFsY(), 1).
 awaitAck(
   g,
   "INIT2_FIN",
@@ -468,7 +465,7 @@ g.state("INIT_POLL_FS_Y", {
 // INIT_POLL_STAT: decision on STAT reply — drain if length>0, else FIN.
 // On the first iteration (ctx.initPollIteration === 0) also detects source:
 //   length 0 → ADF (no status queued); length 12 → flatbed (filler #---#---#---).
-//   Other lengths default to ADF (mirrors scanner.ts:619-633).
+//   Other lengths default to ADF, preserving the source-detection fallback.
 g.state(
   "INIT_POLL_STAT",
   decision<Esci2Ctx>((ctx, packet) => {
@@ -478,7 +475,7 @@ g.state(
     if (header === null) {
       return { error: new Error("INIT_POLL_STAT: unparseable reply header") };
     }
-    // Source detection — only on the FIRST iteration. Per scanner.ts:619-633:
+    // Source detection — only on the FIRST iteration:
     // length 0 → ADF (printer queued no status); length 12 → flatbed (queued
     // `#---#---#---` filler). Other lengths default to ADF with a comment.
     if (ctx.initPollIteration === 0) {
@@ -487,7 +484,7 @@ g.state(
       } else if (header.length === 12) {
         ctx.source = "flatbed";
       } else {
-        ctx.source = "adf"; // fallback per scanner.ts:626-627
+        ctx.source = "adf"; // fallback for unexpected status length
       }
     }
     if (header.length > 0) {
@@ -514,8 +511,8 @@ g.state("INIT_POLL_STAT_DRAIN", {
 });
 
 // INIT_POLL_FIN: decision on FIN reply — loop or advance to MODE_SWITCH.
-// scanner.ts onInitFin: increments initPollIteration; if <3 sends FS Y and
-// loops; else sends FS X and moves to MODE_SWITCH.
+// INIT_POLL_FIN increments initPollIteration; if <3 sends FS Y and loops;
+// else sends FS X and moves to MODE_SWITCH.
 g.state(
   "INIT_POLL_FIN",
   decision<Esci2Ctx>((ctx, packet) => {
@@ -529,7 +526,6 @@ g.state(
       };
     }
     // 3 iterations done — send FS X to enter extended mode → MODE_SWITCH.
-    // scanner.ts onInitFin: sends buildPassthruPacket(buildFsX(), LEGACY_REPLY_SIZE).
     return {
       next: "MODE_SWITCH",
       send: buildPassthruPacket(buildFsX(), LEGACY_REPLY_SIZE),
@@ -554,7 +550,6 @@ function buildParaSend(ctx: Esci2Ctx): Buffer[] {
 }
 
 // MODE_SWITCH: receives the FS X ack (payload[0]=0x06); sends STAT → POST_MODE_STAT.
-// scanner.ts onModeSwitch: validates ACK byte, sends STAT.
 g.state("MODE_SWITCH", {
   on: {
     0xa000: {
@@ -568,7 +563,6 @@ g.state("MODE_SWITCH", {
 // POST_MODE_STAT: decision on STAT reply.
 // If length>0 → pure-read drain → POST_MODE_STAT_DRAIN.
 // If length===0 → send PARA header + body → PARA.
-// scanner.ts onPostModeStat: same drain-or-skip logic; sendParaHeaderAndBody on both paths.
 g.state(
   "POST_MODE_STAT",
   decision<Esci2Ctx>((ctx, packet) => {
@@ -619,7 +613,6 @@ g.state("PARA", {
 });
 
 // TRDT: transfer-data handshake; sends IMG to start the image-receive loop.
-// scanner.ts onTrdt: receives 0xa000, sends IMG → IMG_META.
 g.state("TRDT", {
   on: {
     0xa000: {
@@ -636,7 +629,7 @@ g.state("TRDT", {
 // - Zero-length chunk with no page-end: zero-retry path (up to MAX_ZERO_IMG_RETRIES).
 // - Non-zero chunk size: resets zeroImgRetries, sends pure-read, advances to IMG_DATA.
 //
-// pageEndKind logic (mirrors scanner.ts:835-843):
+// pageEndKind logic:
 //   On flatbed, any #pen is terminal (glass is inherently single-page; #lft
 //   is never emitted on the flatbed path). On ADF, #lftd000 disambiguates
 //   "terminal" (last page) vs "page boundary, more coming".
@@ -662,7 +655,6 @@ g.state(
     }
     ctx.imgChunkSize = header.length;
     ctx.pageSide = tokens.get("typ") === "IMGB" ? "back" : "front";
-    // Per scanner.ts:835-842:
     // On flatbed, any #pen is terminal because the glass is single-page.
     // On ADF, #lftd000 disambiguates "terminal" vs "page boundary, more coming".
     if (tokens.has("pen")) {

--- a/src/esci2/scanner.test.ts
+++ b/src/esci2/scanner.test.ts
@@ -5,9 +5,13 @@ import os from "node:os";
 import { PDFDocument } from "pdf-lib";
 import { runEsci2Scan, withUnlockOnDestroy } from "./scanner.js";
 import type * as tls from "node:tls";
-import { buildIsPacket } from "../protocol.js";
+import { buildIsPacket, IS_HEADER_SIZE } from "../protocol.js";
 import { parseEsci2ReplyHeader } from "./commands.js";
 import { FakeTlsSocket } from "./test-support/fake-tls-socket.js";
+
+function waitImmediate(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
 
 // Fixed capability-body packets used by driveScannerToPara for both init cycles.
 // Scanner discards the body content (it just needs N bytes matching the declared
@@ -50,42 +54,42 @@ async function driveScannerToPara(args: {
 
   const feedEsci2Reply = async (bodyHex: string) => {
     fake.feed(buildIsPacket(0xa000, Buffer.alloc(0)));
-    await new Promise((r) => setImmediate(r));
+    await waitImmediate();
     fake.feed(buildIsPacket(0xa000, Buffer.from(bodyHex, "ascii")));
-    await new Promise((r) => setImmediate(r));
+    await waitImmediate();
   };
   const feedLegacyAck = async () => {
     fake.feed(buildIsPacket(0xa000, Buffer.from([0x06])));
-    await new Promise((r) => setImmediate(r));
+    await waitImmediate();
   };
 
   // Welcome + LOCK
   fake.feed(buildIsPacket(0x8000));
-  await new Promise((r) => setImmediate(r));
+  await waitImmediate();
   fake.feed(buildIsPacket(0xa100, Buffer.from([0x06])));
-  await new Promise((r) => setImmediate(r));
+  await waitImmediate();
 
   // Cycle 1: FS Y ACK, @INFO hdr+body, @CAPA hdr+body, FIN
   await feedLegacyAck();
   await feedEsci2Reply("INFOx00000F4");
   fake.feed(INFO_BODY_PACKET);
-  await new Promise((r) => setImmediate(r));
+  await waitImmediate();
   await feedEsci2Reply("CAPAx0000150");
   fake.feed(CAPA_BODY_PACKET);
-  await new Promise((r) => setImmediate(r));
+  await waitImmediate();
   await feedEsci2Reply("FIN x0000000");
 
   // Cycle 2: FS Z ACK, @INFO, @CAPA, @RESA, FIN
   await feedLegacyAck();
   await feedEsci2Reply("INFOx00000F4");
   fake.feed(INFO_BODY_PACKET);
-  await new Promise((r) => setImmediate(r));
+  await waitImmediate();
   await feedEsci2Reply("CAPAx0000150");
   fake.feed(CAPA_BODY_PACKET);
-  await new Promise((r) => setImmediate(r));
+  await waitImmediate();
   await feedEsci2Reply("RESAx00000A4");
   fake.feed(RESA_BODY_PACKET);
-  await new Promise((r) => setImmediate(r));
+  await waitImmediate();
   await feedEsci2Reply("FIN x0000000");
 
   // INIT_POLL cycle 1 with the test-provided STAT reply; drain if length > 0
@@ -95,9 +99,9 @@ async function driveScannerToPara(args: {
     parseEsci2ReplyHeader(Buffer.from(firstStatReplyHex, "ascii"))?.length ?? 0;
   if (firstStatLength > 0) {
     fake.feed(buildIsPacket(0xa000, Buffer.alloc(0)));
-    await new Promise((r) => setImmediate(r));
+    await waitImmediate();
     fake.feed(buildIsPacket(0xa000, Buffer.alloc(firstStatLength, 0x2d)));
-    await new Promise((r) => setImmediate(r));
+    await waitImmediate();
   }
   await feedEsci2Reply("FIN x0000000");
 
@@ -134,14 +138,14 @@ async function drivePastImgTerminator(
   });
   // PARA reply
   fake.feed(buildIsPacket(0xa000, Buffer.alloc(0)));
-  await new Promise((r) => setImmediate(r));
+  await waitImmediate();
   fake.feed(buildIsPacket(0xa000, Buffer.from("PARAx0000000#parOK", "ascii")));
-  await new Promise((r) => setImmediate(r));
+  await waitImmediate();
   await feedEsci2Reply("TRDTx0000000");
   // One IMG packet with a 4-byte JPEG body, then a terminal #pen-without-#lft
   await feedEsci2Reply("IMG x0000004#pst");
   fake.feed(buildIsPacket(0xa000, Buffer.from("ffd8ffd9", "hex")));
-  await new Promise((r) => setImmediate(r));
+  await waitImmediate();
   // Snapshot writes before the page-end feed; wait for the engine's response
   // (FIN for flatbed-terminal, IMG for ADF-more) before returning.
   const writesBeforePageEnd = fake.writes.length;
@@ -282,7 +286,7 @@ async function replayCapture(
   for (const rec of filtered) {
     if (rec.hook === "recv") {
       fake.feed(Buffer.from(rec.payload_hex ?? "", "hex"));
-      await new Promise((r) => setImmediate(r));
+      await waitImmediate();
     } else {
       // Wait for the scanner to produce this write — handles the engine's
       // async flushPage barrier (multi-microtask: await encode → file I/O →
@@ -295,9 +299,9 @@ async function replayCapture(
     }
   }
 
-  // Let finalizeScan's deferred writeFileSync run to completion.
-  await new Promise((r) => setImmediate(r));
-  await new Promise((r) => setImmediate(r));
+  // Let the DONE-path finalization task run to completion.
+  await waitImmediate();
+  await waitImmediate();
 
   const totalDriverSends = filtered.filter((r) => r.hook === "send").length;
   return { totalDriverSends, scannerWrites: fake.writes, sessionPromise };
@@ -504,9 +508,9 @@ describe("scanner targeted tests — error paths", () => {
     const rejectsAssertion = expect(sessionPromise).rejects.toThrow(/fatal/i);
     fake.simulateConnect();
     fake.feed(buildIsPacket(0x8000));
-    await new Promise((r) => setImmediate(r));
+    await waitImmediate();
     fake.feed(buildIsPacket(0x9000, Buffer.from([0xa0])));
-    await new Promise((r) => setImmediate(r));
+    await waitImmediate();
 
     const lastWrite = fake.writes[fake.writes.length - 1];
     expect(lastWrite.readUInt16BE(2)).toBe(0x2101); // UNLOCK packet type
@@ -534,10 +538,10 @@ describe("scanner targeted tests — error paths", () => {
     );
     fake.simulateConnect();
     fake.feed(buildIsPacket(0x8000));
-    await new Promise((r) => setImmediate(r));
+    await waitImmediate();
     const lockWriteIdx = fake.writes.length;
     fake.feed(buildIsPacket(0xffff));
-    await new Promise((r) => setImmediate(r));
+    await waitImmediate();
 
     const postErrorWrites = fake.writes.slice(lockWriteIdx);
     const sawUnlock = postErrorWrites.some((w) => w.length >= 4 && w.readUInt16BE(2) === 0x2101);
@@ -565,10 +569,10 @@ describe("scanner targeted tests — error paths", () => {
     const rejectsAssertion = expect(sessionPromise).rejects.toThrow(/TLS connection error/i);
     fake.simulateConnect();
     fake.feed(buildIsPacket(0x8000));
-    await new Promise((r) => setImmediate(r));
+    await waitImmediate();
     // Simulate a mid-scan socket error (e.g., printer reboots).
     fake.emit("error", Object.assign(new Error("EPIPE"), { code: "EPIPE" }));
-    await new Promise((r) => setImmediate(r));
+    await waitImmediate();
     // The promise should reject with a classified error message.
     await rejectsAssertion;
     // Last write should be the UNLOCK packet, proving transitionToError ran.
@@ -778,7 +782,7 @@ describe("withUnlockOnDestroy wrapper", () => {
   // IS-header byte 2-3 carries packet type. LOCK is 0x2100, UNLOCK 0x2101 —
   // the wrapper sniffs writes by these bytes to track session state.
   function makeIsTypeStub(typeLo: number): Buffer {
-    const buf = Buffer.alloc(12);
+    const buf = Buffer.alloc(IS_HEADER_SIZE);
     buf[2] = 0x21;
     buf[3] = typeLo;
     return buf;
@@ -934,7 +938,7 @@ describe("runEsci2Scan failure-mode matrix", () => {
       // rejection isn't momentarily unhandled (FakeTlsSocket.destroy() is sync,
       // so the close event fires inside advanceTimersByTimeAsync).
       const rejectsAssertion = expect(scanPromise).rejects.toThrow(/timeout/i);
-      // TIMEOUT_MS is 30_000 in scanner.ts (line 113); 60_000 overshoots safely.
+      // The graph timeout is 30_000 ms; 60_000 overshoots safely.
       await vi.advanceTimersByTimeAsync(60_000);
       await rejectsAssertion;
     } finally {
@@ -1005,9 +1009,8 @@ describe("runEsci2Scan failure-mode matrix", () => {
       fake.asFactory(),
     );
     fake.simulateConnect();
-    // ASYNC_FATAL in scanner.ts:124 contains 0x02 (Disconnect), 0x80 (Timeout),
-    // 0xa0 (ServerError). Use 0x02. (0x05 is "unknown" and falls through to
-    // log.warn with no rejection.)
+    // The ESC/I-2 graph treats 0x02 (Disconnect), 0x80 (Timeout), and
+    // 0xa0 (ServerError) as fatal. Use 0x02. (0x05 is info-only and does not reject.)
     const fatalPacket = buildIsPacket(0x9000, Buffer.from([0x02]));
     // Attach handler before feeding — FakeTlsSocket.destroy() fires "close"
     // synchronously, rejecting the promise inside fake.feed().

--- a/src/scan-session.ts
+++ b/src/scan-session.ts
@@ -446,7 +446,7 @@ export async function runScanSession<Ctx>(
      * either — against the current ctx into a flat array of byte buffers
      * to write in order. Empty array means "no writes."
      */
-    function resolveSend(send: SendSpec<Ctx> | SendSpec<Ctx>[] | Buffer | undefined): Buffer[] {
+    function resolveSend(send: SendSpec<Ctx> | SendSpec<Ctx>[] | undefined): Buffer[] {
       if (!send) return [];
       const items = Array.isArray(send) ? send : [send];
       return items.map((s) => (typeof s === "function" ? s(ctx) : s));
@@ -509,7 +509,7 @@ export async function runScanSession<Ctx>(
      * than calling parseIsPacket on a partial buffer, which would return
      * null for any packet whose payload exceeds the peek window).
      */
-    function tryParseHead(): { type: number; payload: Buffer; totalSize: number } | null {
+    function tryParseHead(): { type: number; payload: Buffer } | null {
       if (recvBytes < IS_HEADER_SIZE) return null;
 
       // Ensure first chunk has at least IS_HEADER_SIZE bytes so we can read
@@ -545,7 +545,7 @@ export async function runScanSession<Ctx>(
       const remainder = merged.subarray(totalSize);
       recvBytes = remainder.length;
       if (remainder.length > 0) recvChunks.push(remainder);
-      return { type, payload, totalSize };
+      return { type, payload };
     }
 
     async function dispatchPacket(packet: { type: number; payload: Buffer }): Promise<void> {
@@ -618,7 +618,7 @@ export async function runScanSession<Ctx>(
      */
     async function applyTransition(t: {
       next: string;
-      send?: SendSpec<Ctx> | SendSpec<Ctx>[] | Buffer | Buffer[];
+      send?: SendSpec<Ctx> | SendSpec<Ctx>[];
       flushPage?: PageFlush;
     }): Promise<void> {
       if (t.flushPage) {


### PR DESCRIPTION
## Summary

- Remove stale refactor-era scanner references from ESC/I-2 graph comments and tests.
- Tighten scan-session engine helper types by dropping redundant Buffer union members and the unused parsed packet totalSize return.
- Replace repeated scanner-test setImmediate boilerplate with a local helper and use IS_HEADER_SIZE for IS packet stubs.

## Validation

- npm test -- src/esci2/scanner.test.ts src/scan-session.test.ts
- npm run format:check
- npm run lint
- npm test