### PR TITLE
M3: esci scanner rewritten onto engine

### DIFF
--- a/src/esci/graph.test.ts
+++ b/src/esci/graph.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { esciGraph, ESCI_TIMEOUT_MS, ESCI_REPLY, type EsciCtx } from "./graph.js";
-import { parseFsGReply } from "./commands.js";
 
 function makeCtx(overrides: Partial<EsciCtx> = {}): EsciCtx {
   return {
@@ -14,10 +13,9 @@ function makeCtx(overrides: Partial<EsciCtx> = {}): EsciCtx {
     inInterPageLoop: false,
     pageCount: 0,
     gammaChannelIdx: 0,
-    fsGReply: null,
+    geom: null,
     imageBuffer: Buffer.alloc(0),
     imageBufferOffset: 0,
-    expectedBytes: 0,
     ...overrides,
   };
 }
@@ -292,13 +290,9 @@ describe("esciGraph reset / gamma / window / start cycles", () => {
       payload.writeUInt32LE(7002, 10);
       const result = state.decide(ctx, { type: ESCI_REPLY, payload });
       expect("next" in result && result.next).toBe("IMG_RECEIVING");
-      expect(ctx.expectedBytes).toBeGreaterThan(0);
-      expect(ctx.imageBuffer.length).toBe(ctx.expectedBytes);
-      // Sanity-check the parsed reply was retained on ctx.
-      expect(ctx.fsGReply).not.toBeNull();
-      expect(ctx.fsGReply!.chunkSize).toBe(0x1000);
-      // parseFsGReply round-trip
-      expect(parseFsGReply(payload).chunkSize).toBe(0x1000);
+      expect(ctx.imageBuffer.length).toBeGreaterThan(0);
+      expect(ctx.geom).not.toBeNull();
+      expect(ctx.imageBuffer.length).toBe(ctx.geom!.widthPx * ctx.geom!.heightPx * 3);
     }
   });
 
@@ -326,11 +320,16 @@ describe("esciGraph reset / gamma / window / start cycles", () => {
 });
 
 describe("esciGraph IMG_RECEIVING / PAGE_EJECT_WAIT / cleanup", () => {
+  // Stub geometry sized so widthPx * heightPx * 3 = the test's pre-allocated
+  // imageBuffer length. flush.encode() is never invoked from these tests, so
+  // dpi / topYOffsetPx values don't matter — only the dimensions feed back
+  // into the IMG_RECEIVING flush spec.
+  const stubGeom = { dpi: 300, widthPx: 1, heightPx: 2, topYOffsetPx: 0 };
+
   it("IMG_RECEIVING accumulates mid-page chunks without advancing", () => {
     const state = esciGraph.states.IMG_RECEIVING;
     if (state.kind === "decision") {
       const ctx = makeCtx({
-        expectedBytes: 100,
         imageBuffer: Buffer.alloc(100),
         imageBufferOffset: 0,
       });
@@ -348,7 +347,7 @@ describe("esciGraph IMG_RECEIVING / PAGE_EJECT_WAIT / cleanup", () => {
     if (state.kind === "decision") {
       const ctx = makeCtx({
         source: "flatbed",
-        expectedBytes: 6,
+        geom: stubGeom,
         imageBuffer: Buffer.alloc(6),
         imageBufferOffset: 0,
       });
@@ -366,7 +365,7 @@ describe("esciGraph IMG_RECEIVING / PAGE_EJECT_WAIT / cleanup", () => {
     if (state.kind === "decision") {
       const ctx = makeCtx({
         source: "adf-duplex",
-        expectedBytes: 6,
+        geom: stubGeom,
         imageBuffer: Buffer.alloc(6),
         imageBufferOffset: 0,
       });
@@ -384,7 +383,7 @@ describe("esciGraph IMG_RECEIVING / PAGE_EJECT_WAIT / cleanup", () => {
       const ctx = makeCtx({
         source: "adf-duplex",
         pageCount: 1, // about to flush page 2 (back)
-        expectedBytes: 6,
+        geom: stubGeom,
         imageBuffer: Buffer.alloc(6),
         imageBufferOffset: 0,
       });

--- a/src/esci/graph.test.ts
+++ b/src/esci/graph.test.ts
@@ -1,0 +1,434 @@
+import { describe, it, expect } from "vitest";
+import { esciGraph, ESCI_TIMEOUT_MS, ESCI_REPLY, type EsciCtx } from "./graph.js";
+import { parseFsGReply } from "./commands.js";
+
+function makeCtx(overrides: Partial<EsciCtx> = {}): EsciCtx {
+  return {
+    duplex: false,
+    forcedSource: null,
+    source: "adf-simplex",
+    format: "jpg",
+    jpegQuality: 90,
+    diagnoseProtocol: false,
+    onSourceDetected: undefined,
+    inInterPageLoop: false,
+    pageCount: 0,
+    gammaChannelIdx: 0,
+    fsGReply: null,
+    imageBuffer: Buffer.alloc(0),
+    imageBufferOffset: 0,
+    expectedBytes: 0,
+    ...overrides,
+  };
+}
+
+describe("esciGraph (smoke)", () => {
+  it("builds with the expected initial state and timeout", () => {
+    expect(esciGraph.initial).toBe("WELCOME");
+    expect(esciGraph.timeoutMs).toBe(ESCI_TIMEOUT_MS);
+    expect(esciGraph.timeoutMs).toBe(60_000);
+  });
+
+  it("declares the cleanup states for post-scan-save fallback", () => {
+    expect(esciGraph.cleanupStates).toBeDefined();
+    expect(esciGraph.cleanupStates!.has("CLEANUP_1")).toBe(true);
+    expect(esciGraph.cleanupStates!.has("CLEANUP_2")).toBe(true);
+    expect(esciGraph.cleanupStates!.has("UNLOCKING")).toBe(true);
+    // POST_STATUS is intentionally NOT a cleanup state.
+    expect(esciGraph.cleanupStates!.has("POST_STATUS")).toBe(false);
+  });
+});
+
+describe("esciGraph WELCOME / LOCKING / INIT", () => {
+  it("WELCOME advances to LOCKING on 0x8000 with a lock-packet send", () => {
+    const state = esciGraph.states.WELCOME;
+    expect(state.kind).toBe("static");
+    if (state.kind === "static") {
+      expect(state.on[0x8000]?.next).toBe("LOCKING");
+      expect(state.on[0x8000]?.send).toBeDefined();
+    }
+  });
+
+  it("LOCKING advances to INIT on 0xa100 with an ESC @ passthru send", () => {
+    const state = esciGraph.states.LOCKING;
+    expect(state.kind).toBe("static");
+    if (state.kind === "static") {
+      expect(state.on[0xa100]?.next).toBe("INIT");
+      expect(state.on[0xa100]?.send).toBeDefined();
+    }
+  });
+
+  it("INIT advances to IDENTITY on a valid ESC @ ack", () => {
+    const state = esciGraph.states.INIT;
+    expect(state.kind).toBe("decision");
+    if (state.kind === "decision") {
+      const ctx = makeCtx();
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload: Buffer.from([0x06]) });
+      expect("next" in result && result.next).toBe("IDENTITY");
+      expect("send" in result && result.send).toBeDefined();
+    }
+  });
+
+  it("INIT advances to DIAGNOSE_INIT_PROBE on NAK when diagnoseProtocol is true", () => {
+    const state = esciGraph.states.INIT;
+    if (state.kind === "decision") {
+      const ctx = makeCtx({ diagnoseProtocol: true });
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload: Buffer.from([0x15]) });
+      expect("next" in result && result.next).toBe("DIAGNOSE_INIT_PROBE");
+    }
+  });
+
+  it("INIT errors on NAK when diagnoseProtocol is false", () => {
+    const state = esciGraph.states.INIT;
+    if (state.kind === "decision") {
+      const ctx = makeCtx();
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload: Buffer.from([0x15]) });
+      expect("error" in result).toBe(true);
+      if ("error" in result) expect(result.error.message).toMatch(/expected ESC @ ack/);
+    }
+  });
+
+  it("DIAGNOSE_INIT_PROBE always errors with the diagnostic-complete message", () => {
+    const state = esciGraph.states.DIAGNOSE_INIT_PROBE;
+    if (state.kind === "decision") {
+      const ctx = makeCtx({ diagnoseProtocol: true });
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload: Buffer.from([0x06]) });
+      expect("error" in result).toBe(true);
+      if ("error" in result) expect(result.error.message).toMatch(/diagnostic probe complete/);
+    }
+  });
+});
+
+describe("esciGraph IDENTITY / STATUS_1A / STATUS_1B / STATUS_2", () => {
+  it("IDENTITY advances to STATUS_1A on an 80-byte identity reply", () => {
+    const state = esciGraph.states.IDENTITY;
+    expect(state.kind).toBe("static");
+    if (state.kind === "static") {
+      expect(state.on[ESCI_REPLY]?.next).toBe("STATUS_1A");
+      expect(state.on[ESCI_REPLY]?.send).toBeDefined();
+    }
+  });
+
+  it("STATUS_1A jumps to CLEANUP_1 when inInterPageLoop and byte 0 = 0x81", () => {
+    const state = esciGraph.states.STATUS_1A;
+    if (state.kind === "decision") {
+      const ctx = makeCtx({ inInterPageLoop: true });
+      const payload = Buffer.alloc(16);
+      payload[0] = 0x81;
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload });
+      expect("next" in result && result.next).toBe("CLEANUP_1");
+      expect(ctx.inInterPageLoop).toBe(false);
+    }
+  });
+
+  it("STATUS_1A advances to STATUS_1B otherwise", () => {
+    const state = esciGraph.states.STATUS_1A;
+    if (state.kind === "decision") {
+      const ctx = makeCtx();
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload: Buffer.alloc(16) });
+      expect("next" in result && result.next).toBe("STATUS_1B");
+    }
+  });
+
+  it("STATUS_1B routes to ADF_IDENTITY_A in the inter-page loop", () => {
+    const state = esciGraph.states.STATUS_1B;
+    if (state.kind === "decision") {
+      const ctx = makeCtx({ inInterPageLoop: true });
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload: Buffer.alloc(16) });
+      expect("next" in result && result.next).toBe("ADF_IDENTITY_A");
+    }
+  });
+
+  it("STATUS_1B routes to SOURCE_ACK1 with ESC e + 0x01 probe initially", () => {
+    const state = esciGraph.states.STATUS_1B;
+    if (state.kind === "decision") {
+      const ctx = makeCtx();
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload: Buffer.alloc(16) });
+      expect("next" in result && result.next).toBe("SOURCE_ACK1");
+      expect("send" in result && Array.isArray(result.send)).toBe(true);
+    }
+  });
+
+  it("STATUS_2 routes to RESET_PAREN when byte 0 = 0x81 (busy)", () => {
+    const state = esciGraph.states.STATUS_2;
+    if (state.kind === "decision") {
+      const ctx = makeCtx();
+      const payload = Buffer.alloc(16);
+      payload[0] = 0x81;
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload });
+      expect("next" in result && result.next).toBe("RESET_PAREN");
+      expect(ctx.source).toBe("flatbed");
+    }
+  });
+
+  it("STATUS_2 routes to ADF_PRESRC_ACK1 when byte 0 = 0x01 (ADF) and duplex=false", () => {
+    const state = esciGraph.states.STATUS_2;
+    if (state.kind === "decision") {
+      const ctx = makeCtx();
+      const payload = Buffer.alloc(16);
+      payload[0] = 0x01;
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload });
+      expect("next" in result && result.next).toBe("ADF_PRESRC_ACK1");
+      expect(ctx.source).toBe("adf-simplex");
+    }
+  });
+
+  it("STATUS_2 routes to ADF_PRESRC_ACK1 with adf-duplex source when duplex=true", () => {
+    const state = esciGraph.states.STATUS_2;
+    if (state.kind === "decision") {
+      const ctx = makeCtx({ duplex: true });
+      const payload = Buffer.alloc(16);
+      payload[0] = 0x01;
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload });
+      expect("next" in result && result.next).toBe("ADF_PRESRC_ACK1");
+      expect(ctx.source).toBe("adf-duplex");
+    }
+  });
+
+  it("STATUS_2 errors with the compatibility-issue message on unrecognised byte", () => {
+    const state = esciGraph.states.STATUS_2;
+    if (state.kind === "decision") {
+      const ctx = makeCtx();
+      const payload = Buffer.alloc(16);
+      payload[0] = 0x42;
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload });
+      expect("error" in result).toBe(true);
+      if ("error" in result) expect(result.error.message).toMatch(/Unrecognised FS F status 0x42/);
+    }
+  });
+
+  it("STATUS_2 forcedSource shortcuts the byte-0 detection", () => {
+    const state = esciGraph.states.STATUS_2;
+    if (state.kind === "decision") {
+      const ctx = makeCtx({ forcedSource: "adf-duplex" });
+      const payload = Buffer.alloc(16);
+      payload[0] = 0x42;
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload });
+      expect(ctx.source).toBe("adf-duplex");
+      // 0x42 is not 0x81 and ctx.source !== "flatbed", so we expect ADF branch.
+      expect("next" in result && result.next).toBe("ADF_PRESRC_ACK1");
+    }
+  });
+
+  it("STATUS_2 calls onSourceDetected with the resolved source", () => {
+    const state = esciGraph.states.STATUS_2;
+    if (state.kind === "decision") {
+      const seen: string[] = [];
+      const ctx = makeCtx({ onSourceDetected: (s) => seen.push(s) });
+      const payload = Buffer.alloc(16);
+      payload[0] = 0x01;
+      state.decide(ctx, { type: ESCI_REPLY, payload });
+      expect(seen).toEqual(["adf-simplex"]);
+    }
+  });
+});
+
+describe("esciGraph helper-generated *_ACK1 / *_ACK2 states", () => {
+  for (const prefix of ["SOURCE", "ADF_PRESRC", "RESET_SRC", "ADF_PDF_SRC", "ADF_CLEANUP"]) {
+    it(`${prefix}_ACK1 / ${prefix}_ACK2 are static states that validate ack byte 0x06`, () => {
+      const ack1 = esciGraph.states[`${prefix}_ACK1`];
+      const ack2 = esciGraph.states[`${prefix}_ACK2`];
+      expect(ack1?.kind).toBe("static");
+      expect(ack2?.kind).toBe("static");
+      if (ack1?.kind === "static") {
+        expect(ack1.on[ESCI_REPLY]?.next).toBe(`${prefix}_ACK2`);
+        expect(ack1.on[ESCI_REPLY]?.validate?.(Buffer.from([0x06]))).toBe(true);
+        expect(ack1.on[ESCI_REPLY]?.validate?.(Buffer.from([0x15]))).toBe(false);
+      }
+    });
+  }
+});
+
+describe("esciGraph reset / gamma / window / start cycles", () => {
+  it("RESET_PAREN advances on a 1-byte reply", () => {
+    const state = esciGraph.states.RESET_PAREN;
+    if (state.kind === "static") {
+      expect(state.on[ESCI_REPLY]?.next).toBe("RESET_INIT");
+      expect(state.on[ESCI_REPLY]?.validate?.(Buffer.from([0x06]))).toBe(true);
+      expect(state.on[ESCI_REPLY]?.validate?.(Buffer.from([0x80]))).toBe(true);
+    }
+  });
+
+  it("GAMMA_DATA loops through three channels then advances to WINDOW_CMD", () => {
+    const state = esciGraph.states.GAMMA_DATA;
+    if (state.kind === "decision") {
+      const ctx = makeCtx({ gammaChannelIdx: 0 });
+      let result = state.decide(ctx, { type: ESCI_REPLY, payload: Buffer.from([0x06]) });
+      expect("next" in result && result.next).toBe("GAMMA_CMD");
+      expect(ctx.gammaChannelIdx).toBe(1);
+
+      result = state.decide(ctx, { type: ESCI_REPLY, payload: Buffer.from([0x06]) });
+      expect("next" in result && result.next).toBe("GAMMA_CMD");
+      expect(ctx.gammaChannelIdx).toBe(2);
+
+      result = state.decide(ctx, { type: ESCI_REPLY, payload: Buffer.from([0x06]) });
+      expect("next" in result && result.next).toBe("WINDOW_CMD");
+      expect(ctx.gammaChannelIdx).toBe(0); // reset for next session
+    }
+  });
+
+  it("START routes to START_POLL when chunkSize=0", () => {
+    const state = esciGraph.states.START;
+    if (state.kind === "decision") {
+      const ctx = makeCtx();
+      // 14-byte FS G reply: status(2) + chunkSize(4) + bytesPerLine(4) + totalLines(4)
+      const payload = Buffer.alloc(14);
+      payload.writeUInt16BE(0x0000, 0); // status
+      payload.writeUInt32LE(0, 2); // chunkSize = 0 → poll path
+      payload.writeUInt32LE(1, 6);
+      payload.writeUInt32LE(1, 10);
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload });
+      expect("next" in result && result.next).toBe("START_POLL");
+    }
+  });
+
+  it("START routes to IMG_RECEIVING when chunkSize > 0 and allocates the per-page buffer", () => {
+    const state = esciGraph.states.START;
+    if (state.kind === "decision") {
+      const ctx = makeCtx({ source: "flatbed", format: "jpg" });
+      const payload = Buffer.alloc(14);
+      payload.writeUInt32LE(0x1000, 2); // chunkSize
+      payload.writeUInt32LE(0x06d6, 6);
+      payload.writeUInt32LE(7002, 10);
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload });
+      expect("next" in result && result.next).toBe("IMG_RECEIVING");
+      expect(ctx.expectedBytes).toBeGreaterThan(0);
+      expect(ctx.imageBuffer.length).toBe(ctx.expectedBytes);
+      // Sanity-check the parsed reply was retained on ctx.
+      expect(ctx.fsGReply).not.toBeNull();
+      expect(ctx.fsGReply!.chunkSize).toBe(0x1000);
+      // parseFsGReply round-trip
+      expect(parseFsGReply(payload).chunkSize).toBe(0x1000);
+    }
+  });
+
+  it("START_POLL advances to START_POLL_READY on byte 0 = 0x01", () => {
+    const state = esciGraph.states.START_POLL;
+    if (state.kind === "decision") {
+      const ctx = makeCtx();
+      const payload = Buffer.alloc(16);
+      payload[0] = 0x01;
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload });
+      expect("next" in result && result.next).toBe("START_POLL_READY");
+    }
+  });
+
+  it("START_POLL re-loops on byte 0 ≠ 0x01", () => {
+    const state = esciGraph.states.START_POLL;
+    if (state.kind === "decision") {
+      const ctx = makeCtx();
+      const payload = Buffer.alloc(16);
+      payload[0] = 0x00;
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload });
+      expect("next" in result && result.next).toBe("START_POLL");
+    }
+  });
+});
+
+describe("esciGraph IMG_RECEIVING / PAGE_EJECT_WAIT / cleanup", () => {
+  it("IMG_RECEIVING accumulates mid-page chunks without advancing", () => {
+    const state = esciGraph.states.IMG_RECEIVING;
+    if (state.kind === "decision") {
+      const ctx = makeCtx({
+        expectedBytes: 100,
+        imageBuffer: Buffer.alloc(100),
+        imageBufferOffset: 0,
+      });
+      // IS-0xa200 chunk: leading status byte then pixel bytes
+      const chunk = Buffer.concat([Buffer.from([0x01]), Buffer.alloc(20, 0xb0)]);
+      const result = state.decide(ctx, { type: 0xa200, payload: chunk });
+      expect("next" in result && result.next).toBe("IMG_RECEIVING");
+      expect(ctx.imageBufferOffset).toBe(20);
+      expect("flushPage" in result).toBe(false);
+    }
+  });
+
+  it("IMG_RECEIVING flushes the page on completion (flatbed → POST_STATUS)", () => {
+    const state = esciGraph.states.IMG_RECEIVING;
+    if (state.kind === "decision") {
+      const ctx = makeCtx({
+        source: "flatbed",
+        expectedBytes: 6,
+        imageBuffer: Buffer.alloc(6),
+        imageBufferOffset: 0,
+      });
+      const chunk = Buffer.concat([Buffer.from([0x01]), Buffer.alloc(6, 0xb0)]);
+      const result = state.decide(ctx, { type: 0xa200, payload: chunk });
+      if ("error" in result) throw new Error("unexpected error result");
+      expect(result.next).toBe("POST_STATUS");
+      expect(result.flushPage?.side).toBe("front");
+      expect(ctx.pageCount).toBe(1);
+    }
+  });
+
+  it("IMG_RECEIVING flushes and routes to PAGE_EJECT_WAIT for ADF", () => {
+    const state = esciGraph.states.IMG_RECEIVING;
+    if (state.kind === "decision") {
+      const ctx = makeCtx({
+        source: "adf-duplex",
+        expectedBytes: 6,
+        imageBuffer: Buffer.alloc(6),
+        imageBufferOffset: 0,
+      });
+      const chunk = Buffer.concat([Buffer.from([0x01]), Buffer.alloc(6, 0xb0)]);
+      const result = state.decide(ctx, { type: 0xa200, payload: chunk });
+      if ("error" in result) throw new Error("unexpected error result");
+      expect(result.next).toBe("PAGE_EJECT_WAIT");
+      expect(result.flushPage?.side).toBe("front"); // page 1 = front
+    }
+  });
+
+  it("IMG_RECEIVING marks back side on even ADF-duplex pages", () => {
+    const state = esciGraph.states.IMG_RECEIVING;
+    if (state.kind === "decision") {
+      const ctx = makeCtx({
+        source: "adf-duplex",
+        pageCount: 1, // about to flush page 2 (back)
+        expectedBytes: 6,
+        imageBuffer: Buffer.alloc(6),
+        imageBufferOffset: 0,
+      });
+      const chunk = Buffer.concat([Buffer.from([0x01]), Buffer.alloc(6, 0xb0)]);
+      const result = state.decide(ctx, { type: 0xa200, payload: chunk });
+      if ("error" in result) throw new Error("unexpected error result");
+      expect(result.flushPage?.side).toBe("back");
+    }
+  });
+
+  it("PAGE_EJECT_WAIT sets inInterPageLoop and routes to STATUS_1A", () => {
+    const state = esciGraph.states.PAGE_EJECT_WAIT;
+    if (state.kind === "decision") {
+      const ctx = makeCtx({ inInterPageLoop: false });
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload: Buffer.from([0x06]) });
+      expect("next" in result && result.next).toBe("STATUS_1A");
+      expect(ctx.inInterPageLoop).toBe(true);
+    }
+  });
+
+  it("CLEANUP_1 routes to ADF_CLEANUP_ACK1 for ADF sources", () => {
+    const state = esciGraph.states.CLEANUP_1;
+    if (state.kind === "decision") {
+      const ctx = makeCtx({ source: "adf-simplex" });
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload: Buffer.from([0x80]) });
+      expect("next" in result && result.next).toBe("ADF_CLEANUP_ACK1");
+    }
+  });
+
+  it("CLEANUP_1 routes to CLEANUP_2 for flatbed", () => {
+    const state = esciGraph.states.CLEANUP_1;
+    if (state.kind === "decision") {
+      const ctx = makeCtx({ source: "flatbed" });
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload: Buffer.from([0x80]) });
+      expect("next" in result && result.next).toBe("CLEANUP_2");
+    }
+  });
+
+  it("UNLOCKING is a static state with onEnter sending the unlock packet", () => {
+    const state = esciGraph.states.UNLOCKING;
+    expect(state.kind).toBe("static");
+    if (state.kind === "static") {
+      expect(state.onEnter).toBeDefined();
+      expect(state.on[0xa101]?.next).toBe("DONE");
+    }
+  });
+});

--- a/src/esci/graph.ts
+++ b/src/esci/graph.ts
@@ -1,0 +1,669 @@
+// src/esci/graph.ts
+//
+// ESC/I (legacy WF-3620) scan-session graph. Built atop the protocol-blind
+// engine in src/scan-session.ts. Mirrors the wire sequence captured from
+// real-hardware Wireshark pcaps; replay tests in src/esci/scanner.test.ts
+// pin every byte we emit.
+//
+// Patterned after src/esci2/graph.ts:
+//   - `expectIsType` guard at the top of every decision state
+//   - `awaitReply` helper for "static state: wait for type, validate, advance+send"
+//   - `escEThenAck` helper for the "ESC e + param then 2 ACKs" pattern that
+//     recurs five times in the ESC/I init / cleanup flows
+//   - all sends live on upstream transitions; only UNLOCKING uses onEnter
+//     (to preserve wire order: ack-of-prev → unlock).
+
+import {
+  createGraph,
+  decision,
+  type Graph,
+  type GraphBuilder,
+  type SendSpec,
+} from "../scan-session.js";
+import {
+  buildLockPacket,
+  buildUnlockPacket,
+  buildPassthruPacket,
+  buildIsPacket,
+} from "../protocol.js";
+import {
+  buildEscInit,
+  buildFsI,
+  buildFsF,
+  buildEscE,
+  buildEscParen,
+  buildEscZ,
+  buildFsW,
+  buildFsG,
+  buildEscCleanup,
+  buildPageEject,
+  buildFsWBlock,
+  buildStreamConfigPayload,
+  parseFsGReply,
+  geometry,
+  legacyDetectSource,
+  SOURCE_BYTE,
+  type Source,
+  type Format,
+  type FsGReply,
+} from "./commands.js";
+// FS Y is the ET-4950 ESC/I-2 init's first command. We use it here only for
+// the DIAGNOSE_PROTOCOL probe — sent after ESC @ NAKs to classify printers
+// stuck between ESC/I and ESC/I-2.
+import { buildFsY } from "../esci2/commands.js";
+import { GAMMA_LUT_R, GAMMA_LUT_G, GAMMA_LUT_B } from "./luts.js";
+import { encodeRawGbrToJpeg } from "./raw-to-jpeg.js";
+
+/**
+ * Per-session mutable state threaded through every transition. The engine
+ * owns sessionTempDir / pageIndex / backPageIndices bookkeeping; everything
+ * here is ESC/I-protocol-specific.
+ */
+export interface EsciCtx {
+  duplex: boolean;
+  forcedSource: Source | null;
+  /** Set in STATUS_2 from the FS F byte (or ctx.forcedSource). */
+  source: Source;
+  format: Format;
+  jpegQuality: number;
+  /** When true, a non-ACK reply to ESC @ triggers an FS Y diagnostic probe. */
+  diagnoseProtocol: boolean;
+  /** Optional test hook fired once when STATUS_2 has decided the source. */
+  onSourceDetected?: (source: Source) => void;
+  /** True when looping back for the back side of a duplex sheet (or next ADF page). */
+  inInterPageLoop: boolean;
+  /** Page count, 1-indexed during dispatch (incremented just before flush). */
+  pageCount: number;
+  /** Gamma channel iterator (R/G/B). */
+  gammaChannelIdx: number;
+  /** Cached parsed FS G reply for the current page. */
+  fsGReply: FsGReply | null;
+  /** Per-page pixel buffer + write offset (allocated on first chunk after FS G). */
+  imageBuffer: Buffer;
+  imageBufferOffset: number;
+  expectedBytes: number;
+}
+
+export const ESCI_TIMEOUT_MS = 60_000;
+
+// IS-0xa000 carries every ESC/I passthru-reply (ACKs, identity, status).
+// IS-0x8000 = welcome; IS-0xa100 = lock-ack; IS-0xa101 = unlock-ack;
+// IS-0xa200 = unsolicited image chunks. The plan's `0x2000` placeholder for
+// ESCI_PASSTHRU_REPLY was the host-side outbound passthru envelope — the
+// matching reply is in 0xa000.
+export const ESCI_REPLY = 0xa000;
+const ACK_BYTE = 0x06;
+// Driver always probes with 0x01 (ADF-simplex) regardless of intended source —
+// matches the Windows driver and ensures the 0x81 busy cycle fires on flatbed.
+const PROBE_SOURCE_BYTE = 0x01;
+
+const GAMMA_CHANNELS = [
+  { tag: 0x52, lut: GAMMA_LUT_R },
+  { tag: 0x47, lut: GAMMA_LUT_G },
+  { tag: 0x42, lut: GAMMA_LUT_B },
+] as const;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function isAck(payload: Buffer): boolean {
+  return payload.length === 1 && payload[0] === ACK_BYTE;
+}
+
+function passthru(cmd: Buffer, replySize: number): Buffer {
+  return buildPassthruPacket(cmd, replySize);
+}
+
+const sendEscZ = (): Buffer => passthru(buildEscZ(), 1);
+const sendFsF = (): Buffer => passthru(buildFsF(), 16);
+const sendFsI = (): Buffer => passthru(buildFsI(), 80);
+const sendEscCleanup = (): Buffer => passthru(buildEscCleanup(), 1);
+
+/** ESC e + 1-byte source param, sent as two back-to-back passthrus. */
+function sendEscEPlusByte(byte: number): SendSpec<EsciCtx>[] {
+  return [passthru(buildEscE(), 1), passthru(Buffer.from([byte]), 1)];
+}
+
+/** ESC e + ctx-resolved source byte. Used in reset / cleanup paths. */
+const sendEscEPlusCtxSource: SendSpec<EsciCtx>[] = [
+  passthru(buildEscE(), 1),
+  (ctx: EsciCtx) => passthru(Buffer.from([SOURCE_BYTE[ctx.source]]), 1),
+];
+
+/**
+ * Guard helper for decision states (mirrors src/esci2/graph.ts:expectIsType):
+ * ensure the incoming packet matches the expected IS type. Returns an Error
+ * TransitionResult on mismatch (engine routes through the failure path);
+ * returns null to continue.
+ */
+function expectIsType(
+  packet: { type: number },
+  expected: number,
+  stateName: string,
+): { error: Error } | null {
+  if (packet.type !== expected) {
+    return {
+      error: new Error(
+        `${stateName}: expected packet type 0x${expected.toString(16).padStart(4, "0")}, got 0x${packet.type.toString(16).padStart(4, "0")}`,
+      ),
+    };
+  }
+  return null;
+}
+
+/**
+ * awaitReply — registers a static state that waits for `expectedReplyType`,
+ * runs `validate` against the payload, then advances to `next` (optionally
+ * emitting `send`). Mirrors the role of esci2/graph.ts:awaitAck but accepts
+ * a custom payload validator (ESC/I has length-based replies of 1, 14, 16
+ * and 80 bytes — not just the single-byte ack pattern).
+ */
+function awaitReply(
+  g: GraphBuilder<EsciCtx>,
+  name: string,
+  expectedReplyType: number,
+  validate: (payload: Buffer) => boolean,
+  next: string,
+  send?: SendSpec<EsciCtx> | SendSpec<EsciCtx>[],
+): void {
+  g.state(name, {
+    on: {
+      [expectedReplyType]: {
+        validate,
+        next,
+        ...(send !== undefined ? { send } : {}),
+      },
+    },
+  });
+}
+
+/**
+ * escEThenAck — collapses the "ESC e + param then 2 ACKs" pattern that
+ * recurs five times in the ESC/I init flow. The caller's upstream
+ * transition emits both the ESC e opcode and the source-byte param via
+ * `send: SendSpec[]`; this helper just registers the two ACK-wait states.
+ * After ACK2, control flows to `next` — and the helper emits `nextSend`
+ * (typically the FS F or ESC z that the destination state expects to
+ * receive a reply for).
+ */
+function escEThenAck(
+  g: GraphBuilder<EsciCtx>,
+  prefix: string,
+  next: string,
+  nextSend?: SendSpec<EsciCtx> | SendSpec<EsciCtx>[],
+): void {
+  awaitReply(g, `${prefix}_ACK1`, ESCI_REPLY, isAck, `${prefix}_ACK2`);
+  awaitReply(g, `${prefix}_ACK2`, ESCI_REPLY, isAck, next, nextSend);
+}
+
+/** Strip the leading status byte from an IS-0xa200 chunk and copy pixel tail. */
+export function appendImageChunk(payload: Buffer, dest: Buffer, offset: number): number {
+  if (payload.length === 0) return offset;
+  payload.subarray(1).copy(dest, offset);
+  return offset + payload.length - 1;
+}
+
+function computeExpectedBytes(source: Source, format: Format): number {
+  const geom = geometry({ source, format });
+  return geom.widthPx * geom.heightPx * 3;
+}
+
+const length1 = (p: Buffer): boolean => p.length === 1;
+const length16 = (p: Buffer): boolean => p.length === 16;
+const length80 = (p: Buffer): boolean => p.length === 80;
+const length14 = (p: Buffer): boolean => p.length === 14;
+
+// =============================================================================
+// Graph builder
+// =============================================================================
+
+const g = createGraph<EsciCtx>("WELCOME", ESCI_TIMEOUT_MS);
+
+// =============================================================================
+// WELCOME / LOCKING / INIT (+ DIAGNOSE_INIT_PROBE)
+// =============================================================================
+
+// WELCOME: 0x8000 from printer → host sends LOCK → LOCKING.
+awaitReply(g, "WELCOME", 0x8000, () => true, "LOCKING", buildLockPacket());
+
+// LOCKING: 0xa100 lock-ack → send ESC @ → INIT.
+awaitReply(g, "LOCKING", 0xa100, () => true, "INIT", passthru(buildEscInit(), 1));
+
+// INIT: ESC @ ack-or-NAK. ACK → IDENTITY (FS I); NAK + diagnoseProtocol →
+// DIAGNOSE_INIT_PROBE (FS Y); NAK + !diagnose → fail with the canonical
+// "expected ESC @ ack, got type=0x{type} payload={hex}" message.
+g.state(
+  "INIT",
+  decision<EsciCtx>((ctx, packet) => {
+    if (packet.type === ESCI_REPLY && isAck(packet.payload)) {
+      return { next: "IDENTITY", send: sendFsI() };
+    }
+    if (ctx.diagnoseProtocol) {
+      return { next: "DIAGNOSE_INIT_PROBE", send: passthru(buildFsY(), 1) };
+    }
+    return {
+      error: new Error(
+        `expected ESC @ ack, got type=0x${packet.type.toString(16)} payload=${packet.payload.toString("hex")}`,
+      ),
+    };
+  }),
+);
+
+// DIAGNOSE_INIT_PROBE: terminal diagnostic state. Whatever comes back, fail
+// with the "diagnostic probe complete" message the test pins.
+g.state(
+  "DIAGNOSE_INIT_PROBE",
+  decision<EsciCtx>(() => ({
+    error: new Error(
+      "diagnostic probe complete — please share the [diagnose] log lines on the GitHub issue",
+    ),
+  })),
+);
+
+// =============================================================================
+// IDENTITY → STATUS_1A → STATUS_1B → SOURCE probe → STATUS_2 (decision)
+// =============================================================================
+
+// IDENTITY: 80-byte identity payload (we don't decode it) → STATUS_1A, send FS F.
+awaitReply(g, "IDENTITY", ESCI_REPLY, length80, "STATUS_1A", sendFsF());
+
+// STATUS_1A: first FS F status reply. In the inter-page loop, byte 0 = 0x81
+// (ADF empty) jumps straight to cleanup; 0x01 means more paper. On initial
+// setup, always proceed to STATUS_1B.
+g.state(
+  "STATUS_1A",
+  decision<EsciCtx>((ctx, packet) => {
+    const typeGuard = expectIsType(packet, ESCI_REPLY, "STATUS_1A");
+    if (typeGuard) return typeGuard;
+    if (packet.payload.length !== 16) {
+      return { error: new Error(`STATUS_1A: expected 16-byte status, got ${packet.payload.length}`) };
+    }
+    if (ctx.inInterPageLoop && packet.payload[0] === 0x81) {
+      ctx.inInterPageLoop = false;
+      return { next: "CLEANUP_1", send: sendEscCleanup() };
+    }
+    return { next: "STATUS_1B", send: sendFsF() };
+  }),
+);
+
+// STATUS_1B: second FS F status reply. Initial setup → ESC e + probe param;
+// inter-page loop (duplex back side) → ADF_IDENTITY_A.
+g.state(
+  "STATUS_1B",
+  decision<EsciCtx>((ctx, packet) => {
+    const typeGuard = expectIsType(packet, ESCI_REPLY, "STATUS_1B");
+    if (typeGuard) return typeGuard;
+    if (packet.payload.length !== 16) {
+      return { error: new Error(`STATUS_1B: expected 16-byte status, got ${packet.payload.length}`) };
+    }
+    if (ctx.inInterPageLoop) {
+      return { next: "ADF_IDENTITY_A", send: sendFsI() };
+    }
+    return { next: "SOURCE_ACK1", send: sendEscEPlusByte(PROBE_SOURCE_BYTE) };
+  }),
+);
+
+// SOURCE_ACK1/ACK2 → STATUS_2 (with FS F to populate the status reply).
+escEThenAck(g, "SOURCE", "STATUS_2", sendFsF());
+
+// STATUS_2: decision on the FS F reply.
+//   - 0x81 → busy / flatbed → reset cycle (RESET_PAREN, send ESC ()
+//   - 0x01 → ADF (duplex/simplex per ctx) → pre-reset probe (ADF_PRESRC, send ESC e + 0x01)
+//   - other → unrecognised, fail with the compatibility-issue message
+//   - forcedSource shortcuts the byte-0 detection but the rest of the
+//     branch logic still depends on whether the wire byte is 0x81 (busy).
+g.state(
+  "STATUS_2",
+  decision<EsciCtx>((ctx, packet) => {
+    const typeGuard = expectIsType(packet, ESCI_REPLY, "STATUS_2");
+    if (typeGuard) return typeGuard;
+    if (packet.payload.length !== 16) {
+      return {
+        error: new Error(`STATUS_2: expected 16-byte status, got ${packet.payload.length}`),
+      };
+    }
+    const statusByte = packet.payload[0];
+    if (ctx.forcedSource) {
+      ctx.source = ctx.forcedSource;
+    } else {
+      const result = legacyDetectSource(statusByte, ctx.duplex);
+      if (!result.ok) {
+        return {
+          error: new Error(
+            `Unrecognised FS F status 0x${result.byte.toString(16).padStart(2, "0")} ` +
+              `— please file a compatibility issue with LOG_LEVEL=debug output ` +
+              `(see CONTRIBUTING.md). Workaround: set ESCI_FORCE_SOURCE.`,
+          ),
+        };
+      }
+      ctx.source = result.source;
+    }
+    ctx.onSourceDetected?.(ctx.source);
+
+    if (statusByte === 0x81) {
+      return { next: "RESET_PAREN", send: passthru(buildEscParen(), 1) };
+    }
+    if (ctx.source !== "flatbed") {
+      return { next: "ADF_PRESRC_ACK1", send: sendEscEPlusByte(PROBE_SOURCE_BYTE) };
+    }
+    // Flatbed reached without busy cycle (rare — most flatbeds reach 0x81 first).
+    return { next: "GAMMA_CMD", send: sendEscZ() };
+  }),
+);
+
+// =============================================================================
+// ADF pre-reset cycle
+// =============================================================================
+
+// ADF_PRESRC_ACK1/ACK2 → ADF_STATUS_3 (with FS F).
+escEThenAck(g, "ADF_PRESRC", "ADF_STATUS_3", sendFsF());
+
+// ADF_STATUS_3: third FS F status check (ADF only); flows into the reset cycle.
+awaitReply(g, "ADF_STATUS_3", ESCI_REPLY, length16, "RESET_PAREN", passthru(buildEscParen(), 1));
+
+// =============================================================================
+// Reset cycle: ESC ( → ESC @ → ESC e + source → FS F → STATUS_READY
+// =============================================================================
+
+// RESET_PAREN: 1-byte ESC ( reply (0x06 or 0x80; both fine) → RESET_INIT, send ESC @.
+awaitReply(g, "RESET_PAREN", ESCI_REPLY, length1, "RESET_INIT", passthru(buildEscInit(), 1));
+
+// RESET_INIT: ACK for ESC @ → RESET_SRC_ACK1, send ESC e + ctx.source byte.
+awaitReply(g, "RESET_INIT", ESCI_REPLY, isAck, "RESET_SRC_ACK1", sendEscEPlusCtxSource);
+
+// RESET_SRC_ACK1/ACK2 → STATUS_READY (with FS F).
+escEThenAck(g, "RESET_SRC", "STATUS_READY", sendFsF());
+
+// STATUS_READY: 16-byte FS F reply. ADF sources read identity twice; flatbed
+// jumps straight to the gamma phase.
+g.state(
+  "STATUS_READY",
+  decision<EsciCtx>((ctx, packet) => {
+    const typeGuard = expectIsType(packet, ESCI_REPLY, "STATUS_READY");
+    if (typeGuard) return typeGuard;
+    if (packet.payload.length !== 16) {
+      return {
+        error: new Error(`STATUS_READY: expected 16-byte status, got ${packet.payload.length}`),
+      };
+    }
+    if (ctx.source !== "flatbed") {
+      return { next: "ADF_IDENTITY_A", send: sendFsI() };
+    }
+    return { next: "GAMMA_CMD", send: sendEscZ() };
+  }),
+);
+
+// =============================================================================
+// ADF post-reset identity reads + ADF+PDF extra source-set
+// =============================================================================
+
+// ADF_IDENTITY_A: 80-byte identity → ADF_IDENTITY_B, send FS I.
+awaitReply(g, "ADF_IDENTITY_A", ESCI_REPLY, length80, "ADF_IDENTITY_B", sendFsI());
+
+// ADF_IDENTITY_B: 80-byte identity. JPEG initial / inter-page loop → GAMMA_CMD;
+// PDF initial → extra ESC e + ctx.source byte before gamma.
+g.state(
+  "ADF_IDENTITY_B",
+  decision<EsciCtx>((ctx, packet) => {
+    const typeGuard = expectIsType(packet, ESCI_REPLY, "ADF_IDENTITY_B");
+    if (typeGuard) return typeGuard;
+    if (packet.payload.length !== 80) {
+      return { error: new Error(`ADF_IDENTITY_B: expected 80-byte identity, got ${packet.payload.length}`) };
+    }
+    if (ctx.format === "pdf" && !ctx.inInterPageLoop) {
+      return { next: "ADF_PDF_SRC_ACK1", send: sendEscEPlusCtxSource };
+    }
+    ctx.inInterPageLoop = false;
+    return { next: "GAMMA_CMD", send: sendEscZ() };
+  }),
+);
+
+// ADF_PDF_SRC_ACK1/ACK2 → GAMMA_CMD (with ESC z).
+escEThenAck(g, "ADF_PDF_SRC", "GAMMA_CMD", sendEscZ());
+
+// =============================================================================
+// Gamma phase — three identical ESC z + LUT cycles for R/G/B (driven via
+// ctx.gammaChannelIdx, so two states represent all six wire exchanges).
+// =============================================================================
+
+// GAMMA_CMD: ACK for ESC z → GAMMA_DATA, send tag + LUT for current channel.
+g.state("GAMMA_CMD", {
+  on: {
+    [ESCI_REPLY]: {
+      validate: isAck,
+      next: "GAMMA_DATA",
+      send: (ctx: EsciCtx) => {
+        const ch = GAMMA_CHANNELS[ctx.gammaChannelIdx];
+        return passthru(Buffer.concat([Buffer.from([ch.tag]), ch.lut]), 1);
+      },
+    },
+  },
+});
+
+// GAMMA_DATA: ACK for the LUT body. Advance channel; loop or proceed to WINDOW.
+g.state(
+  "GAMMA_DATA",
+  decision<EsciCtx>((ctx, packet) => {
+    const typeGuard = expectIsType(packet, ESCI_REPLY, "GAMMA_DATA");
+    if (typeGuard) return typeGuard;
+    if (!isAck(packet.payload)) {
+      return { error: new Error(`GAMMA_DATA: expected gamma LUT ack (channel ${ctx.gammaChannelIdx})`) };
+    }
+    if (ctx.gammaChannelIdx + 1 < GAMMA_CHANNELS.length) {
+      ctx.gammaChannelIdx += 1;
+      return { next: "GAMMA_CMD", send: sendEscZ() };
+    }
+    ctx.gammaChannelIdx = 0;
+    return { next: "WINDOW_CMD", send: passthru(buildFsW(), 1) };
+  }),
+);
+
+// =============================================================================
+// Window + Stream-Config + START
+// =============================================================================
+
+// WINDOW_CMD: ACK for FS W → WINDOW_DATA, send 64-byte FS W block.
+g.state("WINDOW_CMD", {
+  on: {
+    [ESCI_REPLY]: {
+      validate: isAck,
+      next: "WINDOW_DATA",
+      send: (ctx: EsciCtx) =>
+        passthru(buildFsWBlock({ source: ctx.source, format: ctx.format }), 1),
+    },
+  },
+});
+
+// WINDOW_DATA: ACK for the FS W block → STATUS_PRESCAN, send FS F.
+awaitReply(g, "WINDOW_DATA", ESCI_REPLY, isAck, "STATUS_PRESCAN", sendFsF());
+
+// STATUS_PRESCAN: 16-byte FS F → START, send FS G.
+awaitReply(g, "STATUS_PRESCAN", ESCI_REPLY, length16, "START", passthru(buildFsG(), 14));
+
+// START: decision on FS G's 14-byte reply. chunkSize=0 → poll FS F until
+// ready. Otherwise allocate the per-page buffer, send the IS-0x2200 stream-
+// config payload (no reply), and enter IMG_RECEIVING.
+g.state(
+  "START",
+  decision<EsciCtx>((ctx, packet) => {
+    const typeGuard = expectIsType(packet, ESCI_REPLY, "START");
+    if (typeGuard) return typeGuard;
+    if (!length14(packet.payload)) {
+      return { error: new Error(`START: expected 14-byte FS G reply, got ${packet.payload.length}`) };
+    }
+    const reply = parseFsGReply(packet.payload);
+    ctx.fsGReply = reply;
+    if (reply.chunkSize === 0) {
+      return { next: "START_POLL", send: sendFsF() };
+    }
+    ctx.expectedBytes = computeExpectedBytes(ctx.source, ctx.format);
+    ctx.imageBuffer = Buffer.alloc(ctx.expectedBytes);
+    ctx.imageBufferOffset = 0;
+    return {
+      next: "IMG_RECEIVING",
+      send: buildIsPacket(0x2200, buildStreamConfigPayload(reply, ctx.format)),
+    };
+  }),
+);
+
+// START_POLL: keep polling FS F until status byte 0 = 0x01 (ready); then one
+// confirmation FS F via START_POLL_READY before re-issuing FS G.
+g.state(
+  "START_POLL",
+  decision<EsciCtx>((_ctx, packet) => {
+    const typeGuard = expectIsType(packet, ESCI_REPLY, "START_POLL");
+    if (typeGuard) return typeGuard;
+    if (!length16(packet.payload)) {
+      return { error: new Error(`START_POLL: expected 16-byte status, got ${packet.payload.length}`) };
+    }
+    if (packet.payload[0] === 0x01) {
+      return { next: "START_POLL_READY", send: sendFsF() };
+    }
+    return { next: "START_POLL", send: sendFsF() };
+  }),
+);
+
+// START_POLL_READY: final 16-byte FS F → re-send FS G, return to START.
+awaitReply(g, "START_POLL_READY", ESCI_REPLY, length16, "START", passthru(buildFsG(), 14));
+
+// =============================================================================
+// IMG_RECEIVING — pixel stream + flushPage barrier (replaces ~80 LOC of
+// async-encode glue and the encodingDeferred[]/deferredImageChunks[] queues
+// the original scanner needed because the legacy state machine had no way to
+// pause for an async encode).
+// =============================================================================
+
+g.state(
+  "IMG_RECEIVING",
+  decision<EsciCtx>((ctx, packet) => {
+    if (packet.type !== 0xa200) {
+      return {
+        error: new Error(
+          `IMG_RECEIVING: expected IS-0xa200 image chunk, got 0x${packet.type.toString(16).padStart(4, "0")}`,
+        ),
+      };
+    }
+    ctx.imageBufferOffset = appendImageChunk(packet.payload, ctx.imageBuffer, ctx.imageBufferOffset);
+    if (ctx.imageBufferOffset < ctx.expectedBytes) {
+      return { next: "IMG_RECEIVING" };
+    }
+
+    // Page complete — assemble + dispatch flushPage barrier. Increment
+    // BEFORE computing side so pageCount represents the 1-indexed page
+    // we're about to flush; even pageCount → ADF-duplex back side
+    // (matches scanner.ts pageNum = pageCount + 1 then `pageNum % 2 === 0`).
+    ctx.pageCount += 1;
+    const isBack = ctx.source === "adf-duplex" && ctx.pageCount % 2 === 0;
+    const geom = geometry({ source: ctx.source, format: ctx.format });
+    const rawRgb = ctx.imageBuffer;
+    const quality = ctx.jpegQuality;
+    // Reset per-page buffer state so the next page (if any) starts fresh.
+    ctx.imageBuffer = Buffer.alloc(0);
+    ctx.imageBufferOffset = 0;
+    ctx.expectedBytes = 0;
+
+    // Flatbed: skip eject; go to POST_STATUS. ADF: send 0x0c 0x00 page-eject;
+    // PAGE_EJECT_WAIT then waits for the ACK and decides the next page.
+    const flush = {
+      side: isBack ? ("back" as const) : ("front" as const),
+      encode: () => encodeRawGbrToJpeg(rawRgb, geom.widthPx, geom.heightPx, quality),
+    };
+    if (ctx.source === "flatbed") {
+      return { next: "POST_STATUS", send: sendFsF(), flushPage: flush };
+    }
+    return {
+      next: "PAGE_EJECT_WAIT",
+      send: passthru(buildPageEject(), 1),
+      flushPage: flush,
+    };
+  }),
+);
+
+// =============================================================================
+// PAGE_EJECT_WAIT — ADF only; ACKs the 0x0c 0x00 eject, sets the inter-page
+// flag, and routes back to STATUS_1A which decides whether to continue (more
+// paper) or wrap up (ADF empty). Decision so we can mutate ctx and emit FS F
+// in the same transition.
+// =============================================================================
+
+g.state(
+  "PAGE_EJECT_WAIT",
+  decision<EsciCtx>((ctx, packet) => {
+    const typeGuard = expectIsType(packet, ESCI_REPLY, "PAGE_EJECT_WAIT");
+    if (typeGuard) return typeGuard;
+    if (!length1(packet.payload)) {
+      return { error: new Error(`PAGE_EJECT_WAIT: expected 1-byte page-eject ACK, got ${packet.payload.length}`) };
+    }
+    ctx.inInterPageLoop = true;
+    return { next: "STATUS_1A", send: sendFsF() };
+  }),
+);
+
+// =============================================================================
+// POST-IMAGE cleanup: POST_STATUS → CLEANUP_1 → (ADF: cleanup-src cycle) →
+//                     CLEANUP_2 → UNLOCKING → DONE
+// =============================================================================
+
+// POST_STATUS: 16-byte FS F → CLEANUP_1, send ESC ).
+awaitReply(g, "POST_STATUS", ESCI_REPLY, length16, "CLEANUP_1", sendEscCleanup());
+
+// CLEANUP_1: 1-byte ESC ) reply (0x06 ACK or 0x80 NAK; both fine).
+//   ADF → re-set source via ESC e + source byte → ADF_CLEANUP_ACK1
+//   Flatbed → second ESC ) directly → CLEANUP_2
+g.state(
+  "CLEANUP_1",
+  decision<EsciCtx>((ctx, packet) => {
+    const typeGuard = expectIsType(packet, ESCI_REPLY, "CLEANUP_1");
+    if (typeGuard) return typeGuard;
+    if (!length1(packet.payload)) {
+      return { error: new Error(`CLEANUP_1: expected 1-byte ESC ) reply, got ${packet.payload.length}`) };
+    }
+    if (ctx.source !== "flatbed") {
+      return { next: "ADF_CLEANUP_ACK1", send: sendEscEPlusCtxSource };
+    }
+    return { next: "CLEANUP_2", send: sendEscCleanup() };
+  }),
+);
+
+// ADF_CLEANUP_ACK1/ACK2 → ADF_CLEANUP_STATUS (with FS F).
+escEThenAck(g, "ADF_CLEANUP", "ADF_CLEANUP_STATUS", sendFsF());
+
+// ADF_CLEANUP_STATUS: 16-byte FS F → CLEANUP_2, send ESC ).
+awaitReply(g, "ADF_CLEANUP_STATUS", ESCI_REPLY, length16, "CLEANUP_2", sendEscCleanup());
+
+// CLEANUP_2: 1-byte ESC ) reply → UNLOCKING. UNLOCKING's onEnter sends the
+// unlock packet so the bytes land AFTER CLEANUP_2's reply, preserving wire
+// order vs. fixtures (mirrors esci2/graph.ts UNLOCKING shape).
+awaitReply(g, "CLEANUP_2", ESCI_REPLY, length1, "UNLOCKING");
+
+// UNLOCKING: onEnter sends the unlock packet; awaits 0xa101 ack → DONE.
+g.state("UNLOCKING", {
+  onEnter: () => buildUnlockPacket(),
+  on: {
+    0xa101: { next: "DONE" },
+  },
+});
+
+// =============================================================================
+// Cleanup states — post-image-transfer panel hygiene. A failure in any of
+// these recovers via the engine's post-scan-save fallback (v0.3.0 §3.3)
+// provided at least one page has flushed. POST_STATUS is intentionally NOT
+// in this list (treated as part of image-acquisition close — a failure
+// there can signal a real transfer-end protocol error).
+// =============================================================================
+
+g.cleanupStates([
+  "CLEANUP_1",
+  "ADF_CLEANUP_ACK1",
+  "ADF_CLEANUP_ACK2",
+  "ADF_CLEANUP_STATUS",
+  "CLEANUP_2",
+  "UNLOCKING",
+]);
+
+// =============================================================================
+// Export the built graph
+// =============================================================================
+
+export const esciGraph: Graph<EsciCtx> = g.build();

--- a/src/esci/graph.ts
+++ b/src/esci/graph.ts
@@ -45,6 +45,9 @@ import {
 import { buildFsY } from "../esci2/commands.js";
 import { GAMMA_LUT_R, GAMMA_LUT_G, GAMMA_LUT_B } from "./luts.js";
 import { encodeRawGbrToJpeg } from "./raw-to-jpeg.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("scanner-esci");
 
 /**
  * Per-session mutable state threaded through every transition. The engine
@@ -245,26 +248,42 @@ g.state(
     if (packet.type === ESCI_REPLY && isAck(packet.payload)) {
       return { next: "IDENTITY", send: sendFsI() };
     }
+    const detail = `type=0x${packet.type.toString(16)} payload=${packet.payload.toString("hex")}`;
     if (ctx.diagnoseProtocol) {
+      // Compatibility-report breadcrumb. README + config.ts both promise this
+      // [diagnose] line; the terminal error in DIAGNOSE_INIT_PROBE asks the
+      // user to share these lines on the GitHub issue.
+      log.info(
+        `[diagnose] ESC @ returned non-ACK (${detail}) — sending FS Y probe to classify protocol`,
+      );
       return { next: "DIAGNOSE_INIT_PROBE", send: passthru(buildFsY(), 1) };
     }
-    return {
-      error: new Error(
-        `expected ESC @ ack, got type=0x${packet.type.toString(16)} payload=${packet.payload.toString("hex")}`,
-      ),
-    };
+    return { error: new Error(`expected ESC @ ack, got ${detail}`) };
   }),
 );
 
-// DIAGNOSE_INIT_PROBE: terminal diagnostic state. Whatever comes back, fail
-// with the "diagnostic probe complete" message the test pins.
+// DIAGNOSE_INIT_PROBE: terminal diagnostic state. Log the FS Y outcome with
+// enough detail for a compatibility-issue triage, then fail with the
+// "diagnostic probe complete" message the test pins.
 g.state(
   "DIAGNOSE_INIT_PROBE",
-  decision<EsciCtx>(() => ({
-    error: new Error(
-      "diagnostic probe complete — please share the [diagnose] log lines on the GitHub issue",
-    ),
-  })),
+  decision<EsciCtx>((_ctx, packet) => {
+    const detail = `type=0x${packet.type.toString(16)} payload=${packet.payload.toString("hex")}`;
+    if (packet.type === ESCI_REPLY && isAck(packet.payload)) {
+      log.info(
+        `[diagnose] FS Y returned ACK (${detail}) — printer likely speaks ESC/I-2 over plain TCP (ET-4950-style init, no TLS).`,
+      );
+    } else {
+      log.info(
+        `[diagnose] FS Y returned non-ACK (${detail}) — printer rejects both legacy ESC @ and ESC/I-2 FS Y; protocol family unknown.`,
+      );
+    }
+    return {
+      error: new Error(
+        "diagnostic probe complete — please share the [diagnose] log lines on the GitHub issue",
+      ),
+    };
+  }),
 );
 
 // =============================================================================

--- a/src/esci/graph.ts
+++ b/src/esci/graph.ts
@@ -3,15 +3,7 @@
 // ESC/I (legacy WF-3620) scan-session graph. Built atop the protocol-blind
 // engine in src/scan-session.ts. Mirrors the wire sequence captured from
 // real-hardware Wireshark pcaps; replay tests in src/esci/scanner.test.ts
-// pin every byte we emit.
-//
-// Patterned after src/esci2/graph.ts:
-//   - `expectIsType` guard at the top of every decision state
-//   - `awaitReply` helper for "static state: wait for type, validate, advance+send"
-//   - `escEThenAck` helper for the "ESC e + param then 2 ACKs" pattern that
-//     recurs five times in the ESC/I init / cleanup flows
-//   - all sends live on upstream transitions; only UNLOCKING uses onEnter
-//     (to preserve wire order: ack-of-prev → unlock).
+// pin every byte we emit. Structurally parallels src/esci2/graph.ts.
 
 import {
   createGraph,
@@ -45,10 +37,10 @@ import {
   SOURCE_BYTE,
   type Source,
   type Format,
-  type FsGReply,
+  type ScanGeometry,
 } from "./commands.js";
-// FS Y is the ET-4950 ESC/I-2 init's first command. We use it here only for
-// the DIAGNOSE_PROTOCOL probe — sent after ESC @ NAKs to classify printers
+// FS Y is the ET-4950 ESC/I-2 init's first command. Used here only for the
+// DIAGNOSE_PROTOCOL probe — sent after ESC @ NAKs to classify printers
 // stuck between ESC/I and ESC/I-2.
 import { buildFsY } from "../esci2/commands.js";
 import { GAMMA_LUT_R, GAMMA_LUT_G, GAMMA_LUT_B } from "./luts.js";
@@ -76,21 +68,22 @@ export interface EsciCtx {
   pageCount: number;
   /** Gamma channel iterator (R/G/B). */
   gammaChannelIdx: number;
-  /** Cached parsed FS G reply for the current page. */
-  fsGReply: FsGReply | null;
-  /** Per-page pixel buffer + write offset (allocated on first chunk after FS G). */
+  /**
+   * Per-page pixel buffer + write offset. Allocated in START once FS G has
+   * confirmed the scan geometry; reset to a length-0 buffer between pages so
+   * `imageBufferOffset < imageBuffer.length` is the page-complete check.
+   */
   imageBuffer: Buffer;
   imageBufferOffset: number;
-  expectedBytes: number;
+  /** Cached scan geometry (set in START alongside the imageBuffer allocation). */
+  geom: ScanGeometry | null;
 }
 
 export const ESCI_TIMEOUT_MS = 60_000;
 
 // IS-0xa000 carries every ESC/I passthru-reply (ACKs, identity, status).
 // IS-0x8000 = welcome; IS-0xa100 = lock-ack; IS-0xa101 = unlock-ack;
-// IS-0xa200 = unsolicited image chunks. The plan's `0x2000` placeholder for
-// ESCI_PASSTHRU_REPLY was the host-side outbound passthru envelope — the
-// matching reply is in 0xa000.
+// IS-0xa200 = unsolicited image chunks.
 export const ESCI_REPLY = 0xa000;
 const ACK_BYTE = 0x06;
 // Driver always probes with 0x01 (ADF-simplex) regardless of intended source —
@@ -197,6 +190,25 @@ function escEThenAck(
   awaitReply(g, `${prefix}_ACK2`, ESCI_REPLY, isAck, next, nextSend);
 }
 
+/**
+ * Decision-state guard for length-checked ESC/I replies. Companion to
+ * `expectIsType` — returns an error TransitionResult on length mismatch
+ * so the engine routes through the standard failure path; null to continue.
+ */
+function expectLength(
+  payload: Buffer,
+  expected: number,
+  stateName: string,
+  label: string,
+): { error: Error } | null {
+  if (payload.length !== expected) {
+    return {
+      error: new Error(`${stateName}: expected ${expected}-byte ${label}, got ${payload.length}`),
+    };
+  }
+  return null;
+}
+
 /** Strip the leading status byte from an IS-0xa200 chunk and copy pixel tail. */
 export function appendImageChunk(payload: Buffer, dest: Buffer, offset: number): number {
   if (payload.length === 0) return offset;
@@ -204,15 +216,9 @@ export function appendImageChunk(payload: Buffer, dest: Buffer, offset: number):
   return offset + payload.length - 1;
 }
 
-function computeExpectedBytes(source: Source, format: Format): number {
-  const geom = geometry({ source, format });
-  return geom.widthPx * geom.heightPx * 3;
-}
-
 const length1 = (p: Buffer): boolean => p.length === 1;
 const length16 = (p: Buffer): boolean => p.length === 16;
 const length80 = (p: Buffer): boolean => p.length === 80;
-const length14 = (p: Buffer): boolean => p.length === 14;
 
 // =============================================================================
 // Graph builder
@@ -276,11 +282,8 @@ g.state(
   decision<EsciCtx>((ctx, packet) => {
     const typeGuard = expectIsType(packet, ESCI_REPLY, "STATUS_1A");
     if (typeGuard) return typeGuard;
-    if (packet.payload.length !== 16) {
-      return {
-        error: new Error(`STATUS_1A: expected 16-byte status, got ${packet.payload.length}`),
-      };
-    }
+    const lengthGuard = expectLength(packet.payload, 16, "STATUS_1A", "status");
+    if (lengthGuard) return lengthGuard;
     if (ctx.inInterPageLoop && packet.payload[0] === 0x81) {
       ctx.inInterPageLoop = false;
       return { next: "CLEANUP_1", send: sendEscCleanup() };
@@ -296,11 +299,8 @@ g.state(
   decision<EsciCtx>((ctx, packet) => {
     const typeGuard = expectIsType(packet, ESCI_REPLY, "STATUS_1B");
     if (typeGuard) return typeGuard;
-    if (packet.payload.length !== 16) {
-      return {
-        error: new Error(`STATUS_1B: expected 16-byte status, got ${packet.payload.length}`),
-      };
-    }
+    const lengthGuard = expectLength(packet.payload, 16, "STATUS_1B", "status");
+    if (lengthGuard) return lengthGuard;
     if (ctx.inInterPageLoop) {
       return { next: "ADF_IDENTITY_A", send: sendFsI() };
     }
@@ -322,11 +322,8 @@ g.state(
   decision<EsciCtx>((ctx, packet) => {
     const typeGuard = expectIsType(packet, ESCI_REPLY, "STATUS_2");
     if (typeGuard) return typeGuard;
-    if (packet.payload.length !== 16) {
-      return {
-        error: new Error(`STATUS_2: expected 16-byte status, got ${packet.payload.length}`),
-      };
-    }
+    const lengthGuard = expectLength(packet.payload, 16, "STATUS_2", "status");
+    if (lengthGuard) return lengthGuard;
     const statusByte = packet.payload[0];
     if (ctx.forcedSource) {
       ctx.source = ctx.forcedSource;
@@ -386,11 +383,8 @@ g.state(
   decision<EsciCtx>((ctx, packet) => {
     const typeGuard = expectIsType(packet, ESCI_REPLY, "STATUS_READY");
     if (typeGuard) return typeGuard;
-    if (packet.payload.length !== 16) {
-      return {
-        error: new Error(`STATUS_READY: expected 16-byte status, got ${packet.payload.length}`),
-      };
-    }
+    const lengthGuard = expectLength(packet.payload, 16, "STATUS_READY", "status");
+    if (lengthGuard) return lengthGuard;
     if (ctx.source !== "flatbed") {
       return { next: "ADF_IDENTITY_A", send: sendFsI() };
     }
@@ -412,11 +406,8 @@ g.state(
   decision<EsciCtx>((ctx, packet) => {
     const typeGuard = expectIsType(packet, ESCI_REPLY, "ADF_IDENTITY_B");
     if (typeGuard) return typeGuard;
-    if (packet.payload.length !== 80) {
-      return {
-        error: new Error(`ADF_IDENTITY_B: expected 80-byte identity, got ${packet.payload.length}`),
-      };
-    }
+    const lengthGuard = expectLength(packet.payload, 80, "ADF_IDENTITY_B", "identity");
+    if (lengthGuard) return lengthGuard;
     if (ctx.format === "pdf" && !ctx.inInterPageLoop) {
       return { next: "ADF_PDF_SRC_ACK1", send: sendEscEPlusCtxSource };
     }
@@ -497,18 +488,15 @@ g.state(
   decision<EsciCtx>((ctx, packet) => {
     const typeGuard = expectIsType(packet, ESCI_REPLY, "START");
     if (typeGuard) return typeGuard;
-    if (!length14(packet.payload)) {
-      return {
-        error: new Error(`START: expected 14-byte FS G reply, got ${packet.payload.length}`),
-      };
-    }
+    const lengthGuard = expectLength(packet.payload, 14, "START", "FS G reply");
+    if (lengthGuard) return lengthGuard;
     const reply = parseFsGReply(packet.payload);
-    ctx.fsGReply = reply;
     if (reply.chunkSize === 0) {
       return { next: "START_POLL", send: sendFsF() };
     }
-    ctx.expectedBytes = computeExpectedBytes(ctx.source, ctx.format);
-    ctx.imageBuffer = Buffer.alloc(ctx.expectedBytes);
+    const geom = geometry({ source: ctx.source, format: ctx.format });
+    ctx.geom = geom;
+    ctx.imageBuffer = Buffer.alloc(geom.widthPx * geom.heightPx * 3);
     ctx.imageBufferOffset = 0;
     return {
       next: "IMG_RECEIVING",
@@ -524,11 +512,8 @@ g.state(
   decision<EsciCtx>((_ctx, packet) => {
     const typeGuard = expectIsType(packet, ESCI_REPLY, "START_POLL");
     if (typeGuard) return typeGuard;
-    if (!length16(packet.payload)) {
-      return {
-        error: new Error(`START_POLL: expected 16-byte status, got ${packet.payload.length}`),
-      };
-    }
+    const lengthGuard = expectLength(packet.payload, 16, "START_POLL", "status");
+    if (lengthGuard) return lengthGuard;
     if (packet.payload[0] === 0x01) {
       return { next: "START_POLL_READY", send: sendFsF() };
     }
@@ -540,10 +525,9 @@ g.state(
 awaitReply(g, "START_POLL_READY", ESCI_REPLY, length16, "START", passthru(buildFsG(), 14));
 
 // =============================================================================
-// IMG_RECEIVING — pixel stream + flushPage barrier (replaces ~80 LOC of
-// async-encode glue and the encodingDeferred[]/deferredImageChunks[] queues
-// the original scanner needed because the legacy state machine had no way to
-// pause for an async encode).
+// IMG_RECEIVING — accumulates pixel chunks into ctx.imageBuffer; on the
+// page-boundary chunk dispatches the flushPage barrier and routes to
+// PAGE_EJECT_WAIT (ADF) or POST_STATUS (flatbed).
 // =============================================================================
 
 g.state(
@@ -561,29 +545,27 @@ g.state(
       ctx.imageBuffer,
       ctx.imageBufferOffset,
     );
-    if (ctx.imageBufferOffset < ctx.expectedBytes) {
+    if (ctx.imageBufferOffset < ctx.imageBuffer.length) {
       return { next: "IMG_RECEIVING" };
     }
 
-    // Page complete — assemble + dispatch flushPage barrier. Increment
-    // BEFORE computing side so pageCount represents the 1-indexed page
-    // we're about to flush; even pageCount → ADF-duplex back side
-    // (matches scanner.ts pageNum = pageCount + 1 then `pageNum % 2 === 0`).
+    // Increment pageCount BEFORE computing side so pageCount represents the
+    // 1-indexed page we're about to flush; even pageCount → ADF-duplex back
+    // side (1=front, 2=back, 3=front, ...).
     ctx.pageCount += 1;
     const isBack = ctx.source === "adf-duplex" && ctx.pageCount % 2 === 0;
-    const geom = geometry({ source: ctx.source, format: ctx.format });
+    if (!ctx.geom) {
+      return { error: new Error("IMG_RECEIVING: page complete with no cached geometry") };
+    }
+    const { widthPx, heightPx } = ctx.geom;
     const rawRgb = ctx.imageBuffer;
     const quality = ctx.jpegQuality;
-    // Reset per-page buffer state so the next page (if any) starts fresh.
     ctx.imageBuffer = Buffer.alloc(0);
     ctx.imageBufferOffset = 0;
-    ctx.expectedBytes = 0;
 
-    // Flatbed: skip eject; go to POST_STATUS. ADF: send 0x0c 0x00 page-eject;
-    // PAGE_EJECT_WAIT then waits for the ACK and decides the next page.
     const flush = {
       side: isBack ? ("back" as const) : ("front" as const),
-      encode: () => encodeRawGbrToJpeg(rawRgb, geom.widthPx, geom.heightPx, quality),
+      encode: () => encodeRawGbrToJpeg(rawRgb, widthPx, heightPx, quality),
     };
     if (ctx.source === "flatbed") {
       return { next: "POST_STATUS", send: sendFsF(), flushPage: flush };
@@ -608,13 +590,8 @@ g.state(
   decision<EsciCtx>((ctx, packet) => {
     const typeGuard = expectIsType(packet, ESCI_REPLY, "PAGE_EJECT_WAIT");
     if (typeGuard) return typeGuard;
-    if (!length1(packet.payload)) {
-      return {
-        error: new Error(
-          `PAGE_EJECT_WAIT: expected 1-byte page-eject ACK, got ${packet.payload.length}`,
-        ),
-      };
-    }
+    const lengthGuard = expectLength(packet.payload, 1, "PAGE_EJECT_WAIT", "page-eject ACK");
+    if (lengthGuard) return lengthGuard;
     ctx.inInterPageLoop = true;
     return { next: "STATUS_1A", send: sendFsF() };
   }),
@@ -636,11 +613,8 @@ g.state(
   decision<EsciCtx>((ctx, packet) => {
     const typeGuard = expectIsType(packet, ESCI_REPLY, "CLEANUP_1");
     if (typeGuard) return typeGuard;
-    if (!length1(packet.payload)) {
-      return {
-        error: new Error(`CLEANUP_1: expected 1-byte ESC ) reply, got ${packet.payload.length}`),
-      };
-    }
+    const lengthGuard = expectLength(packet.payload, 1, "CLEANUP_1", "ESC ) reply");
+    if (lengthGuard) return lengthGuard;
     if (ctx.source !== "flatbed") {
       return { next: "ADF_CLEANUP_ACK1", send: sendEscEPlusCtxSource };
     }

--- a/src/esci/graph.ts
+++ b/src/esci/graph.ts
@@ -277,7 +277,9 @@ g.state(
     const typeGuard = expectIsType(packet, ESCI_REPLY, "STATUS_1A");
     if (typeGuard) return typeGuard;
     if (packet.payload.length !== 16) {
-      return { error: new Error(`STATUS_1A: expected 16-byte status, got ${packet.payload.length}`) };
+      return {
+        error: new Error(`STATUS_1A: expected 16-byte status, got ${packet.payload.length}`),
+      };
     }
     if (ctx.inInterPageLoop && packet.payload[0] === 0x81) {
       ctx.inInterPageLoop = false;
@@ -295,7 +297,9 @@ g.state(
     const typeGuard = expectIsType(packet, ESCI_REPLY, "STATUS_1B");
     if (typeGuard) return typeGuard;
     if (packet.payload.length !== 16) {
-      return { error: new Error(`STATUS_1B: expected 16-byte status, got ${packet.payload.length}`) };
+      return {
+        error: new Error(`STATUS_1B: expected 16-byte status, got ${packet.payload.length}`),
+      };
     }
     if (ctx.inInterPageLoop) {
       return { next: "ADF_IDENTITY_A", send: sendFsI() };
@@ -409,7 +413,9 @@ g.state(
     const typeGuard = expectIsType(packet, ESCI_REPLY, "ADF_IDENTITY_B");
     if (typeGuard) return typeGuard;
     if (packet.payload.length !== 80) {
-      return { error: new Error(`ADF_IDENTITY_B: expected 80-byte identity, got ${packet.payload.length}`) };
+      return {
+        error: new Error(`ADF_IDENTITY_B: expected 80-byte identity, got ${packet.payload.length}`),
+      };
     }
     if (ctx.format === "pdf" && !ctx.inInterPageLoop) {
       return { next: "ADF_PDF_SRC_ACK1", send: sendEscEPlusCtxSource };
@@ -448,7 +454,9 @@ g.state(
     const typeGuard = expectIsType(packet, ESCI_REPLY, "GAMMA_DATA");
     if (typeGuard) return typeGuard;
     if (!isAck(packet.payload)) {
-      return { error: new Error(`GAMMA_DATA: expected gamma LUT ack (channel ${ctx.gammaChannelIdx})`) };
+      return {
+        error: new Error(`GAMMA_DATA: expected gamma LUT ack (channel ${ctx.gammaChannelIdx})`),
+      };
     }
     if (ctx.gammaChannelIdx + 1 < GAMMA_CHANNELS.length) {
       ctx.gammaChannelIdx += 1;
@@ -490,7 +498,9 @@ g.state(
     const typeGuard = expectIsType(packet, ESCI_REPLY, "START");
     if (typeGuard) return typeGuard;
     if (!length14(packet.payload)) {
-      return { error: new Error(`START: expected 14-byte FS G reply, got ${packet.payload.length}`) };
+      return {
+        error: new Error(`START: expected 14-byte FS G reply, got ${packet.payload.length}`),
+      };
     }
     const reply = parseFsGReply(packet.payload);
     ctx.fsGReply = reply;
@@ -515,7 +525,9 @@ g.state(
     const typeGuard = expectIsType(packet, ESCI_REPLY, "START_POLL");
     if (typeGuard) return typeGuard;
     if (!length16(packet.payload)) {
-      return { error: new Error(`START_POLL: expected 16-byte status, got ${packet.payload.length}`) };
+      return {
+        error: new Error(`START_POLL: expected 16-byte status, got ${packet.payload.length}`),
+      };
     }
     if (packet.payload[0] === 0x01) {
       return { next: "START_POLL_READY", send: sendFsF() };
@@ -544,7 +556,11 @@ g.state(
         ),
       };
     }
-    ctx.imageBufferOffset = appendImageChunk(packet.payload, ctx.imageBuffer, ctx.imageBufferOffset);
+    ctx.imageBufferOffset = appendImageChunk(
+      packet.payload,
+      ctx.imageBuffer,
+      ctx.imageBufferOffset,
+    );
     if (ctx.imageBufferOffset < ctx.expectedBytes) {
       return { next: "IMG_RECEIVING" };
     }
@@ -593,7 +609,11 @@ g.state(
     const typeGuard = expectIsType(packet, ESCI_REPLY, "PAGE_EJECT_WAIT");
     if (typeGuard) return typeGuard;
     if (!length1(packet.payload)) {
-      return { error: new Error(`PAGE_EJECT_WAIT: expected 1-byte page-eject ACK, got ${packet.payload.length}`) };
+      return {
+        error: new Error(
+          `PAGE_EJECT_WAIT: expected 1-byte page-eject ACK, got ${packet.payload.length}`,
+        ),
+      };
     }
     ctx.inInterPageLoop = true;
     return { next: "STATUS_1A", send: sendFsF() };
@@ -617,7 +637,9 @@ g.state(
     const typeGuard = expectIsType(packet, ESCI_REPLY, "CLEANUP_1");
     if (typeGuard) return typeGuard;
     if (!length1(packet.payload)) {
-      return { error: new Error(`CLEANUP_1: expected 1-byte ESC ) reply, got ${packet.payload.length}`) };
+      return {
+        error: new Error(`CLEANUP_1: expected 1-byte ESC ) reply, got ${packet.payload.length}`),
+      };
     }
     if (ctx.source !== "flatbed") {
       return { next: "ADF_CLEANUP_ACK1", send: sendEscEPlusCtxSource };

--- a/src/esci/scanner-diagnose.test.ts
+++ b/src/esci/scanner-diagnose.test.ts
@@ -22,6 +22,16 @@ function passthruCommand(buf: Buffer): Buffer {
   return pkt.payload.subarray(8);
 }
 
+/**
+ * Yield a microtask-and-macrotask round so the engine's async pump can
+ * process buffered feeds and emit writes. Mirrors the pattern used in
+ * src/esci/test-support/replay.ts:driveFixture for the same reason: with
+ * the engine model `transport.on("data", ...)` only registers after the
+ * factory's await yields, so synchronous feed→write→assert chains need
+ * an explicit yield between feed and assertion.
+ */
+const yieldEngine = () => new Promise((r) => setImmediate(r));
+
 describe("scanner-esci DIAGNOSE_PROTOCOL probe", () => {
   it("sends FS Y after ESC @ NAK and rejects with a diagnostic message", async () => {
     const fake = new FakeTcpSocket();
@@ -42,12 +52,15 @@ describe("scanner-esci DIAGNOSE_PROTOCOL probe", () => {
 
     fake.simulateConnect();
     fake.feed(welcome);
+    await yieldEngine();
     expect(parseIsPacket(fake.writes[0])?.type).toBe(0x2100); // lock packet
     fake.feed(lockAck);
+    await yieldEngine();
     expect(passthruCommand(fake.writes[1]).equals(ESC_AT)).toBe(true);
 
     // Printer NAKs ESC @ — diagnostic mode should send FS Y instead of failing.
     fake.feed(nakReply);
+    await yieldEngine();
     expect(passthruCommand(fake.writes[2]).equals(FS_Y)).toBe(true);
 
     // Printer ACKs FS Y — session still aborts, but with a diagnostic message.
@@ -77,6 +90,7 @@ describe("scanner-esci DIAGNOSE_PROTOCOL probe", () => {
     fake.feed(welcome);
     fake.feed(lockAck);
     fake.feed(nakReply);
+    await yieldEngine();
     expect(passthruCommand(fake.writes[2]).equals(FS_Y)).toBe(true);
 
     // Both legacy ESC @ and ESC/I-2 FS Y rejected — printer is in some other family.
@@ -107,8 +121,9 @@ describe("scanner-esci DIAGNOSE_PROTOCOL probe", () => {
     fake.feed(lockAck);
     fake.feed(nakReply);
 
+    // Engine rejects via INIT decision's custom error.
+    await expect(promise).rejects.toThrow(/expected ESC @ ack, got type=0xa000 payload=15/);
     // No FS Y probe — only the lock packet and ESC @ should have been sent.
     expect(fake.writes.length).toBe(2);
-    await expect(promise).rejects.toThrow(/expected ESC @ ack, got type=0xa000 payload=15/);
   });
 });

--- a/src/esci/scanner-diagnose.test.ts
+++ b/src/esci/scanner-diagnose.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { runEsciScan } from "./scanner.js";
 import { FakeTcpSocket } from "./test-support/fake-tcp-socket.js";
 import { buildIsPacket, parseIsPacket } from "../protocol.js";
@@ -33,6 +33,26 @@ function passthruCommand(buf: Buffer): Buffer {
 const yieldEngine = () => new Promise((r) => setImmediate(r));
 
 describe("scanner-esci DIAGNOSE_PROTOCOL probe", () => {
+  // The README + config.ts promise users that DIAGNOSE_PROTOCOL=true emits
+  // [diagnose] log lines they can share on a compatibility-issue ticket;
+  // the terminal error message asks them to do so. Pin the log output so
+  // the breadcrumbs can't silently regress through a future refactor.
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  function diagnoseLogLines(): string[] {
+    return logSpy.mock.calls
+      .map((args) => (typeof args[0] === "string" ? args[0] : String(args[0] ?? "")))
+      .filter((line) => line.includes("[diagnose]"));
+  }
+
   it("sends FS Y after ESC @ NAK and rejects with a diagnostic message", async () => {
     const fake = new FakeTcpSocket();
     const promise = runEsciScan(
@@ -67,6 +87,15 @@ describe("scanner-esci DIAGNOSE_PROTOCOL probe", () => {
     fake.feed(ackReply);
 
     await expect(promise).rejects.toThrow(/diagnostic probe complete/);
+
+    const lines = diagnoseLogLines();
+    expect(lines.length).toBe(2);
+    expect(lines[0]).toMatch(
+      /\[diagnose\] ESC @ returned non-ACK \(type=0xa000 payload=15\) — sending FS Y probe/,
+    );
+    expect(lines[1]).toMatch(
+      /\[diagnose\] FS Y returned ACK \(type=0xa000 payload=06\) — printer likely speaks ESC\/I-2 over plain TCP/,
+    );
   });
 
   it("rejects with a diagnostic message even when FS Y is also NAK'd", async () => {
@@ -97,6 +126,12 @@ describe("scanner-esci DIAGNOSE_PROTOCOL probe", () => {
     fake.feed(nakReply);
 
     await expect(promise).rejects.toThrow(/diagnostic probe complete/);
+
+    const lines = diagnoseLogLines();
+    expect(lines.length).toBe(2);
+    expect(lines[1]).toMatch(
+      /\[diagnose\] FS Y returned non-ACK \(type=0xa000 payload=15\) — printer rejects both legacy ESC @ and ESC\/I-2 FS Y/,
+    );
   });
 
   it("preserves existing behaviour when DIAGNOSE_PROTOCOL is off", async () => {
@@ -125,5 +160,7 @@ describe("scanner-esci DIAGNOSE_PROTOCOL probe", () => {
     await expect(promise).rejects.toThrow(/expected ESC @ ack, got type=0xa000 payload=15/);
     // No FS Y probe — only the lock packet and ESC @ should have been sent.
     expect(fake.writes.length).toBe(2);
+    // No [diagnose] log lines when the flag is off.
+    expect(diagnoseLogLines().length).toBe(0);
   });
 });

--- a/src/esci/scanner.test.ts
+++ b/src/esci/scanner.test.ts
@@ -361,11 +361,11 @@ describe("runEsciScan failure-mode matrix", () => {
       fake.asFactory(),
     );
     fake.simulateConnect();
-    // WELCOME state expects type 0x8000 (scanner-legacy.ts:247).
-    // Feed type 0xa000 — fail() rejects with "expected welcome (0x8000), got 0xa000".
+    // WELCOME state expects IS type 0x8000. Feed type 0xa000 — engine routes
+    // through its "Unexpected packet type ... in state WELCOME" failure path.
     // (Raw garbage that doesn't form a valid IS header would just buffer until timeout.)
     fake.feed(buildIsPacket(0xa000, Buffer.alloc(0)));
-    await expect(scanPromise).rejects.toThrow(/expected welcome \(0x8000\)/);
+    await expect(scanPromise).rejects.toThrow(/Unexpected packet type 0xa000 in state WELCOME/);
   });
 });
 

--- a/src/esci/scanner.ts
+++ b/src/esci/scanner.ts
@@ -49,14 +49,10 @@ function makeTcpTransportFactory(
 ): SessionTransportFactory {
   return () =>
     new Promise<SessionTransport>((resolve, reject) => {
-      // The legacy `net.Socket` already implements `write` / `end` / `destroy`
-      // and the `on('data' | 'error' | 'close')` event triplet that
-      // SessionTransport requires. Plain TCP, no TLS pin, no app-level unlock-
-      // on-destroy concern (the original scanner just `socket.destroy()`d on
-      // failure too) — so we hand the raw socket to the engine directly. If a
-      // future ESC/I quirk needs a wrapper (e.g. post-end RST suppression for
-      // a noisy printer), introduce a sibling `src/esci/transport.ts` then,
-      // not pre-emptively.
+      // net.Socket structurally satisfies SessionTransport; plain TCP needs
+      // no app-level wrapper (no TLS pin, no unlock-on-destroy semantics
+      // peculiar to ESC/I-2). If a future ESC/I quirk needs one, introduce
+      // a sibling src/esci/transport.ts.
       const socket = socketFactory(session.printerIp, session.port, () => {
         resolve(socket);
       });
@@ -69,8 +65,7 @@ export async function runEsciScan(
   socketFactory: TcpSocketFactory = (host, port, cb) => net.connect(port, host, cb),
 ): Promise<void> {
   // Validate the temp-dir base before opening the TCP connection so a bad
-  // path fails fast (rather than waiting until first flushPage). Mirrors the
-  // M2 scanner.ts pattern.
+  // path fails fast (rather than at first flushPage).
   const tempBase = session.tempDir || os.tmpdir();
   try {
     fs.accessSync(tempBase, fs.constants.W_OK);
@@ -84,9 +79,8 @@ export async function runEsciScan(
     initialCtx: {
       duplex: session.duplex,
       forcedSource: session.forcedSource,
-      // Safe default — overwritten in STATUS_2 from the FS F byte (or
-      // forcedSource if set). The plan's wire-up: STATUS_2 mutates ctx.source
-      // before any state that reads it (RESET_INIT, ADF_IDENTITY_B, IMG_RECEIVING).
+      // Safe default — STATUS_2 overwrites this from the FS F byte (or
+      // forcedSource) before any state downstream reads it.
       source: session.forcedSource ?? "adf-simplex",
       format: session.format,
       jpegQuality: session.jpegQuality,
@@ -95,10 +89,9 @@ export async function runEsciScan(
       inInterPageLoop: false,
       pageCount: 0,
       gammaChannelIdx: 0,
-      fsGReply: null,
+      geom: null,
       imageBuffer: Buffer.alloc(0),
       imageBufferOffset: 0,
-      expectedBytes: 0,
     },
     transportFactory: makeTcpTransportFactory(session, socketFactory),
     outputDir: session.outputDir,

--- a/src/esci/scanner.ts
+++ b/src/esci/scanner.ts
@@ -1,66 +1,25 @@
 import net from "node:net";
-import os from "node:os";
 import fs from "node:fs";
-import path from "node:path";
-import { createLogger } from "../logger.js";
+import os from "node:os";
 import {
-  parseIsPacket,
-  buildLockPacket,
-  buildUnlockPacket,
-  buildPassthruPacket,
-  buildIsPacket,
-} from "../protocol.js";
-import {
-  buildEscInit,
-  buildFsI,
-  buildFsF,
-  buildEscE,
-  buildEscParen,
-  buildEscZ,
-  buildFsW,
-  buildFsG,
-  buildEscCleanup,
-  buildPageEject,
-  buildFsWBlock,
-  buildStreamConfigPayload,
-  parseFsGReply,
-  geometry,
-  legacyDetectSource,
-  SOURCE_BYTE,
-  type Source,
-  type Format,
-} from "./commands.js";
-// FS Y (0x1C 0x59) — first command in the ET-4950 ESC/I-2 init sequence
-// (see esci2/scanner.ts INIT1_FS_Y). Used here only by the DIAGNOSE_PROTOCOL probe
-// to classify printers that NAK `ESC @`.
-import { buildFsY } from "../esci2/commands.js";
-import { GAMMA_LUT_R, GAMMA_LUT_G, GAMMA_LUT_B } from "./luts.js";
-import { encodeRawGbrToJpeg } from "./raw-to-jpeg.js";
-import { setJpegOrientation } from "../exif.js";
+  runScanSession,
+  type SessionTransport,
+  type SessionTransportFactory,
+} from "../scan-session.js";
 import { resolveSessionTimestamp } from "../output.js";
-import { finalizeSession } from "../output-tail.js";
+import { esciGraph, type EsciCtx } from "./graph.js";
+import type { Source, Format } from "./commands.js";
 import type { PaperlessUploadOptions } from "../paperless-upload.js";
 
-const log = createLogger("scanner-esci");
-
-const GAMMA_CHANNELS = [
-  { tag: 0x52, lut: GAMMA_LUT_R },
-  { tag: 0x47, lut: GAMMA_LUT_G },
-  { tag: 0x42, lut: GAMMA_LUT_B },
-] as const;
-
-// The Windows driver always sends source byte 0x01 (ADF-simplex) as the initial probe,
-// regardless of the user's intended source. It gets a 0x81 busy reply, resets, then
-// sends the actual source byte. Matching this behaviour ensures the busy cycle fires on
-// real flatbed hardware where sending 0x00 as the probe could skip the reset entirely.
-const PROBE_SOURCE_BYTE = 0x01;
+export { appendImageChunk } from "./graph.js";
 
 export interface LegacyScanSession {
   printerIp: string;
   port: number;
   outputDir: string;
+  /** Base directory for per-session temp spill; "" means `os.tmpdir()` at runtime. */
   tempDir: string;
-  /** Panel-side Sides selection (true → 2-Sided). Source is detected from FS F. */
+  /** Panel-side Sides selection (true → 2-Sided). Source detected from FS F. */
   duplex: boolean;
   /** Override for FS F autodetection — set via ESCI_FORCE_SOURCE env var. */
   forcedSource: Source | null;
@@ -68,10 +27,9 @@ export interface LegacyScanSession {
   jpegQuality: number;
   paperless?: PaperlessUploadOptions;
   /**
-   * When true, a non-ACK reply to `ESC @` triggers one additional `FS Y` probe
-   * (the ET-4950 ESC/I-2 path's first command) before the session fails. Both
-   * replies are logged with full IS type + payload to aid protocol classification
-   * for unsupported printers. Set via the DIAGNOSE_PROTOCOL env var.
+   * When true, a non-ACK reply to ESC @ triggers an additional FS Y probe
+   * (the ET-4950 ESC/I-2 path's first command) before the session fails.
+   * Used to classify printers stuck between ESC/I and ESC/I-2.
    */
   diagnoseProtocol?: boolean;
   /**
@@ -85,824 +43,69 @@ export interface LegacyScanSession {
 
 export type TcpSocketFactory = (host: string, port: number, onConnect?: () => void) => net.Socket;
 
-// prettier-ignore
-type State =
-  | "CONNECTING"
-  | "WELCOME"
-  | "LOCKING"
-  | "INIT"
-  // Diagnostic-only: entered after `ESC @` is NAK'd when DIAGNOSE_PROTOCOL=true.
-  // We send `FS Y` (the ET-4950 ESC/I-2 init's first command) and log whatever
-  // comes back, then fail with a "diagnostic complete" message.
-  | "DIAGNOSE_INIT_PROBE"
-  | "IDENTITY"
-  | "STATUS_1A"
-  | "STATUS_1B"
-  | "SOURCE_CMD"
-  | "SOURCE_PARAM"
-  | "STATUS_2"
-  // ADF-only pre-reset cycle: re-probe source before ESC ( reset
-  // (fixture: adf-single-page-jpeg.jsonl lines 32-43; STATUS_2 returns 0x01 for ADF,
-  //  driver re-sends ESC e + source param + FS F before entering the ESC ( reset cycle)
-  | "ADF_PRESRC_CMD"
-  | "ADF_PRESRC_PARAM"
-  | "ADF_STATUS_3"
-  | "RESET_PAREN"
-  | "RESET_INIT"
-  | "RESET_SRC_CMD"
-  | "RESET_SRC_PARAM"
-  | "STATUS_READY"
-  // ADF-only post-reset identity reads: FS I is sent twice after STATUS_READY for ADF
-  // (fixture: adf-single-page-jpeg.jsonl lines 64-71)
-  | "ADF_IDENTITY_A"
-  | "ADF_IDENTITY_B"
-  // ADF+PDF only: extra ESC e + source param after ADF_IDENTITY_B, before gamma phase
-  // (fixture: adf-single-page-pdf.jsonl lines 72-79)
-  | "ADF_PDF_SRC_CMD"
-  | "ADF_PDF_SRC_PARAM"
-  | "GAMMA_CMD"
-  | "GAMMA_DATA"
-  | "WINDOW_CMD"
-  | "WINDOW_DATA"
-  | "STATUS_PRESCAN"
-  | "START"
-  // ADF FS G not-ready retry: when FS G returns chunkSize=0, poll FS F until ready,
-  // then re-send FS G. Seen in the 4-page duplex PDF capture where the ADF had not
-  // finished feeding paper by the time the host issued FS G.
-  // START_POLL: keep sending FS F; on first status=0x01 → START_POLL_READY.
-  // START_POLL_READY: send one more FS F confirmation; then send FS G and go to START.
-  | "START_POLL"
-  | "START_POLL_READY"
-  | "IMG_RECEIVING"
-  | "PAGE_ENCODING"  // async JPEG encoding in progress; absorbs trailing image chunks
-  // ADF-only page eject: 0x0c 0x00 sent after image stream, before FS F status check
-  // (fixture: adf-single-page-jpeg.jsonl lines 117-120)
-  | "PAGE_EJECT_WAIT"
-  | "POST_STATUS"
-  | "CLEANUP_1"
-  // ADF-only cleanup: after ESC ) NAK, driver re-sends ESC e + source + FS F before 2nd ESC )
-  // (fixture: adf-single-page-jpeg.jsonl lines 127-138)
-  | "ADF_CLEANUP_SRC_CMD"
-  | "ADF_CLEANUP_SRC_PARAM"
-  | "ADF_CLEANUP_STATUS"
-  | "CLEANUP_2"
-  | "UNLOCKING"
-  | "DONE"
-  | "ERROR";
+function makeTcpTransportFactory(
+  session: LegacyScanSession,
+  socketFactory: TcpSocketFactory,
+): SessionTransportFactory {
+  return () =>
+    new Promise<SessionTransport>((resolve, reject) => {
+      // The legacy `net.Socket` already implements `write` / `end` / `destroy`
+      // and the `on('data' | 'error' | 'close')` event triplet that
+      // SessionTransport requires. Plain TCP, no TLS pin, no app-level unlock-
+      // on-destroy concern (the original scanner just `socket.destroy()`d on
+      // failure too) — so we hand the raw socket to the engine directly. If a
+      // future ESC/I quirk needs a wrapper (e.g. post-end RST suppression for
+      // a noisy printer), introduce a sibling `src/esci/transport.ts` then,
+      // not pre-emptively.
+      const socket = socketFactory(session.printerIp, session.port, () => {
+        resolve(socket);
+      });
+      socket.once("error", reject);
+    });
+}
 
-const TIMEOUT_MS = 60_000;
-const ACK_BYTE = 0x06;
-
-export function runEsciScan(
+export async function runEsciScan(
   session: LegacyScanSession,
   socketFactory: TcpSocketFactory = (host, port, cb) => net.connect(port, host, cb),
 ): Promise<void> {
-  return new Promise((resolve, reject) => {
-    // Set in STATUS_2 from the FS F byte (or short-circuited by session.forcedSource).
-    // Replaces session.source for all downstream reads.
-    let detectedSource: Source = session.forcedSource ?? "adf-simplex"; // safe default; overwritten in STATUS_2
+  // Validate the temp-dir base before opening the TCP connection so a bad
+  // path fails fast (rather than waiting until first flushPage). Mirrors the
+  // M2 scanner.ts pattern.
+  const tempBase = session.tempDir || os.tmpdir();
+  try {
+    fs.accessSync(tempBase, fs.constants.W_OK);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to create session temp dir under ${tempBase}: ${msg}`);
+  }
 
-    const sessionTs = resolveSessionTimestamp(new Date(), session.outputDir);
-    const sessionTempDir = fs.mkdtempSync(
-      path.join(session.tempDir || os.tmpdir(), "epson2paperless-leg-"),
-    );
-
-    let state: State = "CONNECTING";
-    let buffer = Buffer.alloc(0);
-    let timeoutTimer: NodeJS.Timeout | null = null;
-    let resolved = false;
-    let errorReason: Error | null = null;
-
-    let fsGReply: ReturnType<typeof parseFsGReply> | null = null;
-    let imageBuffer = Buffer.alloc(0);
-    let imageBufferOffset = 0;
-    let expectedBytes = 0;
-    let pageCount = 0;
-    let gammaChannelIdx = 0;
-    const backPageIndices: number[] = [];
-    // Set to true when looping back for the back side of a duplex sheet; controls
-    // STATUS_1B and ADF_IDENTITY_B to skip the initial source-set / PDF ESC e steps.
-    // Cleared at:
-    //   - STATUS_1A's 0x81 branch (ADF empty → cleanup)
-    //   - ADF_IDENTITY_B's enter-gamma transition
-    let inInterPageLoop = false;
-    // Non-image packets that arrive during PAGE_ENCODING are deferred and replayed after encoding.
-    const encodingDeferred: Array<{ type: number; payload: Buffer }> = [];
-    // IS-0xa200 image chunks that arrive during PAGE_ENCODING are buffered here and fed into
-    // imageBuffer when the state machine re-enters IMG_RECEIVING for the next page.
-    // (In single-page scans these are trailing overflow chunks and are harmless to buffer;
-    // in duplex scans they carry the second page's pixel data.)
-    const deferredImageChunks: Buffer[] = [];
-
-    const socket = socketFactory(session.printerIp, session.port, () => {
-      log.info(`Connected (TCP) to ${session.printerIp}:${session.port}`);
-      state = "WELCOME";
-      armTimeout();
-    });
-
-    socket.on("data", onData);
-    socket.on("error", (err: Error) => fail(`socket error: ${err.message}`));
-    socket.on("close", onClose);
-
-    function resolveOnce(): void {
-      if (resolved) return;
-      resolved = true;
-      if (timeoutTimer) clearTimeout(timeoutTimer);
-      resolve();
-    }
-
-    function failOnce(err: Error): void {
-      if (errorReason) return;
-      errorReason = err;
-      if (state === "ERROR") return;
-      state = "ERROR";
-      log.error(`State machine error: ${err.message}`);
-      if (timeoutTimer) clearTimeout(timeoutTimer);
-      try {
-        socket.destroy();
-      } catch {
-        /* swallow */
-      }
-      try {
-        fs.rmSync(sessionTempDir, { recursive: true, force: true });
-      } catch {
-        /* swallow */
-      }
-      if (resolved) return;
-      resolved = true;
-      reject(err);
-    }
-    function fail(reason: string): void {
-      failOnce(new Error(reason));
-    }
-
-    function armTimeout(): void {
-      if (timeoutTimer) clearTimeout(timeoutTimer);
-      timeoutTimer = setTimeout(() => fail(`state-machine timeout in ${state}`), TIMEOUT_MS);
-    }
-
-    function send(buf: Buffer): void {
-      socket.write(buf);
-    }
-
-    function sendCmd(cmd: Buffer, replySize: number): void {
-      send(buildPassthruPacket(cmd, replySize));
-    }
-
-    // Defeat TypeScript's control-flow narrowing: after `state = "POST_STATUS"`, tsc infers
-    // state is literally "POST_STATUS" and flags subsequent `state === "ERROR"` checks as
-    // impossible. The accessor opaque-ifies the read so narrowing doesn't apply.
-    const getState = (): State => state;
-
-    function onData(chunk: Buffer): void {
-      buffer = Buffer.concat([buffer, chunk]);
-      armTimeout();
-      let pkt = parseIsPacket(buffer);
-      while (pkt) {
-        buffer = buffer.subarray(pkt.totalSize);
-        try {
-          handle(pkt);
-        } catch (err) {
-          fail(`packet handler threw: ${err instanceof Error ? err.message : String(err)}`);
-          return;
-        }
-        if (state === "ERROR" || state === "DONE") return;
-        pkt = parseIsPacket(buffer);
-      }
-    }
-
-    function enterGammaPhase(): void {
-      gammaChannelIdx = 0;
-      state = "GAMMA_CMD";
-      sendCmd(buildEscZ(), 1);
-    }
-
-    function handle(pkt: { type: number; payload: Buffer }): void {
-      switch (state) {
-        case "WELCOME":
-          if (pkt.type !== 0x8000) {
-            return fail(`expected welcome (0x8000), got 0x${pkt.type.toString(16)}`);
-          }
-          state = "LOCKING";
-          send(buildLockPacket());
-          return;
-
-        case "LOCKING":
-          if (pkt.type !== 0xa100) {
-            return fail(`expected lock-ack (0xa100), got 0x${pkt.type.toString(16)}`);
-          }
-          state = "INIT";
-          sendCmd(buildEscInit(), 1);
-          return;
-
-        case "INIT":
-          // IS-0xa000 with payload = 0x06 (ACK for ESC @)
-          if (!isAck(pkt)) {
-            const detail = `type=0x${pkt.type.toString(16)} payload=${pkt.payload.toString("hex")}`;
-            if (session.diagnoseProtocol) {
-              log.info(
-                `[diagnose] ESC @ returned non-ACK (${detail}) — sending FS Y probe to classify protocol`,
-              );
-              state = "DIAGNOSE_INIT_PROBE";
-              sendCmd(buildFsY(), 1);
-              return;
-            }
-            return fail(`expected ESC @ ack, got ${detail}`);
-          }
-          state = "IDENTITY";
-          sendCmd(buildFsI(), 80);
-          return;
-
-        case "DIAGNOSE_INIT_PROBE": {
-          // Diagnostic-only terminal state. Whatever comes back, log it in
-          // detail and fail with a message instructing the user to share the
-          // [diagnose] log lines on the issue tracker.
-          const detail = `type=0x${pkt.type.toString(16)} payload=${pkt.payload.toString("hex")}`;
-          if (isAck(pkt)) {
-            log.info(
-              `[diagnose] FS Y returned ACK (${detail}) — printer likely speaks ESC/I-2 over plain TCP (ET-4950-style init, no TLS).`,
-            );
-          } else {
-            log.info(
-              `[diagnose] FS Y returned non-ACK (${detail}) — printer rejects both legacy ESC @ and ESC/I-2 FS Y; protocol family unknown.`,
-            );
-          }
-          return fail(
-            "diagnostic probe complete — please share the [diagnose] log lines on the GitHub issue",
-          );
-        }
-
-        case "IDENTITY":
-          // IS-0xa000 with 80-byte identity payload; we don't decode it
-          if (pkt.payload.length !== 80) {
-            return fail(`expected 80-byte identity reply, got ${pkt.payload.length}`);
-          }
-          state = "STATUS_1A";
-          sendCmd(buildFsF(), 16);
-          return;
-
-        case "STATUS_1A":
-          // First FS F status reply (16 bytes); driver reads it twice.
-          // In the inter-page loop, byte 0 of the status reply discriminates:
-          //   0x01 → ADF still has paper, continue setup for next page
-          //   0x81 → ADF empty, skip identity/gamma/window and go to cleanup
-          if (pkt.payload.length !== 16) {
-            return fail(`expected 16-byte status, got ${pkt.payload.length}`);
-          }
-          if (inInterPageLoop && pkt.payload[0] === 0x81) {
-            inInterPageLoop = false;
-            state = "CLEANUP_1";
-            sendCmd(buildEscCleanup(), 1);
-            return;
-          }
-          state = "STATUS_1B";
-          sendCmd(buildFsF(), 16);
-          return;
-
-        case "STATUS_1B":
-          // Second FS F status reply.
-          // Initial setup: initiate source-set (ESC e + probe param).
-          // Inter-page loop (duplex back side): skip source-set; go straight to ADF identity reads.
-          if (pkt.payload.length !== 16) {
-            return fail(`expected 16-byte status, got ${pkt.payload.length}`);
-          }
-          if (inInterPageLoop) {
-            state = "ADF_IDENTITY_A";
-            sendCmd(buildFsI(), 80);
-            return;
-          }
-          state = "SOURCE_CMD";
-          sendCmd(buildEscE(), 1);
-          // Send param in same tick as separate passthru (driver sends opcode + param as two writes).
-          // Always probe with PROBE_SOURCE_BYTE (0x01/ADF-simplex) regardless of intended source —
-          // this matches the Windows driver's behaviour and ensures the 0x81 busy cycle fires.
-          sendCmd(Buffer.from([PROBE_SOURCE_BYTE]), 1);
-          return;
-
-        case "SOURCE_CMD":
-          // ACK for ESC e opcode
-          if (!isAck(pkt)) return fail(`expected ESC e ack`);
-          state = "SOURCE_PARAM";
-          return;
-
-        case "SOURCE_PARAM":
-          // ACK for ESC e param byte
-          if (!isAck(pkt)) return fail(`expected ESC e param ack`);
-          state = "STATUS_2";
-          sendCmd(buildFsF(), 16);
-          return;
-
-        case "STATUS_2": {
-          // Status after source-set probe.
-          // FS F byte 0 carries the source signal:
-          //   0x81 → flatbed (no ADF paper / no ADF present)
-          //   0x01 → ADF has paper; duplex flag disambiguates simplex/duplex
-          //   other → unknown (jam, mid-feed, panel-conflict). Reject loudly.
-          // session.forcedSource (ESCI_FORCE_SOURCE) short-circuits the detection.
-          if (pkt.payload.length !== 16) {
-            return fail(`expected 16-byte status in STATUS_2, got ${pkt.payload.length}`);
-          }
-          const statusByte = pkt.payload[0];
-          if (session.forcedSource) {
-            log.info(
-              `STATUS_2: ESCI_FORCE_SOURCE override: ${session.forcedSource} ` +
-                `(FS F byte 0x${statusByte.toString(16)} ignored)`,
-            );
-            detectedSource = session.forcedSource;
-          } else {
-            const result = legacyDetectSource(statusByte, session.duplex);
-            if (!result.ok) {
-              return fail(
-                `Unrecognised FS F status 0x${result.byte.toString(16).padStart(2, "0")} ` +
-                  `— please file a compatibility issue with LOG_LEVEL=debug output ` +
-                  `(see CONTRIBUTING.md). Workaround: set ESCI_FORCE_SOURCE.`,
-              );
-            }
-            detectedSource = result.source;
-            log.info(
-              `STATUS_2: source detected from FS F byte 0x${statusByte.toString(16)} → ${detectedSource}`,
-            );
-          }
-          // Fire the test hook (no-op in production — the field is undefined).
-          session.onSourceDetected?.(detectedSource);
-          // Original branching, now in terms of detectedSource:
-          if (statusByte === 0x81) {
-            log.debug("STATUS_2: scanner busy (0x81), starting reset cycle");
-            state = "RESET_PAREN";
-            sendCmd(buildEscParen(), 1);
-          } else if (detectedSource !== "flatbed") {
-            log.debug(
-              `STATUS_2: ADF status 0x${statusByte.toString(16)}, starting ADF pre-reset probe`,
-            );
-            state = "ADF_PRESRC_CMD";
-            sendCmd(buildEscE(), 1);
-            sendCmd(Buffer.from([PROBE_SOURCE_BYTE]), 1);
-          } else {
-            log.debug(
-              `STATUS_2: scanner ready (0x${statusByte.toString(16)}), entering gamma phase`,
-            );
-            enterGammaPhase();
-          }
-          return;
-        }
-
-        case "ADF_PRESRC_CMD":
-          // ACK for the re-probe ESC e opcode sent in the ADF branch of STATUS_2.
-          if (!isAck(pkt)) return fail(`expected ACK for ADF pre-reset ESC e opcode`);
-          state = "ADF_PRESRC_PARAM";
-          return;
-
-        case "ADF_PRESRC_PARAM":
-          // ACK for the re-probe source param byte (0x01).
-          if (!isAck(pkt)) return fail(`expected ACK for ADF pre-reset source param`);
-          state = "ADF_STATUS_3";
-          sendCmd(buildFsF(), 16);
-          return;
-
-        case "ADF_STATUS_3":
-          // Third FS F status check (ADF only); flows into the ESC ( reset cycle.
-          if (pkt.payload.length !== 16) {
-            return fail(`expected 16-byte status in ADF_STATUS_3, got ${pkt.payload.length}`);
-          }
-          log.debug(`ADF_STATUS_3: status byte 0x${pkt.payload[0].toString(16)}`);
-          state = "RESET_PAREN";
-          sendCmd(buildEscParen(), 1);
-          return;
-
-        case "RESET_PAREN":
-          // ESC ( returns 0x06 (ready) or 0x80 (busy); either way, proceed with reset
-          if (pkt.payload.length !== 1) {
-            return fail(`expected 1-byte ESC ( reply, got ${pkt.payload.length}`);
-          }
-          log.debug(`RESET_PAREN: ESC ( returned 0x${pkt.payload[0].toString(16)}`);
-          state = "RESET_INIT";
-          sendCmd(buildEscInit(), 1);
-          return;
-
-        case "RESET_INIT":
-          if (!isAck(pkt)) return fail(`expected ESC @ ack in reset cycle`);
-          state = "RESET_SRC_CMD";
-          sendCmd(buildEscE(), 1);
-          sendCmd(Buffer.from([SOURCE_BYTE[detectedSource]]), 1);
-          return;
-
-        case "RESET_SRC_CMD":
-          if (!isAck(pkt)) return fail(`expected ESC e ack in reset cycle`);
-          state = "RESET_SRC_PARAM";
-          return;
-
-        case "RESET_SRC_PARAM":
-          if (!isAck(pkt)) return fail(`expected ESC e param ack in reset cycle`);
-          state = "STATUS_READY";
-          sendCmd(buildFsF(), 16);
-          return;
-
-        case "STATUS_READY":
-          // Status after reset cycle; should be ready now.
-          // ADF sources read identity (FS I) twice before entering gamma phase; flatbed goes straight to gamma.
-          if (pkt.payload.length !== 16) {
-            return fail(`expected 16-byte status in STATUS_READY, got ${pkt.payload.length}`);
-          }
-          log.debug(`STATUS_READY: status byte 0x${pkt.payload[0].toString(16)}`);
-          if (detectedSource !== "flatbed") {
-            state = "ADF_IDENTITY_A";
-            sendCmd(buildFsI(), 80);
-          } else {
-            enterGammaPhase();
-          }
-          return;
-
-        case "ADF_IDENTITY_A":
-          // First FS I identity read after ADF reset cycle.
-          if (pkt.payload.length !== 80) {
-            return fail(`expected 80-byte identity in ADF_IDENTITY_A, got ${pkt.payload.length}`);
-          }
-          state = "ADF_IDENTITY_B";
-          sendCmd(buildFsI(), 80);
-          return;
-
-        case "ADF_IDENTITY_B":
-          // Second FS I identity read after ADF reset cycle (or inter-page loop).
-          // JPEG initial setup: proceed directly to gamma phase.
-          // PDF initial setup: an extra ESC e + source param follows before gamma.
-          // Inter-page loop (duplex): always enter gamma directly — no ESC e for PDF here.
-          if (pkt.payload.length !== 80) {
-            return fail(`expected 80-byte identity in ADF_IDENTITY_B, got ${pkt.payload.length}`);
-          }
-          if (session.format === "pdf" && !inInterPageLoop) {
-            state = "ADF_PDF_SRC_CMD";
-            sendCmd(buildEscE(), 1);
-            sendCmd(Buffer.from([SOURCE_BYTE[detectedSource]]), 1);
-          } else {
-            // Inter-page loop: flag has been consumed by STATUS_1B and now here;
-            // reset it so it's not stuck true for any future multi-sheet iterations.
-            inInterPageLoop = false;
-            enterGammaPhase();
-          }
-          return;
-
-        case "ADF_PDF_SRC_CMD":
-          // ACK for ESC e opcode in the ADF+PDF post-identity source re-set.
-          if (!isAck(pkt)) return fail(`expected ACK for ADF+PDF post-identity ESC e opcode`);
-          state = "ADF_PDF_SRC_PARAM";
-          return;
-
-        case "ADF_PDF_SRC_PARAM":
-          // ACK for source param byte in the ADF+PDF post-identity source re-set.
-          if (!isAck(pkt)) return fail(`expected ACK for ADF+PDF post-identity source param`);
-          enterGammaPhase();
-          return;
-
-        case "GAMMA_CMD": {
-          if (!isAck(pkt)) return fail(`expected ESC z ack (channel ${gammaChannelIdx})`);
-          const ch = GAMMA_CHANNELS[gammaChannelIdx];
-          state = "GAMMA_DATA";
-          sendCmd(Buffer.concat([Buffer.from([ch.tag]), ch.lut]), 1);
-          return;
-        }
-
-        case "GAMMA_DATA":
-          if (!isAck(pkt)) return fail(`expected gamma LUT ack (channel ${gammaChannelIdx})`);
-          if (gammaChannelIdx + 1 < GAMMA_CHANNELS.length) {
-            gammaChannelIdx++;
-            state = "GAMMA_CMD";
-            sendCmd(buildEscZ(), 1);
-          } else {
-            gammaChannelIdx = 0;
-            state = "WINDOW_CMD";
-            sendCmd(buildFsW(), 1);
-          }
-          return;
-
-        case "WINDOW_CMD":
-          if (!isAck(pkt)) return fail(`expected FS W ack`);
-          state = "WINDOW_DATA";
-          sendCmd(buildFsWBlock({ source: detectedSource, format: session.format }), 1);
-          return;
-
-        case "WINDOW_DATA":
-          if (!isAck(pkt)) return fail(`expected FS W block ack`);
-          state = "STATUS_PRESCAN";
-          sendCmd(buildFsF(), 16);
-          return;
-
-        case "STATUS_PRESCAN":
-          // Pre-scan status; now request scan start via FS G
-          if (pkt.payload.length !== 16) {
-            return fail(`expected 16-byte status, got ${pkt.payload.length}`);
-          }
-          state = "START";
-          sendCmd(buildFsG(), 14);
-          return;
-
-        case "START": {
-          // FS G reply: 14-byte scan geometry
-          if (pkt.payload.length !== 14) {
-            return fail(`expected 14-byte FS G reply, got ${pkt.payload.length}`);
-          }
-          fsGReply = parseFsGReply(pkt.payload);
-          // If chunkSize=0, the scanner is not yet ready (ADF still feeding paper).
-          // Poll FS F until status byte[0]=0x01 (ready), then re-send FS G.
-          if (fsGReply.chunkSize === 0) {
-            log.debug("START: FS G returned chunkSize=0, entering not-ready poll loop");
-            state = "START_POLL";
-            sendCmd(buildFsF(), 16);
-            return;
-          }
-          expectedBytes = computeExpectedBytes(detectedSource, session.format);
-          imageBuffer = Buffer.alloc(expectedBytes);
-          imageBufferOffset = 0;
-          log.debug(`START: expectedBytes=${expectedBytes}, chunkSize=${fsGReply.chunkSize}`);
-          // Send stream-config IS-0x2200 immediately; no reply expected before image stream starts
-          send(buildIsPacket(0x2200, buildStreamConfigPayload(fsGReply, session.format)));
-          state = "IMG_RECEIVING";
-          return;
-        }
-
-        case "START_POLL":
-          // FS F status poll during FS G not-ready retry loop.
-          // Keep polling until status byte[0]=0x01 (scanner ready), then do one more confirmation poll.
-          if (pkt.payload.length !== 16) {
-            return fail(`expected 16-byte status in START_POLL, got ${pkt.payload.length}`);
-          }
-          log.debug(`START_POLL: status byte 0x${pkt.payload[0].toString(16)}`);
-          state = pkt.payload[0] === 0x01 ? "START_POLL_READY" : "START_POLL";
-          sendCmd(buildFsF(), 16);
-          return;
-
-        case "START_POLL_READY":
-          // Final FS F reply after seeing status=0x01; now re-send FS G.
-          if (pkt.payload.length !== 16) {
-            return fail(`expected 16-byte status in START_POLL_READY, got ${pkt.payload.length}`);
-          }
-          log.debug(
-            `START_POLL_READY: status byte 0x${pkt.payload[0].toString(16)}, re-sending FS G`,
-          );
-          state = "START";
-          sendCmd(buildFsG(), 14);
-          return;
-
-        case "IMG_RECEIVING":
-          if (pkt.type !== 0xa200) {
-            return fail(
-              `expected IS-0xa200 image chunk, got 0x${pkt.type.toString(16)} in state IMG_RECEIVING`,
-            );
-          }
-          imageBufferOffset = appendImageChunk(pkt.payload, imageBuffer, imageBufferOffset);
-          if (imageBufferOffset >= expectedBytes) {
-            // Transition to PAGE_ENCODING immediately to absorb any trailing image chunks
-            // while the async JPEG encoding runs in the background.
-            state = "PAGE_ENCODING";
-            void onPageComplete();
-          }
-          return;
-
-        case "PAGE_ENCODING":
-          // Buffer IS-0xa200 image chunks for the next page (duplex) or trailing overflow
-          // (single-page); they will be replayed into imageBuffer when IMG_RECEIVING re-opens.
-          // Buffer all other packets and replay them once encoding completes.
-          if (pkt.type === 0xa200) {
-            deferredImageChunks.push(pkt.payload);
-          } else {
-            encodingDeferred.push({ type: pkt.type, payload: pkt.payload });
-          }
-          return;
-
-        case "PAGE_EJECT_WAIT":
-          // ACK for the ADF page-eject command (0x0c 0x00) sent after image stream ends.
-          // Always poll ADF status after eject; STATUS_1A's handler decides whether to
-          // continue the inter-page loop (status byte 0 = 0x01) or wrap up (0x81 = ADF empty).
-          if (pkt.payload.length !== 1) {
-            return fail(`expected 1-byte page-eject ACK, got ${pkt.payload.length}`);
-          }
-          log.debug(`PAGE_EJECT_WAIT: eject ACK 0x${pkt.payload[0].toString(16)}`);
-          // Duplex: after an odd-numbered completed page (1, 3, ...), the next page
-          // is the back side of the same sheet.
-          // Pages are 1-indexed: 1 (front), 2 (back), 3 (front), 4 (back) ... so back-pages
-          // are even indices. We push them as we discover them.
-          if (detectedSource === "adf-duplex" && pageCount % 2 === 1) {
-            backPageIndices.push(pageCount + 1);
-            // We push speculatively (next page may not arrive on hardware fault).
-            // composePdfFromJpegs uses Set.has() so a dangling index is benign.
-          }
-          inInterPageLoop = true;
-          state = "STATUS_1A";
-          sendCmd(buildFsF(), 16);
-          return;
-
-        case "POST_STATUS":
-          // FS F status after image stream; proceed to cleanup
-          if (pkt.payload.length !== 16) {
-            return fail(`expected 16-byte post-scan status, got ${pkt.payload.length}`);
-          }
-          state = "CLEANUP_1";
-          sendCmd(buildEscCleanup(), 1);
-          return;
-
-        case "CLEANUP_1":
-          // ESC ) may return 0x80 (NAK) or 0x06 (ACK).
-          // ADF: after first ESC ), re-set source (ESC e + param + FS F) before 2nd ESC ).
-          // Flatbed: send second ESC ) directly.
-          if (pkt.payload.length !== 1) {
-            return fail(`expected 1-byte CLEANUP_1 reply, got ${pkt.payload.length}`);
-          }
-          log.debug(`CLEANUP_1: ESC ) returned 0x${pkt.payload[0].toString(16)}`);
-          if (detectedSource !== "flatbed") {
-            state = "ADF_CLEANUP_SRC_CMD";
-            sendCmd(buildEscE(), 1);
-            sendCmd(Buffer.from([SOURCE_BYTE[detectedSource]]), 1);
-          } else {
-            state = "CLEANUP_2";
-            sendCmd(buildEscCleanup(), 1);
-          }
-          return;
-
-        case "ADF_CLEANUP_SRC_CMD":
-          // ACK for ESC e opcode during ADF post-scan cleanup.
-          if (!isAck(pkt)) return fail(`expected ACK for ADF cleanup ESC e opcode`);
-          state = "ADF_CLEANUP_SRC_PARAM";
-          return;
-
-        case "ADF_CLEANUP_SRC_PARAM":
-          // ACK for source param byte during ADF post-scan cleanup.
-          if (!isAck(pkt)) return fail(`expected ACK for ADF cleanup source param`);
-          state = "ADF_CLEANUP_STATUS";
-          sendCmd(buildFsF(), 16);
-          return;
-
-        case "ADF_CLEANUP_STATUS":
-          if (pkt.payload.length !== 16) {
-            return fail(`expected 16-byte status in ADF_CLEANUP_STATUS, got ${pkt.payload.length}`);
-          }
-          log.debug(`ADF_CLEANUP_STATUS: status byte 0x${pkt.payload[0].toString(16)}`);
-          state = "CLEANUP_2";
-          sendCmd(buildEscCleanup(), 1);
-          return;
-
-        case "CLEANUP_2":
-          // May return 0x80 (NAK); both values are acceptable.
-          if (pkt.payload.length !== 1) {
-            return fail(`expected 1-byte CLEANUP_2 reply, got ${pkt.payload.length}`);
-          }
-          log.debug(`CLEANUP_2: ESC ) returned 0x${pkt.payload[0].toString(16)}`);
-          state = "UNLOCKING";
-          send(buildUnlockPacket());
-          return;
-
-        case "UNLOCKING":
-          // IS-0xa101 unlock ack
-          if (pkt.type !== 0xa101) {
-            return fail(`expected unlock ack (0xa101), got 0x${pkt.type.toString(16)}`);
-          }
-          state = "DONE";
-          finalize();
-          return;
-
-        case "DONE":
-        case "ERROR":
-          return;
-
-        default:
-          fail(`unhandled state ${String(state)}`);
-      }
-    }
-
-    async function onPageComplete(): Promise<void> {
-      if (!fsGReply) return fail("page complete with no FS G reply");
-      const geom = geometry({ source: detectedSource, format: session.format });
-      try {
-        let jpg = await encodeRawGbrToJpeg(
-          imageBuffer,
-          geom.widthPx,
-          geom.heightPx,
-          session.jpegQuality,
-        );
-        if (getState() === "ERROR") return; // bail if fail() ran during the ~8s encode
-        const pageNum = pageCount + 1;
-        // Duplex: even-numbered pages (2, 4, …) are back pages and come out rotated 180° due to
-        // the ADF U-turn path. Insert EXIF Orientation=3 so viewers render them right-side up.
-        if (detectedSource === "adf-duplex" && pageNum % 2 === 0) {
-          jpg = setJpegOrientation(jpg, 3);
-        }
-        const jpgPath = path.join(sessionTempDir, `page_${String(pageNum).padStart(2, "0")}.jpg`);
-        fs.writeFileSync(jpgPath, jpg);
-        pageCount++;
-        log.debug(`Page ${pageNum} encoded, ${jpg.length} bytes -> ${jpgPath}`);
-      } catch (err) {
-        fail(`raw-to-jpeg encoding failed: ${err instanceof Error ? err.message : String(err)}`);
-        return;
-      }
-
-      if (getState() === "ERROR") return; // also bail before transitioning
-
-      // Flatbed: skip eject; go straight to POST_STATUS.
-      // ADF: send 0x0c 0x00 page-eject, wait for ACK, then FS F in PAGE_EJECT_WAIT handler.
-      if (detectedSource !== "flatbed") {
-        state = "PAGE_EJECT_WAIT";
-        sendCmd(buildPageEject(), 1);
-      } else {
-        state = "POST_STATUS";
-        sendCmd(buildFsF(), 16);
-      }
-
-      // Replay non-image packets that were buffered during PAGE_ENCODING.
-      // Stop as soon as the state transitions to IMG_RECEIVING — the remaining items belong
-      // to the next page's post-scan phase and must wait until that page's image stream
-      // has been received. Re-queue them into encodingDeferred so that the next
-      // onPageComplete invocation picks them up.
-      const deferred = encodingDeferred.splice(0);
-      for (let i = 0; i < deferred.length; i++) {
-        if (getState() === "ERROR" || getState() === "DONE") return;
-        try {
-          handle(deferred[i]);
-        } catch (err) {
-          fail(
-            `deferred packet handler threw: ${err instanceof Error ? err.message : String(err)}`,
-          );
-          return;
-        }
-        // After handle(), if we transitioned to IMG_RECEIVING, the next-page image data has not
-        // arrived yet. Re-queue remaining items for the next onPageComplete deferred replay.
-        if (getState() === "IMG_RECEIVING") {
-          for (let j = i + 1; j < deferred.length; j++) {
-            encodingDeferred.push(deferred[j]);
-          }
-          break;
-        }
-      }
-
-      // If deferred control replay brought us into IMG_RECEIVING (next page in multi-page run),
-      // drain any IS-0xa200 image chunks that arrived while we were encoding the previous page.
-      // Single-page final: deferredImageChunks are trailing overflow and are discarded.
-      if (getState() === "IMG_RECEIVING" && deferredImageChunks.length > 0) {
-        const imageChunks = deferredImageChunks.splice(0);
-        for (let i = 0; i < imageChunks.length; i++) {
-          if (getState() !== "IMG_RECEIVING") break;
-          const chunk = imageChunks[i];
-          imageBufferOffset = appendImageChunk(chunk, imageBuffer, imageBufferOffset);
-          if (imageBufferOffset >= expectedBytes) {
-            // Page filled. Any remaining chunks in imageChunks belong to a subsequent page —
-            // put them back into deferredImageChunks so the next onPageComplete can drain them.
-            for (let j = i + 1; j < imageChunks.length; j++) {
-              deferredImageChunks.push(imageChunks[j]);
-            }
-            state = "PAGE_ENCODING";
-            void onPageComplete();
-            break;
-          }
-        }
-      } else {
-        // Discard any lingering image chunks (e.g. trailing overflow on the final page).
-        deferredImageChunks.length = 0;
-      }
-    }
-
-    function finalize(): void {
-      if (timeoutTimer) clearTimeout(timeoutTimer);
-      socket.end();
-      setImmediate(() => {
-        finalizeSession({
-          sessionTempDir,
-          outputDir: session.outputDir,
-          sessionTs,
-          action: session.format,
-          backPageIndices,
-          paperless: session.paperless,
-        })
-          .catch((err: unknown) => {
-            const msg = err instanceof Error ? err.message : String(err);
-            log.error(`finalizeSession failed: ${msg}`);
-            // Symmetric with scanner.ts D.3: a finalize failure means no
-            // completed scan was saved, so reject — don't let the .finally
-            // resolveOnce silently mask it. failOnce sets errorReason and
-            // rejects via the resolved-guard; the .finally resolveOnce is
-            // then a no-op.
-            failOnce(new Error(`finalizeSession failure: ${msg}`));
-          })
-          .finally(() => resolveOnce());
-      });
-    }
-
-    function onClose(): void {
-      if (state !== "DONE" && state !== "ERROR") {
-        fail(`socket closed in state ${state}`);
-      }
-    }
+  const result = await runScanSession<EsciCtx>({
+    graph: esciGraph,
+    initialCtx: {
+      duplex: session.duplex,
+      forcedSource: session.forcedSource,
+      // Safe default — overwritten in STATUS_2 from the FS F byte (or
+      // forcedSource if set). The plan's wire-up: STATUS_2 mutates ctx.source
+      // before any state that reads it (RESET_INIT, ADF_IDENTITY_B, IMG_RECEIVING).
+      source: session.forcedSource ?? "adf-simplex",
+      format: session.format,
+      jpegQuality: session.jpegQuality,
+      diagnoseProtocol: session.diagnoseProtocol ?? false,
+      onSourceDetected: session.onSourceDetected,
+      inInterPageLoop: false,
+      pageCount: 0,
+      gammaChannelIdx: 0,
+      fsGReply: null,
+      imageBuffer: Buffer.alloc(0),
+      imageBufferOffset: 0,
+      expectedBytes: 0,
+    },
+    transportFactory: makeTcpTransportFactory(session, socketFactory),
+    outputDir: session.outputDir,
+    tempDir: session.tempDir,
+    sessionTs: resolveSessionTimestamp(new Date(), session.outputDir),
+    action: session.format === "pdf" ? "pdf" : "jpg",
+    paperless: session.paperless,
   });
-}
-
-function isAck(pkt: { payload: Buffer }): boolean {
-  return pkt.payload.length === 1 && pkt.payload[0] === ACK_BYTE;
-}
-
-function computeExpectedBytes(source: Source, format: Format): number {
-  const geom = geometry({ source, format });
-  return geom.widthPx * geom.heightPx * 3;
-}
-
-/** Strips the leading status byte from an IS-0xa200 chunk payload, then appends the pixel tail. */
-export function appendImageChunk(payload: Buffer, dest: Buffer, offset: number): number {
-  if (payload.length === 0) return offset;
-  payload.subarray(1).copy(dest, offset);
-  return offset + payload.length - 1;
+  if (!result.ok) throw result.reason;
 }

--- a/src/esci/test-support/fake-tcp-socket.ts
+++ b/src/esci/test-support/fake-tcp-socket.ts
@@ -1,6 +1,22 @@
 import { EventEmitter } from "node:events";
 import type * as net from "node:net";
 
+/**
+ * Minimal duplex-ish object that looks enough like a `net.Socket` to drive
+ * the ESC/I scanner's state machine in tests. Captures every `.write()` call
+ * as a Buffer; tests feed receive data via `feed()`.
+ *
+ * Mirrors src/esci2/test-support/fake-tls-socket.ts (without TLS):
+ *   - `feed(chunk)` buffers when no `data` listener is attached yet, then
+ *     replays via queueMicrotask on first `.on("data", ...)`. Real sockets
+ *     buffer received bytes during the connecting state too; without this,
+ *     a `simulateConnect(); feed(...)` pair would drop the first packet
+ *     because the engine attaches `transport.on("data", ...)` only AFTER
+ *     `await transportFactory()` yields a microtask.
+ *   - `emit("error", ...)` buffers when only `once`-listeners are present
+ *     (e.g. the factory's `socket.once("error", reject)`), then replays
+ *     when a persistent listener attaches.
+ */
 export class FakeTcpSocket extends EventEmitter {
   readonly writes: Buffer[] = [];
   private onConnect?: () => void;
@@ -13,8 +29,54 @@ export class FakeTcpSocket extends EventEmitter {
     this.onConnect?.();
   }
 
+  private pendingChunks: Buffer[] = [];
+  private pendingError: Error | null = null;
+
   feed(chunk: Buffer): void {
-    this.emit("data", chunk);
+    if (this.listenerCount("data") > 0) {
+      this.emit("data", chunk);
+    } else {
+      this.pendingChunks.push(chunk);
+    }
+  }
+
+  override on(event: string | symbol, listener: (...args: unknown[]) => void): this {
+    super.on(event, listener);
+    if (event === "data" && this.pendingChunks.length > 0) {
+      const chunks = this.pendingChunks;
+      this.pendingChunks = [];
+      // Defer to microtask: the engine declares `let dispatching = false`
+      // immediately AFTER transport.on("data", ...) registers, so a
+      // synchronous replay would dispatch while `dispatching` is still in
+      // the temporal dead zone. queueMicrotask also runs before any test
+      // setImmediate, preserving ordering vs. live feeds on later iterations.
+      queueMicrotask(() => {
+        for (const chunk of chunks) this.emit("data", chunk);
+      });
+    }
+    if (event === "error" && this.pendingError !== null) {
+      const err = this.pendingError;
+      this.pendingError = null;
+      queueMicrotask(() => this.emit("error", err));
+    }
+    return this;
+  }
+
+  override emit(event: string | symbol, ...args: unknown[]): boolean {
+    if (event === "error" && args.length > 0) {
+      const before = this.listenerCount("error");
+      const result = super.emit(event, ...args);
+      const after = this.listenerCount("error");
+      // If the only listener was a `once` (factory's pre-handshake
+      // `socket.once("error", reject)`), `before > 0 && after === 0`.
+      // The engine's persistent listener hasn't attached yet — buffer for
+      // replay on next .on("error", ...) registration.
+      if (before > 0 && after === 0) {
+        this.pendingError = args[0] as Error;
+      }
+      return result;
+    }
+    return super.emit(event, ...args);
   }
 
   write(data: Buffer): boolean {

--- a/src/esci/test-support/fake-tcp-socket.ts
+++ b/src/esci/test-support/fake-tcp-socket.ts
@@ -1,24 +1,11 @@
-import { EventEmitter } from "node:events";
 import type * as net from "node:net";
+import { FakeSocketBase } from "../../test-support/fake-socket-base.js";
 
 /**
- * Minimal duplex-ish object that looks enough like a `net.Socket` to drive
- * the ESC/I scanner's state machine in tests. Captures every `.write()` call
- * as a Buffer; tests feed receive data via `feed()`.
- *
- * Mirrors src/esci2/test-support/fake-tls-socket.ts (without TLS):
- *   - `feed(chunk)` buffers when no `data` listener is attached yet, then
- *     replays via queueMicrotask on first `.on("data", ...)`. Real sockets
- *     buffer received bytes during the connecting state too; without this,
- *     a `simulateConnect(); feed(...)` pair would drop the first packet
- *     because the engine attaches `transport.on("data", ...)` only AFTER
- *     `await transportFactory()` yields a microtask.
- *   - `emit("error", ...)` buffers when only `once`-listeners are present
- *     (e.g. the factory's `socket.once("error", reject)`), then replays
- *     when a persistent listener attaches.
+ * Minimal `net.Socket`-shaped fake driving the ESC/I scanner in tests.
+ * Inherits buffering for `data` / `error` events from FakeSocketBase.
  */
-export class FakeTcpSocket extends EventEmitter {
-  readonly writes: Buffer[] = [];
+export class FakeTcpSocket extends FakeSocketBase {
   private onConnect?: () => void;
 
   setOnConnect(cb?: () => void): void {
@@ -27,61 +14,6 @@ export class FakeTcpSocket extends EventEmitter {
 
   simulateConnect(): void {
     this.onConnect?.();
-  }
-
-  private pendingChunks: Buffer[] = [];
-  private pendingError: Error | null = null;
-
-  feed(chunk: Buffer): void {
-    if (this.listenerCount("data") > 0) {
-      this.emit("data", chunk);
-    } else {
-      this.pendingChunks.push(chunk);
-    }
-  }
-
-  override on(event: string | symbol, listener: (...args: unknown[]) => void): this {
-    super.on(event, listener);
-    if (event === "data" && this.pendingChunks.length > 0) {
-      const chunks = this.pendingChunks;
-      this.pendingChunks = [];
-      // Defer to microtask: the engine declares `let dispatching = false`
-      // immediately AFTER transport.on("data", ...) registers, so a
-      // synchronous replay would dispatch while `dispatching` is still in
-      // the temporal dead zone. queueMicrotask also runs before any test
-      // setImmediate, preserving ordering vs. live feeds on later iterations.
-      queueMicrotask(() => {
-        for (const chunk of chunks) this.emit("data", chunk);
-      });
-    }
-    if (event === "error" && this.pendingError !== null) {
-      const err = this.pendingError;
-      this.pendingError = null;
-      queueMicrotask(() => this.emit("error", err));
-    }
-    return this;
-  }
-
-  override emit(event: string | symbol, ...args: unknown[]): boolean {
-    if (event === "error" && args.length > 0) {
-      const before = this.listenerCount("error");
-      const result = super.emit(event, ...args);
-      const after = this.listenerCount("error");
-      // If the only listener was a `once` (factory's pre-handshake
-      // `socket.once("error", reject)`), `before > 0 && after === 0`.
-      // The engine's persistent listener hasn't attached yet — buffer for
-      // replay on next .on("error", ...) registration.
-      if (before > 0 && after === 0) {
-        this.pendingError = args[0] as Error;
-      }
-      return result;
-    }
-    return super.emit(event, ...args);
-  }
-
-  write(data: Buffer): boolean {
-    this.writes.push(Buffer.from(data));
-    return true;
   }
 
   end(): void {

--- a/src/esci2/test-support/fake-tls-socket.ts
+++ b/src/esci2/test-support/fake-tls-socket.ts
@@ -1,17 +1,14 @@
-import { EventEmitter } from "node:events";
 import type * as tls from "node:tls";
+import { FakeSocketBase } from "../../test-support/fake-socket-base.js";
 
 /**
- * Minimal duplex-ish object that looks enough like a `tls.TLSSocket` to
- * drive `scanner.ts`'s state machine in tests. Captures every `.write()`
- * call as a Buffer; tests feed receive data via `feed()`. No TLS, no real
- * socket.
- *
- * Casting: `socketFactory` in scanner.ts expects a `tls.TLSSocket`. We
- * return this via `as unknown as tls.TLSSocket` in tests.
+ * Minimal `tls.TLSSocket`-shaped fake driving the ESC/I-2 scanner in
+ * tests. Inherits buffering for `data` / `error` events from
+ * FakeSocketBase. Adds peer-cert pinning, `end(buf)` half-close-with-
+ * payload, and a `waitForWriteCount` predicate the engine's flushPage
+ * barrier needs (multi-microtask wire-level wait, not a fixed tick count).
  */
-export class FakeTlsSocket extends EventEmitter {
-  readonly writes: Buffer[] = [];
+export class FakeTlsSocket extends FakeSocketBase {
   private onSecureConnect?: () => void;
   private peerCertFingerprint: string | null = null;
 
@@ -38,102 +35,16 @@ export class FakeTlsSocket extends EventEmitter {
     this.onSecureConnect?.();
   }
 
-  private pendingChunks: Buffer[] = [];
-  private pendingError: Error | null = null;
-
-  /**
-   * Feed bytes as if the remote side sent them. If no `"data"` listener is
-   * attached yet, buffer the chunk and replay synchronously when one
-   * attaches via `on("data", ...)`. This matches real TCP/TLS socket
-   * behaviour where bytes received in the connecting state are buffered
-   * until the application starts reading. Without this, tests that call
-   * `simulateConnect(); feed(...)` synchronously would drop the first
-   * packet because the engine's `transport.on("data", ...)` registration
-   * happens on the next microtask after `await transportFactory()`.
-   */
-  feed(chunk: Buffer): void {
-    if (this.listenerCount("data") > 0) {
-      this.emit("data", chunk);
-    } else {
-      this.pendingChunks.push(chunk);
-    }
-  }
-
-  override on(event: string | symbol, listener: (...args: unknown[]) => void): this {
-    super.on(event, listener);
-    if (event === "data" && this.pendingChunks.length > 0) {
-      const chunks = this.pendingChunks;
-      this.pendingChunks = [];
-      // Defer the replay to the microtask queue. Two reasons:
-      //   1. The engine declares `let dispatching = false` AFTER
-      //      `transport.on("data", ...)` registers, so a synchronous
-      //      replay would call `tryDispatch()` while `dispatching` is
-      //      still in the temporal dead zone.
-      //   2. We need the replay to run BEFORE the test's next
-      //      `await new Promise(r => setImmediate(r))` resolves —
-      //      otherwise live feeds on the next iteration arrive in
-      //      `recvChunks` ahead of the buffered chunks, scrambling
-      //      packet order. queueMicrotask runs in the microtask phase
-      //      (immediately after the engine's setup body completes,
-      //      before any setImmediate fires), which preserves order.
-      queueMicrotask(() => {
-        for (const chunk of chunks) this.emit("data", chunk);
-      });
-    }
-    if (event === "error" && this.pendingError !== null) {
-      const err = this.pendingError;
-      this.pendingError = null;
-      queueMicrotask(() => this.emit("error", err));
-    }
-    return this;
-  }
-
-  /**
-   * Override emit() so that an "error" emitted before any non-once listener
-   * is registered (e.g., the test calls `fake.emit("error", ...)` between
-   * simulateConnect and the engine attaching its error listener via
-   * `transport.on("error", ...)` after `await transportFactory()` resolves)
-   * gets buffered and replayed when the listener attaches. Mirrors the data
-   * buffering above, for the same reason: real sockets buffer errors during
-   * the connecting state too.
-   */
-  override emit(event: string | symbol, ...args: unknown[]): boolean {
-    if (event === "error" && args.length > 0) {
-      // Count listeners EXCLUDING the factory's `once("error", reject)` which
-      // is attached pre-handshake. Heuristic: if the only listener is one
-      // attached via `once()` (we can't distinguish reliably), the error may
-      // still be lost on the engine. Simplest robust check: if listener
-      // count drops to 0 after emit (because once removes itself), buffer
-      // for replay when a future on() registers.
-      const before = this.listenerCount("error");
-      const result = super.emit(event, ...args);
-      const after = this.listenerCount("error");
-      if (before > 0 && after === 0) {
-        // Only `once` listeners were present; the engine hasn't attached
-        // its persistent listener yet. Buffer the error for replay.
-        this.pendingError = args[0] as Error;
-      }
-      return result;
-    }
-    return super.emit(event, ...args);
-  }
-
-  write(data: Buffer): boolean {
-    this.writes.push(Buffer.from(data));
-    return true;
-  }
-
   /**
    * Resolves once `this.writes.length >= target`. Polls per setImmediate
    * until the target is reached or `timeoutMs` elapses (default 1000 ms).
    *
-   * Why a predicate-based wait instead of a fixed `await setImmediate(r)`?
-   * The engine's flushPage barrier is genuinely multi-microtask (await
-   * encode → optionally async file I/O → unpause → write staged send →
-   * enter next state). Tests that assert "FIN follows the page-end feed"
-   * shouldn't hard-code a tick count — they should wait for the wire-level
-   * promise. This also turns "scanner is stuck" into a useful timeout
-   * error instead of an opaque assertion failure.
+   * Predicate-based wait, not a fixed `await setImmediate(r)`, because the
+   * engine's flushPage barrier is genuinely multi-microtask (await encode →
+   * optional async file I/O → unpause → write staged send → enter next
+   * state). Tests asserting "FIN follows the page-end feed" shouldn't hard-
+   * code a tick count — they wait for the wire-level signal. Also turns
+   * "scanner is stuck" into a useful timeout error.
    */
   async waitForWriteCount(target: number, opts: { timeoutMs?: number } = {}): Promise<void> {
     const timeoutMs = opts.timeoutMs ?? 1000;

--- a/src/test-support/fake-socket-base.ts
+++ b/src/test-support/fake-socket-base.ts
@@ -1,0 +1,82 @@
+import { EventEmitter } from "node:events";
+
+/**
+ * Shared base for FakeTcpSocket / FakeTlsSocket. Captures the buffering
+ * and replay logic that both fakes need to compensate for the engine's
+ * factory-await-yield gap:
+ *
+ *   - `feed(chunk)` buffers when no `data` listener is attached yet, then
+ *     replays via queueMicrotask on first `.on("data", ...)`. Real sockets
+ *     buffer received bytes during the connecting state too; without this,
+ *     a `simulateConnect(); feed(...)` pair would drop the first packet
+ *     because the engine attaches `transport.on("data", ...)` only AFTER
+ *     `await transportFactory()` yields a microtask.
+ *
+ *   - `emit("error", ...)` buffers when only `once`-listeners are present
+ *     (e.g. the factory's `socket.once("error", reject)`), then replays
+ *     when a persistent listener attaches.
+ *
+ * Subclasses add the protocol-specific surface: `write` capture,
+ * `simulateConnect` shape, `asFactory` signature, and any TLS-only bits
+ * (peer-cert pinning, `end(buf)` half-close-with-payload).
+ */
+export class FakeSocketBase extends EventEmitter {
+  readonly writes: Buffer[] = [];
+
+  private pendingChunks: Buffer[] = [];
+  private pendingError: Error | null = null;
+
+  feed(chunk: Buffer): void {
+    if (this.listenerCount("data") > 0) {
+      this.emit("data", chunk);
+    } else {
+      this.pendingChunks.push(chunk);
+    }
+  }
+
+  override on(event: string | symbol, listener: (...args: unknown[]) => void): this {
+    super.on(event, listener);
+    if (event === "data" && this.pendingChunks.length > 0) {
+      const chunks = this.pendingChunks;
+      this.pendingChunks = [];
+      // Defer to microtask: the engine declares `let dispatching = false`
+      // immediately AFTER transport.on("data", ...) registers, so a
+      // synchronous replay would dispatch while `dispatching` is still in
+      // the temporal dead zone. queueMicrotask also runs before any test
+      // setImmediate, preserving ordering vs. live feeds on later iterations.
+      queueMicrotask(() => {
+        for (const chunk of chunks) this.emit("data", chunk);
+      });
+    }
+    if (event === "error" && this.pendingError !== null) {
+      const err = this.pendingError;
+      this.pendingError = null;
+      queueMicrotask(() => this.emit("error", err));
+    }
+    return this;
+  }
+
+  override emit(event: string | symbol, ...args: unknown[]): boolean {
+    if (event === "error" && args.length > 0) {
+      const before = this.listenerCount("error");
+      const result = super.emit(event, ...args);
+      const after = this.listenerCount("error");
+      // If the only listener was a `once` (factory's pre-handshake
+      // `socket.once("error", reject)`), `before > 0 && after === 0`.
+      // The engine's persistent listener hasn't attached yet — buffer for
+      // replay on next .on("error", ...) registration. Only a single
+      // pre-listener error is buffered; tests don't exercise multi-error
+      // races, but if they ever do, this is the place to extend.
+      if (before > 0 && after === 0) {
+        this.pendingError = args[0] as Error;
+      }
+      return result;
+    }
+    return super.emit(event, ...args);
+  }
+
+  write(data: Buffer): boolean {
+    this.writes.push(Buffer.from(data));
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary

Third milestone of the v0.4.0 architectural rebuild ([plan](docs/superpowers/plans/2026-05-06-v0.4.0-architecture.md)). Refactors the ESC/I (WF-3620 / legacy) scanner onto the shared `runScanSession` engine introduced in M1, mirroring the M2 structure for ESC/I-2.

- **`src/esci/graph.ts`** (new, 691 LOC) — protocol graph for ESC/I, patterned after `src/esci2/graph.ts`. Five copies of the "ESC e + param + double-ACK" pattern collapse into the `escEThenAck` helper. Static "wait + advance + send" states use the new `awaitReply` helper (parallels M2's `awaitAck` but accepts a custom payload validator since ESC/I has length-checked replies of 1, 14, 16, and 80 bytes — not just the single-ack-byte pattern). All decision states use the same `expectIsType` guard helper M2 uses.
- **`src/esci/scanner.ts`** (908 → 111 LOC) — pure orchestration shell: builds initial ctx, wires a TCP transport factory, hands off to `runScanSession`. No separate `transport.ts` adapter (ESC/I has no TLS, no app-level unlock-on-destroy concern, no benign post-end RST class — `net.Socket` structurally satisfies `SessionTransport` directly).
- **`src/esci/graph.test.ts`** (new, 38 tests) — graph-shape unit tests for every state and decision branch.
- **`src/esci/test-support/fake-tcp-socket.ts`** — brought to parity with M2's `fake-tls-socket.ts`: pre-listener buffering for both `data` and `error` events. Without this, the engine's `transport.on('data', …)` registration race after `await transportFactory()` would drop synchronously-fed packets.

The 80 LOC of `encodingDeferred[]` / `deferredImageChunks[]` queues that the original needed (synchronous state machine couldn't pause for sharp's async JPEG encode) are gone — replaced by a single `flushPage` barrier in `IMG_RECEIVING`. The `getState()` workaround that defeated TypeScript's control-flow narrowing after `state =` mutation is gone too.

`DIAGNOSE_INIT_PROBE` preserved (the plan didn't enumerate it but `scanner-diagnose.test.ts`'s 3 tests must keep passing).

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 456 passed, 1 skipped (was 418 + 1; +38 graph-shape tests). All 10 byte-equivalent replay-matrix tests across the WF-3620 fixtures (1p / 3p simplex / 2p+4p duplex × jpg+pdf, plus flatbed jpg+pdf) pass byte-for-byte.
- [x] `npm run build` — `dist/` produced; no test-support directories or `*.test.js` files in output.
- [x] CI green on PR