### PR TITLE
refactor(engine): internal cleanups (PR 2 of v0.4.0 follow-up)

### DIFF
--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -106,7 +106,7 @@ The command bytes are either:
 
 **PARA is sent in two passthru packets**, not one. The first packet carries the 12-byte `PARAx<hex-len>` header with `reply_size=0`. The second carries the raw parameter bytes with `reply_size=64`. The printer responds only to the second packet, with a 64-byte `PARAx0000000#parOK…` reply if the parameters were accepted or `#parFAIL` if not. This two-phase structure was discovered from the Frida capture: the Windows driver never batches the two sends into a single passthru.
 
-ESC/I-2 command builders are in `src/esci2/commands.ts`. `buildFsY`, `buildFsX`, `buildFsZ` produce the legacy 2-byte initialization commands. `buildEsci2Command` builds the generic 12-byte ESC/I-2 header. `buildParaHeader` and `buildParaPayload` build the two PARA phases. Reply parsing is done by `parseEsci2ReplyHeader` (extracts the 12-byte reply header's `cmd` and `length` fields) and `parseTokens` (splits the `#KEY value` token stream from reply bodies).
+ESC/I-2 command builders are in `src/esci2/commands.ts`. The legacy 2-byte initialization commands (`buildFsY`, `buildFsX`, `buildFsZ`) live in `src/commands-fs.ts` and are shared with the WF-3620 ESC/I path (which uses `buildFsY` for the `DIAGNOSE_PROTOCOL` probe). `buildEsci2Command` builds the generic 12-byte ESC/I-2 header. `buildParaHeader` and `buildParaPayload` build the two PARA phases. Reply parsing is done by `parseEsci2ReplyHeader` (extracts the 12-byte reply header's `cmd` and `length` fields) and `parseTokens` (splits the `#KEY value` token stream from reply bodies).
 
 The SANE `epsonds` backend provides a useful cross-reference: its passthru framing — IS header layout, `0x000C` data offset, 8-byte data header with `cmd_size` / `reply_size` — is byte-identical to what the ET-4950 expects. However, `epsonds` targets older scanners that do not require the legacy ESC/I initialization loop before ESC/I-2 commands. The ET-4950's firmware requires `FS Y → STAT → FIN` polling repeated until the printer reports ready, followed by a `FS X` mode switch, before any ESC/I-2 command will be accepted.
 
@@ -379,8 +379,10 @@ Because the protocol was built from these captures, the replay tests are both re
 | `src/pushscan.ts`         | TCP server for push-scan trigger, SOAP parsing, x-uid echo                 |
 | `src/esci2/scanner.ts`    | ESC/I-2 TLS scan session state machine                                     |
 | `src/esci2/commands.ts`   | ESC/I-2 command builders, PARA payload blobs, reply parsers                |
+| `src/commands-fs.ts`      | Legacy 2-byte `FS Y` / `FS X` / `FS Z` builders shared by both protocols   |
 | `src/esci/scanner.ts`     | ESC/I plain-TCP scan session state machine                                 |
 | `src/esci/commands.ts`    | ESC/I command builders and reply parsers                                   |
+| `src/graph-helpers.ts`    | Shared graph-state helpers (`expectIsType`, `expectLength`, `ackByte`)     |
 | `src/esci/luts.ts`        | Gamma LUT tables for the ESC/I scan path                                   |
 | `src/esci/raw-to-jpeg.ts` | Raw 24-bit RGB → JPEG encoding via sharp                                   |
 | `src/protocol.ts`         | IS-frame encode/decode, lock/unlock/passthru/pureread packet builders      |

--- a/docs/superpowers/specs/2026-05-06-v0.4.0-architecture-design.md
+++ b/docs/superpowers/specs/2026-05-06-v0.4.0-architecture-design.md
@@ -65,9 +65,19 @@ Both Node `tls.TLSSocket` and `net.Socket` satisfy this interface structurally �
 **Engine responsibility:** "Given an already-connected byte stream, run this graph."
 **Factory responsibility:** "Connect however this protocol requires, then return a stream."
 
-> **M2 finding (2026-05-07).** The original "no wrappers needed" line was overoptimistic. ESC/I-2 panel hygiene depends on application-level teardown timing — sending UNLOCK before half-close, swallowing benign post-FIN ECONNRESET / EPIPE, no-op'ing destroy after a graceful end so close_notify lands. None of that belongs in the generic engine; none of it belongs in the orchestration shell either. Each protocol that needs this gets its own **transport adapter** module (`src/esci2/transport.ts` exporting `withEsci2UnlockOnDestroy(socket: tls.TLSSocket): SessionTransport`). The factory wires raw socket → adapter → engine. Future ESC/I-2-over-plain-TCP gets a sibling factory in `scanner.ts` reusing the same adapter unchanged. ESC/I, when ported to the engine in M3, gets its own adapter (`src/esci/transport.ts`) — do not unify with ESC/I-2's, the close-timing rules differ.
+> **M2 finding (2026-05-07).** The original "no wrappers needed" line was overoptimistic. ESC/I-2 panel hygiene depends on application-level teardown timing — sending UNLOCK before half-close, swallowing benign post-FIN ECONNRESET / EPIPE, no-op'ing destroy after a graceful end so close_notify lands. None of that belongs in the generic engine; none of it belongs in the orchestration shell either. Each protocol that needs this gets its own **transport adapter** module (`src/esci2/transport.ts`).
+>
+> **PR 2 (2026-05-07) refactor.** The original `withEsci2UnlockOnDestroy(socket: tls.TLSSocket)` bundled three concerns: unlock-on-abort + `politelyClosed` (transport-blind), TLS-error labelling (TLS-only), and post-`end()` ECONNRESET/EPIPE swallow (TLS-only). PR 2 split it into two `SessionTransport → SessionTransport` adapters that compose by nesting:
+>
+> - `withTlsErrorLabels(inner)` — labels mid-session errors with `"TLS connection error: …"` and swallows benign post-`end()` resets.
+> - `withEsci2UnlockOnDestroy(inner)` — unlock-on-abort + `politelyClosed` gate; works equally over TLS and plain TCP.
+> - `socketAsTransport(socket)` — explicit cast bridging `net.Socket` / `tls.TLSSocket` onto `SessionTransport`.
+>
+> Composition order matters: `withEsci2UnlockOnDestroy(withTlsErrorLabels(socketAsTransport(socket)))` for the TLS path. The unlock wrapper is OUTER so its destroy-time `inner.end(buildUnlockPacket())` flows through the TLS-error wrapper's `end(data?)`, setting that wrapper's `endCalled = true` before the bytes leave. ET-2750-targeted plain-TCP factory composes only the unlock adapter (no `withTlsErrorLabels` — there's no TLS layer to label).
+>
+> The composition is what made `SessionTransport.end` widen from `end(): void` to `end(data?: Buffer): void`. Both Node `net.Socket.end` and `tls.TLSSocket.end` already accept this shape; the engine itself only ever calls `transport.end()` with no argument (DONE entry) — the parameter exists for adapter composition.
 
-The dispatcher (`src/protocol-probe.ts` + `src/startup.ts:dispatchScanSession`) keeps probe / auto-detection logic. The factory is small. ET-2750 lands as a third dispatcher case (ESC/I-2 graph + plain-TCP factory + same `withEsci2UnlockOnDestroy` adapter) without engine or graph changes.
+The dispatcher (`src/protocol-probe.ts` + `src/startup.ts:dispatchScanSession`) keeps probe / auto-detection logic. The factory is small. ET-2750 lands as a third dispatcher case (ESC/I-2 graph + plain-TCP factory + the unlock-only adapter composition above) without engine or graph changes.
 
 ### 3.2. Graph data structure
 
@@ -94,13 +104,17 @@ export interface Graph<Ctx> {
   /**
    * Optional pre-dispatch filter for packets to discard. Used for
    * protocol-level "wait for body" patterns (e.g. ESC/I-2 empty 0xa000
-   * envelopes — the body follows in a subsequent packet). Receives
-   * the current state name so a filter can scope itself per state
-   * (e.g. ESC/I-2 filters empty 0xa000 globally EXCEPT in
-   * POSTSCAN_*_STAT_DRAIN, where the same shape is the actual
-   * drain-complete reply). Returns `true` to discard.
+   * envelopes — the body follows in a subsequent packet). Returns
+   * `true` to discard.
+   *
+   * State-blind: scoping happens via the per-state `bypassIgnoreFilter`
+   * flag on `GraphState` (PR 2 refactor — replaced the original
+   * "filter takes currentState as a second arg" wart). ESC/I-2's filter
+   * is now a one-line shape predicate; the two POSTSCAN_*_STAT_DRAIN
+   * states declare `bypassIgnoreFilter: true` so the empty 0xa000
+   * drain-complete reply reaches them unfiltered.
    */
-  globalIgnoreFilter?: (packet: { type: number; payload: Buffer }, currentState: string) => boolean;
+  globalIgnoreFilter?: (packet: { type: number; payload: Buffer }) => boolean;
 }
 
 export type GraphState<Ctx> =
@@ -300,6 +314,7 @@ While `paused === true`, `socket.on("data")` only appends to `recvChunks`. No tr
 - **Page index tracking.** Engine-owned. `pageIndex` increments on each flush; `backPageIndices: number[]` accumulates indices where `side === "back"`. Both passed to `finalizeSession` at scan-end.
 - **Error contract.** Unchanged from v0.3.0. Engine returns `{ ok: true } | { ok: false; reason: Error }` from its `runScanSession()` entry point. `dispatchScanSession` continues to convert `{ ok: false }` to a promise rejection — daemon and one-shot CLI see no contract change.
 - **Finalize handoff.** Engine calls `finalizeSession(...)` from `src/output-tail.ts` after the graph reaches `DONE`. Existing function; no changes.
+- **IS payload sanity-cap (PR 2).** `tryParseHead` checks the declared `payloadSize` against `Graph.maxPayloadBytes` (default 32 MB — comfortably exceeds the ~28 KB max observed in real fixtures) before accumulating bytes. A header that declares a payload larger than the cap settles `{ ok: false }` immediately with a `"likely framing desync in state X. First 32 bytes: <hex>"` diagnostic. Today's misleading symptom would be a `"Timeout in state X"` 30 seconds later — the cap turns the wrong diagnostic into the right one.
 
 ### 3.7. Engine signature
 
@@ -437,7 +452,7 @@ The transport-orthogonality constraint is satisfied by the design above; this se
 ET-2750 (hypothesis 1: ESC/I-2 over plain TCP) lands as:
 
 1. A new dispatcher branch in `src/protocol-probe.ts` / `src/startup.ts:dispatchScanSession` recognising "ESC/I-2 protocol script + plain TCP transport." Detection rule TBD by the v0.3.1 protocol-diagnose mode output.
-2. `src/esci2/scanner.ts` exposes a second factory variant: `makeTcpTransportFactory(session)` alongside the existing `makeTlsTransportFactory`. Cert-fingerprint logic stays in the TLS variant only. Both factories wrap their raw socket in the existing `withEsci2UnlockOnDestroy` adapter from `src/esci2/transport.ts` — same panel-hygiene rules apply over plain TCP.
+2. `src/esci2/scanner.ts` exposes a second factory variant: `makePlainEsci2TransportFactory(session)` alongside the existing `makeTlsTransportFactory`. Cert-fingerprint logic stays in the TLS variant only. The TLS factory composes both adapters (`withEsci2UnlockOnDestroy(withTlsErrorLabels(socketAsTransport(socket)))`); the plain-TCP factory composes only the unlock adapter (`withEsci2UnlockOnDestroy(socketAsTransport(socket))`) — same panel-hygiene rules apply, but there's no TLS layer to label or to swallow post-FIN resets from. See §3.1's PR 2 note for the adapter split.
 3. Same `esci2Graph` runs over the new factory. **No engine changes. No graph changes. No transport-adapter changes.**
 
 Hypothesis 2 (eSCL on port 80) would NOT use this engine — eSCL is HTTP/SOAP and shares no IS-framing or ESC/I-2 vocabulary with our engine. It would be a parallel implementation under `src/escl/` sharing only the output-tail boundary. Group A doesn't anticipate this; it would be a separate spec.
@@ -539,7 +554,7 @@ Steps:
    - Define `Esci2Ctx`.
    - Build `esci2Graph` via `createGraph<Esci2Ctx>("WELCOME", 30_000)` + `g.state(...)` calls.
    - Implement helpers: `awaitAck(g, prefix, sendNext, next)`, `statThenDrain(g, prefix, onDone)`.
-   - All 32 current states map onto the new graph; the helper composition collapses repeated sub-flows. **Target: no more than 14 distinct hand-named `g.state(...)` calls in `esci2/graph.ts`.** Helper-generated states (e.g. `${prefix}_CMD` / `${prefix}_PARAM`) are not counted toward this budget; only the explicit `g.state("NAME", ...)` calls written directly in the file.
+   - All 32 current states map onto the new graph; the helper composition collapses repeated sub-flows. **Post-M3 reality: 21 named `g.state(...)` calls in `esci2/graph.ts`.** The earlier "no more than 14" target was an architectural sketch from before the helpers landed; the actual count includes states that carry real protocol decisions (e.g. each two-phase-read pair, the POSTSCAN*FS_Y*\*, INIT_POLL_FIN's loop-back). Helpers absorb the mechanical repetition (`twoPhaseRead`, `statThenDrain`, `awaitReply`); explicit named states are correct where they encode genuine wire structure rather than copy-pasted boilerplate.
 2. Refactor `src/esci2/scanner.ts` to a ~30-LOC orchestration shell that:
    - Builds a `SessionTransportFactory` from the TLS socket factory + cert-fingerprint config.
    - Calls `runScanSession({ graph: esci2Graph, initialCtx, transportFactory, ... })`.
@@ -560,7 +575,7 @@ Steps:
    - Define `EsciCtx`.
    - Build `esciGraph` via `createGraph<EsciCtx>("WELCOME", 60_000)` + `g.state(...)` calls.
    - Implement helpers: `escEThenAck(g, prefix, srcByte, next)`, possibly `awaitAck(g, prefix, ...)` (likely shared shape with esci2 helper but lives in `esci/graph.ts` per the no-cross-scanner-imports rule).
-   - All 42 current states map onto the new graph. Five copies of `ESC e + param + double-ACK` collapse into five `escEThenAck` calls. ADF-vs-flatbed branching becomes computed transitions at `STATUS_2` and other named decision points (allowlist §3.4); the six ADF-only state-enum entries disappear. **Target: no more than 14 distinct hand-named `g.state(...)` calls in `esci/graph.ts`.** Helper-generated states are not counted, same convention as M2.
+   - All 42 current states map onto the new graph. Five copies of `ESC e + param + double-ACK` collapse into five `escEThenAck` calls. ADF-vs-flatbed branching becomes computed transitions at `STATUS_2` and other named decision points (allowlist §3.4); the six ADF-only state-enum entries disappear. **Post-M3 reality: 17 named `g.state(...)` calls in `esci/graph.ts`.** Same caveat as §6.3 — explicit named states are correct where they carry real protocol decisions (e.g. `STATUS_1A` / `STATUS_1B` / `STATUS_2` are three distinct decision points, not boilerplate). Helpers (`escEThenAck`, `awaitReply`) absorb the mechanical repetition.
    - The `getState()` TypeScript-narrowing workaround disappears.
    - Async page encoding uses `flushPage.encode = () => sharp(rawRgb, opts).jpeg({ quality }).toBuffer()`. The 80 LOC of `encodingDeferred[]` + `deferredImageChunks[]` + `PAGE_ENCODING` glue is deleted; engine owns the barrier.
 2. Rewrite `src/esci/scanner.ts` to a ~30-LOC orchestration shell.

--- a/src/commands-fs.ts
+++ b/src/commands-fs.ts
@@ -1,0 +1,38 @@
+// src/commands-fs.ts
+//
+// Legacy ESC/I "FS *" two-byte commands. Used by both protocol generations:
+// the WF-3620 ESC/I path emits FS Y (in the diagnose-protocol probe), and
+// the ET-4950 ESC/I-2 path uses FS Y / FS X / FS Z to drive the legacy
+// init poll before switching to extended mode. Lifting them out of
+// `src/esci2/commands.ts` keeps `src/esci/graph.ts` free of cross-protocol
+// imports — `from "../esci2/commands.js"` was the only such reach across
+// the protocol boundary.
+
+/**
+ * Legacy ESC/I "Inquire Extended Status" (FS Y). Two raw bytes.
+ * Caller sends as passthru with cmd_size=2, reply_size=1.
+ * Reply is 1 byte: 0x06 = ACK.
+ */
+export function buildFsY(): Buffer {
+  return Buffer.from([0x1c, 0x59]);
+}
+
+/**
+ * Legacy ESC/I "Switch to Extended Mode" (FS X). Two raw bytes.
+ * Sent once after the init poll confirms the printer is ready, transitioning
+ * the session from legacy ESC/I to ESC/I-2 framing.
+ * Caller sends as passthru with cmd_size=2, reply_size=1.
+ * Reply is 1 byte: 0x06 = ACK.
+ */
+export function buildFsX(): Buffer {
+  return Buffer.from([0x1c, 0x58]);
+}
+
+/**
+ * Legacy ESC/I FS Z (0x1C 0x5A). Used in the driver's cycle-2 init
+ * polling to request a second, smaller capability-discovery pass.
+ * Caller sends as passthru with cmd_size=2, reply_size=1; reply is 0x06.
+ */
+export function buildFsZ(): Buffer {
+  return Buffer.from([0x1c, 0x5a]);
+}

--- a/src/esci/graph.test.ts
+++ b/src/esci/graph.test.ts
@@ -6,10 +6,10 @@ function makeCtx(overrides: Partial<EsciCtx> = {}): EsciCtx {
     duplex: false,
     forcedSource: null,
     source: "adf-simplex",
+    sourceDetected: false,
     format: "jpg",
     jpegQuality: 90,
     diagnoseProtocol: false,
-    onSourceDetected: undefined,
     inInterPageLoop: false,
     pageCount: 0,
     gammaChannelIdx: 0,
@@ -208,15 +208,19 @@ describe("esciGraph IDENTITY / STATUS_1A / STATUS_1B / STATUS_2", () => {
     }
   });
 
-  it("STATUS_2 calls onSourceDetected with the resolved source", () => {
+  it("STATUS_2 sets ctx.sourceDetected once the source has been resolved", () => {
+    // The graph-level contract is: STATUS_2 records the decision on the
+    // ctx flag; the scanner shell reads the flag post-DONE to decide
+    // whether to fire the public onSourceDetected hook (success-only).
     const state = esciGraph.states.STATUS_2;
     if (state.kind === "decision") {
-      const seen: string[] = [];
-      const ctx = makeCtx({ onSourceDetected: (s) => seen.push(s) });
+      const ctx = makeCtx();
+      expect(ctx.sourceDetected).toBe(false);
       const payload = Buffer.alloc(16);
       payload[0] = 0x01;
       state.decide(ctx, { type: ESCI_REPLY, payload });
-      expect(seen).toEqual(["adf-simplex"]);
+      expect(ctx.sourceDetected).toBe(true);
+      expect(ctx.source).toBe("adf-simplex");
     }
   });
 });

--- a/src/esci/graph.ts
+++ b/src/esci/graph.ts
@@ -39,10 +39,12 @@ import {
   type Format,
   type ScanGeometry,
 } from "./commands.js";
-// FS Y is the ET-4950 ESC/I-2 init's first command. Used here only for the
-// DIAGNOSE_PROTOCOL probe — sent after ESC @ NAKs to classify printers
-// stuck between ESC/I and ESC/I-2.
-import { buildFsY } from "../esci2/commands.js";
+// FS Y is the ET-4950 ESC/I-2 init's first command, now lifted to the
+// shared `commands-fs.ts` module. Used here only for the DIAGNOSE_PROTOCOL
+// probe — sent after ESC @ NAKs to classify printers stuck between ESC/I
+// and ESC/I-2.
+import { buildFsY } from "../commands-fs.js";
+import { expectIsType, expectLength } from "../graph-helpers.js";
 import { GAMMA_LUT_R, GAMMA_LUT_G, GAMMA_LUT_B } from "./luts.js";
 import { encodeRawGbrToJpeg } from "./raw-to-jpeg.js";
 import { createLogger } from "../logger.js";
@@ -63,8 +65,17 @@ export interface EsciCtx {
   jpegQuality: number;
   /** When true, a non-ACK reply to ESC @ triggers an FS Y diagnostic probe. */
   diagnoseProtocol: boolean;
-  /** Optional test hook fired once when STATUS_2 has decided the source. */
-  onSourceDetected?: (source: Source) => void;
+  /**
+   * True once STATUS_2 has actually run and assigned `ctx.source` (either
+   * from the FS F status byte via `legacyDetectSource` or from
+   * `ctx.forcedSource`). The shell uses this flag — not just the presence
+   * of `ctx.source` — to decide whether to fire `LegacyScanSession.onSourceDetected`,
+   * because `source` is initialized to `forcedSource ?? "adf-simplex"` in
+   * the scanner shell before any state has run, so a session that fails
+   * inside WELCOME / LOCKING / INIT could otherwise produce a spurious
+   * detection callback on the failure path.
+   */
+  sourceDetected: boolean;
   /** True when looping back for the back side of a duplex sheet (or next ADF page). */
   inInterPageLoop: boolean;
   /** Page count, 1-indexed during dispatch (incremented just before flush). */
@@ -128,32 +139,16 @@ const sendEscEPlusCtxSource: SendSpec<EsciCtx>[] = [
 ];
 
 /**
- * Guard helper for decision states (mirrors src/esci2/graph.ts:expectIsType):
- * ensure the incoming packet matches the expected IS type. Returns an Error
- * TransitionResult on mismatch (engine routes through the failure path);
- * returns null to continue.
- */
-function expectIsType(
-  packet: { type: number },
-  expected: number,
-  stateName: string,
-): { error: Error } | null {
-  if (packet.type !== expected) {
-    return {
-      error: new Error(
-        `${stateName}: expected packet type 0x${expected.toString(16).padStart(4, "0")}, got 0x${packet.type.toString(16).padStart(4, "0")}`,
-      ),
-    };
-  }
-  return null;
-}
-
-/**
  * awaitReply — registers a static state that waits for `expectedReplyType`,
  * runs `validate` against the payload, then advances to `next` (optionally
- * emitting `send`). Mirrors the role of esci2/graph.ts:awaitAck but accepts
- * a custom payload validator (ESC/I has length-based replies of 1, 14, 16
- * and 80 bytes — not just the single-byte ack pattern).
+ * emitting `send`). Same shape as the per-graph helper in
+ * `src/esci2/graph.ts`; intentionally not lifted to a shared module —
+ * each graph parameterises it with its own `Ctx`, and the cost of two
+ * copies is smaller than the cost of a generic shared abstraction. The
+ * ESC/I path additionally needs custom validators (length-based replies
+ * of 1 / 14 / 16 / 80 bytes, not just single-byte ACKs), which the
+ * shape predicates in `src/graph-helpers.ts` like `ackByte` cover for
+ * the simple cases.
  */
 function awaitReply(
   g: GraphBuilder<EsciCtx>,
@@ -191,25 +186,6 @@ function escEThenAck(
 ): void {
   awaitReply(g, `${prefix}_ACK1`, ESCI_REPLY, isAck, `${prefix}_ACK2`);
   awaitReply(g, `${prefix}_ACK2`, ESCI_REPLY, isAck, next, nextSend);
-}
-
-/**
- * Decision-state guard for length-checked ESC/I replies. Companion to
- * `expectIsType` — returns an error TransitionResult on length mismatch
- * so the engine routes through the standard failure path; null to continue.
- */
-function expectLength(
-  payload: Buffer,
-  expected: number,
-  stateName: string,
-  label: string,
-): { error: Error } | null {
-  if (payload.length !== expected) {
-    return {
-      error: new Error(`${stateName}: expected ${expected}-byte ${label}, got ${payload.length}`),
-    };
-  }
-  return null;
 }
 
 /** Strip the leading status byte from an IS-0xa200 chunk and copy pixel tail. */
@@ -359,7 +335,7 @@ g.state(
       }
       ctx.source = result.source;
     }
-    ctx.onSourceDetected?.(ctx.source);
+    ctx.sourceDetected = true;
 
     if (statusByte === 0x81) {
       return { next: "RESET_PAREN", send: passthru(buildEscParen(), 1) };

--- a/src/esci/scanner.ts
+++ b/src/esci/scanner.ts
@@ -3,13 +3,13 @@ import fs from "node:fs";
 import os from "node:os";
 import {
   runScanSession,
+  socketAsTransport,
   type SessionTransport,
   type SessionTransportFactory,
 } from "../scan-session.js";
 import { resolveSessionTimestamp } from "../output.js";
 import { esciGraph, type EsciCtx } from "./graph.js";
 import type { Source, Format } from "./commands.js";
-import { socketAsTransport } from "../esci2/transport.js";
 import type { PaperlessUploadOptions } from "../paperless-upload.js";
 
 export { appendImageChunk } from "./graph.js";

--- a/src/esci/scanner.ts
+++ b/src/esci/scanner.ts
@@ -9,6 +9,7 @@ import {
 import { resolveSessionTimestamp } from "../output.js";
 import { esciGraph, type EsciCtx } from "./graph.js";
 import type { Source, Format } from "./commands.js";
+import { socketAsTransport } from "../esci2/transport.js";
 import type { PaperlessUploadOptions } from "../paperless-upload.js";
 
 export { appendImageChunk } from "./graph.js";
@@ -49,12 +50,16 @@ function makeTcpTransportFactory(
 ): SessionTransportFactory {
   return () =>
     new Promise<SessionTransport>((resolve, reject) => {
-      // net.Socket structurally satisfies SessionTransport; plain TCP needs
-      // no app-level wrapper (no TLS pin, no unlock-on-destroy semantics
-      // peculiar to ESC/I-2). If a future ESC/I quirk needs one, introduce
-      // a sibling src/esci/transport.ts.
+      // Plain TCP needs no app-level wrapper (no TLS pin, no
+      // unlock-on-destroy semantics peculiar to ESC/I-2). The
+      // socketAsTransport bridge is just an explicit-cast shim so the
+      // engine's SessionTransport.end(data?) signature is honoured —
+      // net.Socket.end has its own overload set that doesn't directly
+      // satisfy the interface as a structural subtype. If a future
+      // ESC/I quirk needs a wrapper, introduce a sibling
+      // src/esci/transport.ts.
       const socket = socketFactory(session.printerIp, session.port, () => {
-        resolve(socket);
+        resolve(socketAsTransport(socket));
       });
       socket.once("error", reject);
     });
@@ -80,12 +85,15 @@ export async function runEsciScan(
       duplex: session.duplex,
       forcedSource: session.forcedSource,
       // Safe default — STATUS_2 overwrites this from the FS F byte (or
-      // forcedSource) before any state downstream reads it.
+      // forcedSource) before any state downstream reads it. The
+      // `sourceDetected` flag below disambiguates "this default" from
+      // "STATUS_2 actually ran" so the shell only fires onSourceDetected
+      // on success paths.
       source: session.forcedSource ?? "adf-simplex",
+      sourceDetected: false,
       format: session.format,
       jpegQuality: session.jpegQuality,
       diagnoseProtocol: session.diagnoseProtocol ?? false,
-      onSourceDetected: session.onSourceDetected,
       inInterPageLoop: false,
       pageCount: 0,
       gammaChannelIdx: 0,
@@ -100,5 +108,13 @@ export async function runEsciScan(
     action: session.format === "pdf" ? "pdf" : "jpg",
     paperless: session.paperless,
   });
+
+  // Fire the public onSourceDetected hook only on success paths AND only
+  // when STATUS_2 actually ran. Production callers don't pass this hook;
+  // the replay-test matrix uses it to assert per-fixture detection.
+  if (result.ok && result.finalCtx.sourceDetected) {
+    session.onSourceDetected?.(result.finalCtx.source);
+  }
+
   if (!result.ok) throw result.reason;
 }

--- a/src/esci2/commands.test.ts
+++ b/src/esci2/commands.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { buildFsY, buildFsX, buildFsZ } from "../commands-fs.js";
 import {
-  buildFsY,
-  buildFsX,
-  buildFsZ,
   buildEsci2Command,
   buildParaHeader,
   buildParaPayload,

--- a/src/esci2/commands.ts
+++ b/src/esci2/commands.ts
@@ -2,36 +2,9 @@ import { createLogger } from "../logger.js";
 
 const log = createLogger("esci");
 
-// ─── Legacy ESC/I commands (2 raw bytes each) ─────────────────────────────
-
-/**
- * Legacy ESC/I "Inquire Extended Status" (FS Y). Two raw bytes.
- * Caller sends as passthru with cmd_size=2, reply_size=1.
- * Reply is 1 byte: 0x06 = ACK.
- */
-export function buildFsY(): Buffer {
-  return Buffer.from([0x1c, 0x59]);
-}
-
-/**
- * Legacy ESC/I "Switch to Extended Mode" (FS X). Two raw bytes.
- * Sent once after the init poll confirms the printer is ready, transitioning
- * the session from legacy ESC/I to ESC/I-2 framing.
- * Caller sends as passthru with cmd_size=2, reply_size=1.
- * Reply is 1 byte: 0x06 = ACK.
- */
-export function buildFsX(): Buffer {
-  return Buffer.from([0x1c, 0x58]);
-}
-
-/**
- * Legacy ESC/I FS Z (0x1C 0x5A). Used in the driver's cycle-2 init
- * polling to request a second, smaller capability-discovery pass.
- * Caller sends as passthru with cmd_size=2, reply_size=1; reply is 0x06.
- */
-export function buildFsZ(): Buffer {
-  return Buffer.from([0x1c, 0x5a]);
-}
+// Legacy ESC/I "FS *" commands shared with the WF-3620 path now live in
+// `src/commands-fs.ts`. They retain the same wire bytes; this comment is
+// the only thing that moved.
 
 // ─── ESC/I-2 commands ─────────────────────────────────────────────────────
 

--- a/src/esci2/graph.test.ts
+++ b/src/esci2/graph.test.ts
@@ -13,42 +13,29 @@ describe("esci2Graph (smoke)", () => {
     expect(esci2Graph.states.WELCOME).toBeDefined();
   });
 
-  it("has globalIgnoreFilter defined for empty 0xa000 envelopes outside POSTSCAN drain", () => {
+  it("has globalIgnoreFilter defined as a pure shape predicate (state-blind)", () => {
     expect(esci2Graph.globalIgnoreFilter).toBeDefined();
-    // Empty 0xa000 in image-flow / init / mode-switch states → ignored
-    // (these are "wait for body" pre-data signals).
-    expect(
-      esci2Graph.globalIgnoreFilter!({ type: 0xa000, payload: Buffer.alloc(0) }, "IMG_META"),
-    ).toBe(true);
-    expect(
-      esci2Graph.globalIgnoreFilter!({ type: 0xa000, payload: Buffer.alloc(0) }, "WELCOME"),
-    ).toBe(true);
-    // Non-empty 0xa000 → not ignored regardless of state
-    expect(
-      esci2Graph.globalIgnoreFilter!({ type: 0xa000, payload: Buffer.from([0x01]) }, "IMG_META"),
-    ).toBe(false);
-    // Other types → not ignored
-    expect(
-      esci2Graph.globalIgnoreFilter!({ type: 0x2000, payload: Buffer.alloc(0) }, "IMG_META"),
-    ).toBe(false);
+    // Empty 0xa000 → ignored.
+    expect(esci2Graph.globalIgnoreFilter!({ type: 0xa000, payload: Buffer.alloc(0) })).toBe(true);
+    // Non-empty 0xa000 → not ignored.
+    expect(esci2Graph.globalIgnoreFilter!({ type: 0xa000, payload: Buffer.from([0x01]) })).toBe(
+      false,
+    );
+    // Other types → not ignored.
+    expect(esci2Graph.globalIgnoreFilter!({ type: 0x2000, payload: Buffer.alloc(0) })).toBe(false);
   });
 
-  it("globalIgnoreFilter passes through empty 0xa000 in POSTSCAN_*_STAT_DRAIN (drain-complete reply)", () => {
+  it("POSTSCAN_*_STAT_DRAIN states opt out of the filter via bypassIgnoreFilter", () => {
     // After our pure-read(0) for a length=0 STAT, the printer's empty
-    // 0xa000 reply IS the drain-complete signal — must not be filtered
-    // out, or _STAT_DRAIN hangs waiting on a packet that never comes.
-    expect(
-      esci2Graph.globalIgnoreFilter!(
-        { type: 0xa000, payload: Buffer.alloc(0) },
-        "POSTSCAN_1_STAT_DRAIN",
-      ),
-    ).toBe(false);
-    expect(
-      esci2Graph.globalIgnoreFilter!(
-        { type: 0xa000, payload: Buffer.alloc(0) },
-        "POSTSCAN_2_STAT_DRAIN",
-      ),
-    ).toBe(false);
+    // 0xa000 reply IS the drain-complete signal — the engine must NOT
+    // run the filter for these states, or _STAT_DRAIN hangs waiting on
+    // a packet that never reaches its transition table.
+    expect(esci2Graph.states.POSTSCAN_1_STAT_DRAIN.bypassIgnoreFilter).toBe(true);
+    expect(esci2Graph.states.POSTSCAN_2_STAT_DRAIN.bypassIgnoreFilter).toBe(true);
+    // Other states (e.g. POST_MODE / INIT_POLL drain) do NOT need the
+    // bypass — their _STAT decisions skip the drain entirely on length=0.
+    expect(esci2Graph.states.POST_MODE_STAT_DRAIN.bypassIgnoreFilter).toBeUndefined();
+    expect(esci2Graph.states.INIT_POLL_STAT_DRAIN.bypassIgnoreFilter).toBeUndefined();
   });
 
   it("has globalAbortHandlers covering 0x9000", () => {

--- a/src/esci2/graph.ts
+++ b/src/esci2/graph.ts
@@ -13,16 +13,15 @@ import {
   buildPassthruPacket,
   buildPurereadPacket,
 } from "../protocol.js";
+import { buildFsY, buildFsX, buildFsZ } from "../commands-fs.js";
 import {
-  buildFsY,
-  buildFsX,
-  buildFsZ,
   buildEsci2Command,
   buildParaHeader,
   buildParaPayload,
   parseEsci2ReplyHeader,
   parseTokens,
 } from "./commands.js";
+import { ackByte, expectIsType } from "../graph-helpers.js";
 
 /**
  * Per-session mutable state threaded through every transition. The engine
@@ -70,74 +69,50 @@ const ASYNC_CANCEL_BYTES = new Set([0x03 /* ScanCancel */]);
 // =============================================================================
 
 /**
- * awaitAck — creates a static state that waits for `expectedReplyType` and
- * optionally validates the payload byte 0 (e.g. legacy ESC/I-2 ACKs are
- * 0x06 inside an 0xa000 envelope) before advancing.
+ * awaitReply — registers a static state that waits for `expectedReplyType`,
+ * runs `validate` against the payload, then advances to `next` (optionally
+ * emitting `send`). Local rename of what used to be `awaitAck` — both
+ * graphs now have a same-shaped helper but they intentionally stay
+ * per-graph (no shared abstraction) because the marginal cost of two
+ * copies is small and the graphs use the helper with different `Ctx`
+ * type parameters; lifting it would force a generic Ctx parameter that
+ * adds a layer of indirection without payoff. Revisit if a third graph
+ * appears.
  */
-function awaitAck(
+function awaitReply(
   g: GraphBuilder<Esci2Ctx>,
   name: string,
   expectedReplyType: number,
+  validate: (payload: Buffer) => boolean,
   next: string,
   send?: SendSpec<Esci2Ctx> | SendSpec<Esci2Ctx>[],
-  expectedAckByte?: number,
 ): void {
   g.state(name, {
     on: {
       [expectedReplyType]: {
+        validate,
         next,
         ...(send !== undefined ? { send } : {}),
-        ...(expectedAckByte !== undefined
-          ? { validate: (payload: Buffer) => payload[0] === expectedAckByte }
-          : {}),
       },
     },
   });
-}
-
-/**
- * Guard helper for decision states: ensure the incoming packet matches the
- * expected IS type. Returns an Error TransitionResult on mismatch (the engine
- * routes it through the normal failure path); returns null to continue.
- *
- * Static states fail fast on unmatched packet types automatically (engine
- * behaviour), but decision states see every packet, so each one needs its
- * own type guard to avoid acting on the wrong wire data.
- */
-function expectIsType(
-  packet: { type: number },
-  expected: number,
-  stateName: string,
-): { error: Error } | null {
-  if (packet.type !== expected) {
-    return {
-      error: new Error(
-        `${stateName}: expected packet type 0x${expected.toString(16).padStart(4, "0")}, got 0x${packet.type.toString(16).padStart(4, "0")}`,
-      ),
-    };
-  }
-  return null;
 }
 
 // =============================================================================
 // Graph builder
 // =============================================================================
 
+// Empty 0xa000 envelopes are "wait for body" pre-data signals on the
+// ESC/I-2 wire EXCEPT in POSTSCAN_*_STAT_DRAIN — there, after our
+// pure-read(0) for a length=0 STAT reply, the printer's empty 0xa000
+// IS the drain-complete trigger and must reach the state for it to
+// advance to FIN. The bypass is per-state via `bypassIgnoreFilter: true`
+// on the two drain states (declared below) — the filter itself stays a
+// pure shape predicate. INIT_POLL_STAT_DRAIN and POST_MODE_STAT_DRAIN
+// never need the bypass (their _STAT decisions skip the drain when
+// length === 0).
 const g = createGraph<Esci2Ctx>("WELCOME", ESCI2_TIMEOUT_MS)
-  // Empty 0xa000 envelopes are "wait for body" pre-data signals on the
-  // ESC/I-2 wire EXCEPT in POSTSCAN_*_STAT_DRAIN — there, after our
-  // pure-read(0) for a length=0 STAT reply, the printer's empty 0xa000
-  // IS the drain-complete trigger and must reach the state for it to
-  // advance to FIN. INIT_POLL_STAT_DRAIN and POST_MODE_STAT_DRAIN never
-  // have length=0 (their _STAT decision skips drain when length===0),
-  // so the bypass is scoped to the two POSTSCAN drains where
-  // alwaysDrain=true forces a pure-read regardless of length.
-  .globalIgnoreFilter((packet, currentState) => {
-    if (currentState === "POSTSCAN_1_STAT_DRAIN" || currentState === "POSTSCAN_2_STAT_DRAIN") {
-      return false;
-    }
-    return packet.type === 0xa000 && packet.payload.length === 0;
-  })
+  .globalIgnoreFilter((packet) => packet.type === 0xa000 && packet.payload.length === 0)
   // 0x9000 is the protocol-level async event channel: fatal/cancel
   // payloads abort the session regardless of state; ScanStart/Stop and
   // unknown bytes are info-only (return null to ignore).
@@ -160,47 +135,55 @@ const g = createGraph<Esci2Ctx>("WELCOME", ESCI2_TIMEOUT_MS)
 
 // WELCOME: 0x8000 from printer → host sends LOCK → LOCKING
 // Replaces the T21 placeholder.
-awaitAck(g, "WELCOME", 0x8000, "LOCKING", buildLockPacket());
+awaitReply(g, "WELCOME", 0x8000, () => true, "LOCKING", buildLockPacket());
 
 // LOCKING: 0xa100 lock-ack (payload[0] === 0x06) → send FS Y → INIT1_FS_Y
-awaitAck(
+awaitReply(
   g,
   "LOCKING",
   0xa100,
+  ackByte(0x06),
   "INIT1_FS_Y",
   buildPassthruPacket(buildFsY(), LEGACY_REPLY_SIZE),
-  0x06,
 );
 
 // INIT1_FS_Y: 0xa000 FS-Y-ack (1-byte 0x06) → send INFO META command → INIT1_INFO_META
-awaitAck(
+awaitReply(
   g,
   "INIT1_FS_Y",
   0xa000,
+  ackByte(0x06),
   "INIT1_INFO_META",
   buildPassthruPacket(buildEsci2Command("INFO"), ESCI2_REPLY_SIZE),
-  0x06,
 );
 
 // INIT1_FIN: 0xa000 FIN-ack → send FS Z → INIT2_FS_Z
 // (No ack-byte check here — FIN reply is a 64-byte envelope, not a 1-byte ACK.)
-awaitAck(g, "INIT1_FIN", 0xa000, "INIT2_FS_Z", buildPassthruPacket(buildFsZ(), LEGACY_REPLY_SIZE));
+awaitReply(
+  g,
+  "INIT1_FIN",
+  0xa000,
+  () => true,
+  "INIT2_FS_Z",
+  buildPassthruPacket(buildFsZ(), LEGACY_REPLY_SIZE),
+);
 
 // INIT2_FS_Z: 0xa000 FS-Z-ack (1-byte 0x06) → send INFO META command → INIT2_INFO_META
-awaitAck(
+awaitReply(
   g,
   "INIT2_FS_Z",
   0xa000,
+  ackByte(0x06),
   "INIT2_INFO_META",
   buildPassthruPacket(buildEsci2Command("INFO"), ESCI2_REPLY_SIZE),
-  0x06,
 );
 
 // INIT2_FIN: 0xa000 FIN-ack → reset initPollIteration, send FS Y → INIT_POLL_FS_Y.
-awaitAck(
+awaitReply(
   g,
   "INIT2_FIN",
   0xa000,
+  () => true,
   "INIT_POLL_FS_Y",
   buildPassthruPacket(buildFsY(), LEGACY_REPLY_SIZE),
 );
@@ -369,6 +352,13 @@ function statThenDrain(
         send: buildPassthruPacket(buildEsci2Command("FIN"), ESCI2_REPLY_SIZE),
       },
     },
+    // POSTSCAN drains run with `alwaysDrain=true` and the printer can
+    // reply length=0 — the empty 0xa000 IS the drain-complete trigger
+    // here, so opt this state out of `globalIgnoreFilter`. The
+    // POST_MODE / INIT_POLL drains never reach with length=0 (their
+    // _STAT decisions skip the drain entirely in that case), so the
+    // bypass is scoped to alwaysDrain cycles only.
+    ...(alwaysDrain ? { bypassIgnoreFilter: true as const } : {}),
   });
 
   g.state(`${prefix}_FIN`, {

--- a/src/esci2/scanner.ts
+++ b/src/esci2/scanner.ts
@@ -3,12 +3,13 @@ import fs from "node:fs";
 import os from "node:os";
 import {
   runScanSession,
+  socketAsTransport,
   type SessionTransport,
   type SessionTransportFactory,
 } from "../scan-session.js";
 import { resolveSessionTimestamp } from "../output.js";
 import { esci2Graph, type Esci2Ctx } from "./graph.js";
-import { socketAsTransport, withEsci2UnlockOnDestroy, withTlsErrorLabels } from "./transport.js";
+import { withEsci2UnlockOnDestroy, withTlsErrorLabels } from "./transport.js";
 import type { PaperlessUploadOptions } from "../paperless-upload.js";
 
 export interface ScanSession {

--- a/src/esci2/scanner.ts
+++ b/src/esci2/scanner.ts
@@ -8,7 +8,7 @@ import {
 } from "../scan-session.js";
 import { resolveSessionTimestamp } from "../output.js";
 import { esci2Graph, type Esci2Ctx } from "./graph.js";
-import { withEsci2UnlockOnDestroy } from "./transport.js";
+import { socketAsTransport, withEsci2UnlockOnDestroy, withTlsErrorLabels } from "./transport.js";
 import type { PaperlessUploadOptions } from "../paperless-upload.js";
 
 export interface ScanSession {
@@ -70,7 +70,13 @@ function makeTlsTransportFactory(
             return;
           }
         }
-        resolve(withEsci2UnlockOnDestroy(socket));
+        // Composition order matters: the unlock wrapper is OUTER so its
+        // destroy-time `inner.end(buildUnlockPacket())` flows through the
+        // TLS-error wrapper's `end(data?)`, setting that wrapper's
+        // `endCalled = true` before the bytes leave the host. Without that
+        // ordering, a printer-side RST during the close handshake could
+        // surface as a labelled error instead of being swallowed.
+        resolve(withEsci2UnlockOnDestroy(withTlsErrorLabels(socketAsTransport(socket))));
       });
       socket.once("error", reject);
     });

--- a/src/esci2/transport.test.ts
+++ b/src/esci2/transport.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import type * as tls from "node:tls";
-import { withEsci2UnlockOnDestroy } from "./transport.js";
+import type { SessionTransport } from "../scan-session.js";
+import { withEsci2UnlockOnDestroy, withTlsErrorLabels } from "./transport.js";
 import { IS_HEADER_SIZE } from "../protocol.js";
 
 describe("withEsci2UnlockOnDestroy wrapper", () => {
@@ -15,16 +15,16 @@ describe("withEsci2UnlockOnDestroy wrapper", () => {
   const lockPacket = () => makeIsTypeStub(0x00);
   const unlockPacket = () => makeIsTypeStub(0x01);
 
-  // Stub socket: records end()/destroy() invocations without actually
-  // doing TLS / network work. Just enough surface for the wrapper.
-  function makeStubSocket() {
+  // Stub transport: records end()/destroy() invocations without doing any
+  // real network work. Just enough surface for the wrapper.
+  function makeStubTransport() {
     const calls: { end: number; destroy: number; endData: Buffer | null } = {
       end: 0,
       destroy: 0,
       endData: null,
     };
     const writes: Buffer[] = [];
-    const stub = {
+    const stub: SessionTransport = {
       write(buf: Buffer) {
         writes.push(buf);
         return true;
@@ -36,11 +36,11 @@ describe("withEsci2UnlockOnDestroy wrapper", () => {
       destroy(_err?: Error) {
         calls.destroy += 1;
       },
-      on(_event: string, _cb: (...args: unknown[]) => void) {
+      on() {
         return stub;
       },
-    } as unknown as tls.TLSSocket;
-    return { socket: stub, calls, writes };
+    };
+    return { transport: stub, calls, writes };
   }
 
   it("destroy() is a no-op after end() — preserves graceful TLS close_notify", () => {
@@ -48,8 +48,8 @@ describe("withEsci2UnlockOnDestroy wrapper", () => {
     // (FIN), then settle → transport.destroy(). The wrapper must NOT
     // RST the socket on the second call, or TLS close_notify never
     // lands and the printer sees an unclean disconnect.
-    const { socket, calls } = makeStubSocket();
-    const wrapped = withEsci2UnlockOnDestroy(socket);
+    const { transport, calls } = makeStubTransport();
+    const wrapped = withEsci2UnlockOnDestroy(transport);
     wrapped.end();
     expect(calls.end).toBe(1);
     wrapped.destroy();
@@ -57,8 +57,8 @@ describe("withEsci2UnlockOnDestroy wrapper", () => {
   });
 
   it("destroy() force-closes when LOCK was never sent (true error path, pre-LOCK)", () => {
-    const { socket, calls } = makeStubSocket();
-    const wrapped = withEsci2UnlockOnDestroy(socket);
+    const { transport, calls } = makeStubTransport();
+    const wrapped = withEsci2UnlockOnDestroy(transport);
     wrapped.destroy();
     expect(calls.destroy).toBe(1);
     expect(calls.end).toBe(0);
@@ -71,8 +71,8 @@ describe("withEsci2UnlockOnDestroy wrapper", () => {
     // TCP close preserves close_notify timing for the printer's
     // panel hygiene; a hard destroy reintroduces the panel errors
     // the wrapper is meant to prevent.
-    const { socket, calls } = makeStubSocket();
-    const wrapped = withEsci2UnlockOnDestroy(socket);
+    const { transport, calls } = makeStubTransport();
+    const wrapped = withEsci2UnlockOnDestroy(transport);
     wrapped.write(lockPacket());
     wrapped.write(unlockPacket());
     wrapped.destroy();
@@ -84,8 +84,8 @@ describe("withEsci2UnlockOnDestroy wrapper", () => {
   it("destroy() sends UNLOCK via end(unlock) when LOCK was sent but UNLOCK wasn't", () => {
     // Engine errored mid-session after LOCK landed; wrapper sends the
     // UNLOCK record before half-closing.
-    const { socket, calls } = makeStubSocket();
-    const wrapped = withEsci2UnlockOnDestroy(socket);
+    const { transport, calls } = makeStubTransport();
+    const wrapped = withEsci2UnlockOnDestroy(transport);
     wrapped.write(lockPacket());
     wrapped.destroy();
     expect(calls.destroy).toBe(0);
@@ -93,5 +93,153 @@ describe("withEsci2UnlockOnDestroy wrapper", () => {
     expect(calls.endData).not.toBeNull();
     expect(calls.endData?.[2]).toBe(0x21);
     expect(calls.endData?.[3]).toBe(0x01);
+  });
+});
+
+describe("withTlsErrorLabels wrapper", () => {
+  /**
+   * Stub inner transport whose `error`-listener we can fire on demand.
+   * Records writes / end / destroy so we can assert forwarding.
+   */
+  function makeStubTransport() {
+    const calls: { end: number; destroy: number; endData: Buffer | null } = {
+      end: 0,
+      destroy: 0,
+      endData: null,
+    };
+    let errorListener: ((...args: unknown[]) => void) | null = null;
+    const stub: SessionTransport = {
+      write() {
+        return true;
+      },
+      end(data?: Buffer) {
+        calls.end += 1;
+        if (data) calls.endData = data;
+      },
+      destroy(_err?: Error) {
+        calls.destroy += 1;
+      },
+      on(event: string, cb: (...args: unknown[]) => void) {
+        if (event === "error") errorListener = cb;
+        return stub;
+      },
+    };
+    return {
+      transport: stub,
+      calls,
+      fireError(err: Error & { code?: string }) {
+        errorListener?.(err);
+      },
+    };
+  }
+
+  it("labels mid-session error messages with 'TLS connection error: <msg>'", () => {
+    const { transport, fireError } = makeStubTransport();
+    const wrapped = withTlsErrorLabels(transport);
+    const seen: Error[] = [];
+    wrapped.on("error", (err) => seen.push(err));
+    fireError(new Error("EHOSTUNREACH"));
+    expect(seen).toHaveLength(1);
+    expect(seen[0].message).toBe("TLS connection error: EHOSTUNREACH");
+  });
+
+  it("swallows ECONNRESET / EPIPE after end() so a healthy DONE doesn't surface a benign post-FIN reset", () => {
+    const { transport, fireError } = makeStubTransport();
+    const wrapped = withTlsErrorLabels(transport);
+    const seen: Error[] = [];
+    wrapped.on("error", (err) => seen.push(err));
+    wrapped.end();
+    const reset = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    const epipe = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+    fireError(reset);
+    fireError(epipe);
+    expect(seen).toHaveLength(0);
+  });
+
+  it("forwards end(data?) to inner — the unlock wrapper composes via end(data)", () => {
+    const { transport, calls } = makeStubTransport();
+    const wrapped = withTlsErrorLabels(transport);
+    const payload = Buffer.from([0xab, 0xcd]);
+    wrapped.end(payload);
+    expect(calls.end).toBe(1);
+    expect(calls.endData?.equals(payload)).toBe(true);
+  });
+
+  it("non-end-related errors after end() still forward (only ECONNRESET / EPIPE are benign)", () => {
+    const { transport, fireError } = makeStubTransport();
+    const wrapped = withTlsErrorLabels(transport);
+    const seen: Error[] = [];
+    wrapped.on("error", (err) => seen.push(err));
+    wrapped.end();
+    fireError(Object.assign(new Error("EACCES"), { code: "EACCES" }));
+    expect(seen).toHaveLength(1);
+    expect(seen[0].message).toBe("TLS connection error: EACCES");
+  });
+});
+
+describe("withEsci2UnlockOnDestroy ∘ withTlsErrorLabels composition", () => {
+  /**
+   * Stub the leaf with both `end` capture (for unlock-on-abort assertions)
+   * and an `error` listener slot (so we can assert error labels propagate
+   * across the two layers).
+   */
+  function makeStubLeaf() {
+    const calls: { end: number; destroy: number; endData: Buffer | null } = {
+      end: 0,
+      destroy: 0,
+      endData: null,
+    };
+    let errorListener: ((...args: unknown[]) => void) | null = null;
+    const stub: SessionTransport = {
+      write() {
+        return true;
+      },
+      end(data?: Buffer) {
+        calls.end += 1;
+        if (data) calls.endData = data;
+      },
+      destroy() {
+        calls.destroy += 1;
+      },
+      on(event: string, cb: (...args: unknown[]) => void) {
+        if (event === "error") errorListener = cb;
+        return stub;
+      },
+    };
+    return {
+      leaf: stub,
+      calls,
+      fireError(err: Error & { code?: string }) {
+        errorListener?.(err);
+      },
+    };
+  }
+
+  it("destroy() after mid-session LOCK still sends UNLOCK via the labeled wrapper's end(data)", () => {
+    const { leaf, calls } = makeStubLeaf();
+    const wrapped = withEsci2UnlockOnDestroy(withTlsErrorLabels(leaf));
+    // Write a LOCK packet (IS type 0x2100) through the outer.
+    const lock = Buffer.alloc(IS_HEADER_SIZE);
+    lock[2] = 0x21;
+    lock[3] = 0x00;
+    wrapped.write(lock);
+    // Destroy mid-session: outer routes through inner.end(unlockPacket).
+    wrapped.destroy();
+    expect(calls.destroy).toBe(0);
+    expect(calls.end).toBe(1);
+    expect(calls.endData?.[2]).toBe(0x21);
+    expect(calls.endData?.[3]).toBe(0x01);
+  });
+
+  it("post-end ECONNRESET on the leaf is suppressed at the outer error listener", () => {
+    const { leaf, fireError } = makeStubLeaf();
+    const wrapped = withEsci2UnlockOnDestroy(withTlsErrorLabels(leaf));
+    const seen: Error[] = [];
+    wrapped.on("error", (err) => seen.push(err));
+    // Polite close (engine reached DONE) — flows through both wrappers.
+    wrapped.end();
+    // Printer RSTs after our FIN — TLS-labels swallows.
+    fireError(Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }));
+    expect(seen).toHaveLength(0);
   });
 });

--- a/src/esci2/transport.ts
+++ b/src/esci2/transport.ts
@@ -1,19 +1,5 @@
-import type net from "node:net";
-import type tls from "node:tls";
 import type { SessionTransport } from "../scan-session.js";
 import { buildUnlockPacket } from "../protocol.js";
-
-/**
- * Bridges a raw Node socket (`net.Socket` / `tls.TLSSocket`) onto the
- * engine's `SessionTransport` interface. Both socket types already
- * structurally implement `write` / `end(data?)` / `destroy(err?)` / `on`,
- * so the cast is safe; the named function makes the boundary explicit and
- * gives the wrappers below a single place to reason about "this is the
- * raw-socket leaf of the transport stack."
- */
-export function socketAsTransport(socket: net.Socket | tls.TLSSocket): SessionTransport {
-  return socket as unknown as SessionTransport;
-}
 
 /**
  * Adds TLS-flavoured error handling on top of any `SessionTransport`:

--- a/src/esci2/transport.ts
+++ b/src/esci2/transport.ts
@@ -1,72 +1,125 @@
+import type net from "node:net";
 import type tls from "node:tls";
 import type { SessionTransport } from "../scan-session.js";
 import { buildUnlockPacket } from "../protocol.js";
 
 /**
- * Wraps a `tls.TLSSocket` into a `SessionTransport` with three protocol-
- * aware concerns the generic engine doesn't know about:
- *
- * 1. **Unlock on abort.** If the engine destroys the transport mid-session
- *    (after LOCK was sent but before the graph reached UNLOCKING),
- *    politely send the UNLOCK packet via `socket.end(unlock)` so the bytes
- *    actually leave the host before the socket closes — `socket.destroy()`
- *    can otherwise discard queued writes or send a TCP reset.
- *
- * 2. **TLS-error wrapping.** Bare ECONNRESET / EPIPE / etc. surfaces as
- *    "TLS connection error: <msg>" so operators (and tests) get a
- *    recognisable category.
- *
- * 3. **Suppress benign post-end errors.** Once the engine has called
- *    `transport.end()` (which only happens on entering DONE), the printer
- *    may still RST or EPIPE before its FIN reaches the host. Forwarding
- *    that to the engine would turn a successful scan into a rejection.
- *    The wrapper swallows those benign codes after end() has been called.
- *
- * Lives in its own module rather than in the scanner orchestration shell
- * so the protocol-aware close-timing logic doesn't bleed into either the
- * generic engine or the tiny shell. A future ESC/I-2-over-non-TLS
- * adapter (issue #43, ET-2750 hypothesis) gets a sibling factory in
- * scanner.ts and reuses this same wrapper unchanged.
+ * Bridges a raw Node socket (`net.Socket` / `tls.TLSSocket`) onto the
+ * engine's `SessionTransport` interface. Both socket types already
+ * structurally implement `write` / `end(data?)` / `destroy(err?)` / `on`,
+ * so the cast is safe; the named function makes the boundary explicit and
+ * gives the wrappers below a single place to reason about "this is the
+ * raw-socket leaf of the transport stack."
  */
-export function withEsci2UnlockOnDestroy(socket: tls.TLSSocket): SessionTransport {
+export function socketAsTransport(socket: net.Socket | tls.TLSSocket): SessionTransport {
+  return socket as unknown as SessionTransport;
+}
+
+/**
+ * Adds TLS-flavoured error handling on top of any `SessionTransport`:
+ *
+ * 1. **Mid-session error labelling.** Bare `ECONNRESET` / `EPIPE` / etc on
+ *    the inner transport surfaces to the engine as
+ *    `"TLS connection error: <msg>"` so operators (and tests) get a
+ *    recognisable category. Handshake errors are caught by the factory's
+ *    `socket.once("error", reject)` and never reach this wrapper, so the
+ *    label only ever appears mid-session.
+ *
+ * 2. **Suppress benign post-`end()` resets.** Once `end()` has been called
+ *    (engine entered DONE), the printer may still RST or EPIPE before its
+ *    FIN reaches the host. Forwarding that would turn a successful scan
+ *    into a rejection. The wrapper swallows those benign codes after
+ *    `end()` has been called.
+ *
+ * Composes inside `withEsci2UnlockOnDestroy`; the outer unlock wrapper
+ * coordinates destroy semantics, this layer just tracks whether `end()`
+ * was reached so the post-end RST swallow is correct.
+ */
+export function withTlsErrorLabels(inner: SessionTransport): SessionTransport {
+  let endCalled = false;
+  const wrapped: SessionTransport = {
+    write(buf: Buffer) {
+      return inner.write(buf);
+    },
+    end: (data?: Buffer) => {
+      endCalled = true;
+      inner.end(data);
+    },
+    destroy(err?: Error) {
+      inner.destroy(err);
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    on(event: string, cb: (...args: any[]) => void) {
+      if (event === "error") {
+        inner.on("error", (err: Error & { code?: string }) => {
+          if (endCalled && (err.code === "ECONNRESET" || err.code === "EPIPE")) {
+            return;
+          }
+          cb(new Error(`TLS connection error: ${err.message}`));
+        });
+      } else if (event === "data") {
+        inner.on("data", cb as (chunk: Buffer) => void);
+      } else if (event === "close") {
+        inner.on("close", cb as (hadError?: boolean) => void);
+      }
+      return wrapped;
+    },
+  };
+  return wrapped;
+}
+
+/**
+ * Wraps any `SessionTransport` (TLS or plain TCP) with ESC/I-2-protocol-
+ * aware destroy-time semantics:
+ *
+ * 1. **Track LOCK / UNLOCK on the wire.** Sniffs writes by IS type byte
+ *    (header bytes 2-3): `0x21 0x00` = LOCK, `0x21 0x01` = UNLOCK.
+ *
+ * 2. **Unlock-on-abort.** If the engine destroys the transport mid-session
+ *    (after LOCK was sent but before UNLOCK), politely send the UNLOCK
+ *    packet via `inner.end(unlock)` so the bytes leave before the socket
+ *    closes — a bare `destroy()` could discard queued writes or send a
+ *    TCP reset.
+ *
+ * 3. **Polite-close gate.** When `end()` has already been called (engine
+ *    reached DONE), a follow-up `destroy()` is a no-op so it doesn't RST
+ *    the connection mid-TLS-`close_notify` and cancel the FIN we politely
+ *    queued. The engine's `settle()` always calls `destroy()`; this gate
+ *    is what makes that contract safe.
+ *
+ * Transport-blind: works equally well over TLS (composed with
+ * `withTlsErrorLabels`) and plain TCP (composed alone). The optional
+ * `data` argument on `inner.end()` is the reason `SessionTransport.end`
+ * accepts a buffer — `inner.end(buildUnlockPacket())` flows the bytes
+ * through the lower layer's flush before the FIN.
+ */
+export function withEsci2UnlockOnDestroy(inner: SessionTransport): SessionTransport {
   let unlockSent = false;
   let lockSent = false;
-  // Tracks any teardown so post-close ECONNRESET / EPIPE noise can be
-  // swallowed. Set by both end() and destroy().
-  let endCalled = false;
-  // Tracks specifically whether we already initiated a graceful close
-  // via end(). The engine calls transport.destroy() from settle even on
-  // healthy DONE (after end()), and a socket.destroy() there would RST
-  // the connection mid-TLS-close_notify and cancel the FIN we politely
-  // queued — reintroducing timing-dependent panel errors. When this is
-  // true, destroy() is a no-op and the graceful close completes on its
-  // own clock.
   let politelyClosed = false;
   const wrapped: SessionTransport = {
     write(buf: Buffer) {
-      // Track LOCK / UNLOCK sends by IS type byte (header byte 2-3).
+      // Track LOCK / UNLOCK sends by IS type byte (header bytes 2-3).
       if (buf.length >= 4 && buf[2] === 0x21) {
         if (buf[3] === 0x00) lockSent = true;
         if (buf[3] === 0x01) unlockSent = true;
       }
-      return socket.write(buf);
+      return inner.write(buf);
     },
-    end: () => {
-      endCalled = true;
+    end: (data?: Buffer) => {
       politelyClosed = true;
-      socket.end();
+      inner.end(data);
     },
     destroy(err?: Error) {
       if (politelyClosed) return;
-      endCalled = true;
       if (lockSent && !unlockSent) {
-        // Mid-session error: send unlock then half-close, so the bytes
+        // Mid-session error: send UNLOCK then half-close, so the bytes
         // actually leave the host. Plain `write` + immediate `destroy`
         // can discard queued bytes or send TCP RST.
         try {
-          socket.end(buildUnlockPacket());
+          inner.end(buildUnlockPacket());
         } catch {
-          socket.destroy(err);
+          inner.destroy(err);
         }
       } else if (lockSent && unlockSent) {
         // Cleanup-state error after UNLOCK was already on the wire
@@ -76,31 +129,26 @@ export function withEsci2UnlockOnDestroy(socket: tls.TLSSocket): SessionTranspor
         // preserves close_notify timing, which the legacy scanner
         // relied on for panel hygiene.
         try {
-          socket.end();
+          inner.end();
         } catch {
-          socket.destroy(err);
+          inner.destroy(err);
         }
       } else {
         // Never locked — straight destroy is fine, no protocol state
         // to preserve.
-        socket.destroy(err);
+        inner.destroy(err);
       }
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     on(event: string, cb: (...args: any[]) => void) {
-      if (event === "error") {
-        socket.on(event, (err: Error & { code?: string }) => {
-          // Suppress benign post-end resets so a printer that closes the
-          // connection between our FIN and its FIN doesn't fail an
-          // otherwise-successful scan. Mirrors the pre-engine scanner's
-          // post-DONE error tolerance.
-          if (endCalled && (err.code === "ECONNRESET" || err.code === "EPIPE")) {
-            return;
-          }
-          cb(new Error(`TLS connection error: ${err.message}`));
-        });
-      } else {
-        socket.on(event, cb);
+      // SessionTransport.on is overloaded per event; dispatch by event so
+      // each branch hits the matching overload signature.
+      if (event === "data") {
+        inner.on("data", cb as (chunk: Buffer) => void);
+      } else if (event === "error") {
+        inner.on("error", cb as (err: Error) => void);
+      } else if (event === "close") {
+        inner.on("close", cb as (hadError?: boolean) => void);
       }
       return wrapped;
     },

--- a/src/graph-helpers.ts
+++ b/src/graph-helpers.ts
@@ -1,0 +1,72 @@
+// src/graph-helpers.ts
+//
+// Shared graph-state helpers used by both `src/esci2/graph.ts` and
+// `src/esci/graph.ts`. The two graphs mostly diverge on protocol-specific
+// vocabulary (commands, packet semantics, page-end detection); this module
+// captures the small handful of patterns that are byte-identical between
+// them, so editing one no longer means remembering to mirror the change in
+// the other.
+
+/**
+ * Decision-state guard: ensure the incoming packet's IS type matches what
+ * this state expects. Returns an `error` TransitionResult on mismatch (the
+ * engine routes it through the standard failure path); returns null to
+ * continue.
+ *
+ * Static states already fail fast on unmatched packet types via the engine's
+ * dispatch table; decision states see every packet that wasn't filtered or
+ * preempted by a global abort handler, so they need their own type guard
+ * to avoid acting on the wrong wire data.
+ */
+export function expectIsType(
+  packet: { type: number },
+  expected: number,
+  stateName: string,
+): { error: Error } | null {
+  if (packet.type !== expected) {
+    return {
+      error: new Error(
+        `${stateName}: expected packet type 0x${expected.toString(16).padStart(4, "0")}, got 0x${packet.type.toString(16).padStart(4, "0")}`,
+      ),
+    };
+  }
+  return null;
+}
+
+/**
+ * Decision-state guard for length-checked replies. Companion to
+ * `expectIsType`. Returns an `error` TransitionResult on length mismatch
+ * so the engine routes through the standard failure path; null to continue.
+ *
+ * `label` is included in the error message to disambiguate replies that
+ * share an IS type but carry different payload sizes (e.g. ESC/I returns
+ * 1-byte ACKs, 14-byte FS G replies, 16-byte FS F status, and 80-byte FS I
+ * identity all under the same `0xa000` envelope).
+ */
+export function expectLength(
+  payload: Buffer,
+  expected: number,
+  stateName: string,
+  label: string,
+): { error: Error } | null {
+  if (payload.length !== expected) {
+    return {
+      error: new Error(`${stateName}: expected ${expected}-byte ${label}, got ${payload.length}`),
+    };
+  }
+  return null;
+}
+
+/**
+ * Static-transition payload validator: the reply's first byte must equal
+ * `b`. Use as the `validate` field on an `awaitReply`-style helper to
+ * encode the "reply is a single ACK byte" pattern that recurs throughout
+ * both ESC/I-2's pre-extended-mode handshake and ESC/I's per-command
+ * passthru replies.
+ *
+ *   awaitReply(g, "LOCKING", 0xa100, ackByte(0x06), "INIT", lockResponse);
+ */
+export const ackByte =
+  (b: number) =>
+  (payload: Buffer): boolean =>
+    payload[0] === b;

--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -743,22 +743,23 @@ describe("runScanSession (engine pump)", () => {
     expect(infoSeen).toBe(true);
   });
 
-  it("passes currentState to globalIgnoreFilter so it can scope itself per state", async () => {
-    // The filter bypasses itself in state DRAIN (drain-complete reply
-    // has the same wire shape as the wait-for-body signal in WAIT). The
-    // engine must thread currentState through, otherwise the filter
-    // can't distinguish and either over- or under-filters.
+  it("respects per-state bypassIgnoreFilter — opted-in states see filtered shapes unfiltered", async () => {
+    // The filter would normally discard empty 0xa000 packets (ESC/I-2's
+    // wait-for-body signal). The DRAIN state opts out via
+    // `bypassIgnoreFilter: true` because there, the empty 0xa000 IS the
+    // drain-complete trigger and must reach the state's transition table.
+    // The filter itself stays state-blind — a one-line shape predicate.
     const transport = new FakeTransport();
-    const observed: { state: string; payloadLen: number }[] = [];
-    const g = createGraph<Record<string, never>>("WAIT", 1_000).globalIgnoreFilter(
-      (packet, currentState) => {
-        observed.push({ state: currentState, payloadLen: packet.payload.length });
-        if (currentState === "DRAIN") return false;
-        return packet.type === 0xa000 && packet.payload.length === 0;
-      },
-    );
+    const filterCalls: number[] = [];
+    const g = createGraph<Record<string, never>>("WAIT", 1_000).globalIgnoreFilter((packet) => {
+      filterCalls.push(packet.payload.length);
+      return packet.type === 0xa000 && packet.payload.length === 0;
+    });
     g.state("WAIT", { on: { 0xa000: { next: "DRAIN" } } });
-    g.state("DRAIN", { on: { 0xa000: { next: "DONE" } } });
+    g.state("DRAIN", {
+      on: { 0xa000: { next: "DONE" } },
+      bypassIgnoreFilter: true,
+    });
 
     const promise = runScanSession({
       graph: g.build(),
@@ -774,17 +775,16 @@ describe("runScanSession (engine pump)", () => {
     setImmediate(() => {
       // First packet (non-empty in WAIT) → not filtered, advances to DRAIN.
       transport.emit("data", buildIsPacket(0xa000, Buffer.from([0xab])));
-      // Second packet (empty in DRAIN) — filter bypasses itself, advances to DONE.
+      // Second packet (empty 0xa000 in DRAIN) — filter is bypassed, packet
+      // reaches the DRAIN transition table and advances to DONE.
       setImmediate(() => transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0))));
     });
 
     const result = await promise;
     expect(result.ok).toBe(true);
-    // Filter saw both packets with their respective states.
-    expect(observed).toEqual([
-      { state: "WAIT", payloadLen: 1 },
-      { state: "DRAIN", payloadLen: 0 },
-    ]);
+    // Filter ran exactly once (in WAIT). It was bypassed entirely in DRAIN —
+    // so the empty packet's length never made it to filterCalls.
+    expect(filterCalls).toEqual([1]);
   });
 
   it("silently discards packets matched by globalIgnoreFilter", async () => {
@@ -1330,6 +1330,80 @@ describe("runScanSession (engine pump)", () => {
     expect(transport.destroyCallCount).toBeGreaterThanOrEqual(1);
 
     fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // 2e: IS payloadSize sanity-cap. A wild value in the size field is
+  // almost always framing desync — surface a clear diagnostic instead
+  // of waiting 30s for the timeout.
+  it("rejects with a framing-desync diagnostic when an IS header declares a payload larger than the cap", async () => {
+    const transport = new FakeTransport();
+    const g = createGraph<Record<string, never>>("WAITING", 1_000);
+    g.state("WAITING", { on: { 0xa000: { next: "DONE" } } });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    // Hand-craft a full 12-byte IS header whose 4-byte size field
+    // declares 64 MB (well above the 32 MB default cap). Magic + type
+    // are valid so the initial-magic check passes; only the cap check
+    // should fail.
+    const desync = Buffer.alloc(12);
+    desync[0] = 0x49; // 'I'
+    desync[1] = 0x53; // 'S'
+    desync.writeUInt16BE(0xa000, 2);
+    desync.writeUInt32BE(64 * 1024 * 1024, 6);
+    setImmediate(() => transport.emit("data", desync));
+
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason.message).toMatch(/IS payload claims/);
+      expect(result.reason.message).toMatch(/exceeds 32MB cap/);
+      expect(result.reason.message).toMatch(/framing desync in state WAITING/);
+      // Hex prefix of the desync header is included for triage.
+      expect(result.reason.message).toMatch(/4953a000.*04000000/);
+    }
+  });
+
+  it("custom maxPayloadBytes on the graph overrides the default cap", async () => {
+    const transport = new FakeTransport();
+    const g = createGraph<Record<string, never>>("WAITING", 1_000);
+    g.state("WAITING", { on: { 0xa000: { next: "DONE" } } });
+    const built = g.build();
+    // Override the cap to 1 KB — anything larger should trip immediately.
+    const tightGraph = { ...built, maxPayloadBytes: 1024 };
+
+    const promise = runScanSession({
+      graph: tightGraph,
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir: "/tmp",
+      tempDir: "/tmp",
+      sessionTs: new Date(),
+      action: "jpg",
+      allowZeroPages: true,
+    });
+
+    const desync = Buffer.alloc(12);
+    desync[0] = 0x49;
+    desync[1] = 0x53;
+    desync.writeUInt16BE(0xa000, 2);
+    desync.writeUInt32BE(2048, 6); // 2 KB > 1 KB cap
+    setImmediate(() => transport.emit("data", desync));
+
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason.message).toMatch(/IS payload claims 2048 bytes/);
+    }
   });
 
   it("settles cleanly when 'error' arrives during a flushPage barrier", async () => {

--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -1351,14 +1351,10 @@ describe("runScanSession (engine pump)", () => {
       allowZeroPages: true,
     });
 
-    // Hand-craft a full 12-byte IS header whose 4-byte size field
-    // declares 64 MB (well above the 32 MB default cap). Magic + type
-    // are valid so the initial-magic check passes; only the cap check
-    // should fail.
-    const desync = Buffer.alloc(12);
-    desync[0] = 0x49; // 'I'
-    desync[1] = 0x53; // 'S'
-    desync.writeUInt16BE(0xa000, 2);
+    // Build a valid IS header, then mutate the 4-byte size field at
+    // offset 6 to declare 64 MB (well above the 32 MB default cap).
+    // Magic + type pass the initial check; only the cap trips.
+    const desync = buildIsPacket(0xa000);
     desync.writeUInt32BE(64 * 1024 * 1024, 6);
     setImmediate(() => transport.emit("data", desync));
 
@@ -1392,10 +1388,7 @@ describe("runScanSession (engine pump)", () => {
       allowZeroPages: true,
     });
 
-    const desync = Buffer.alloc(12);
-    desync[0] = 0x49;
-    desync[1] = 0x53;
-    desync.writeUInt16BE(0xa000, 2);
+    const desync = buildIsPacket(0xa000);
     desync.writeUInt32BE(2048, 6); // 2 KB > 1 KB cap
     setImmediate(() => transport.emit("data", desync));
 

--- a/src/scan-session.ts
+++ b/src/scan-session.ts
@@ -1,8 +1,10 @@
 // src/scan-session.ts
 
 import * as fs from "node:fs";
+import type * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
+import type * as tls from "node:tls";
 import { IS_HEADER_SIZE } from "./protocol.js";
 import type { PaperlessUploadOptions } from "./paperless-upload.js";
 
@@ -30,6 +32,21 @@ export interface SessionTransport {
   on(event: "data", cb: (chunk: Buffer) => void): this;
   on(event: "error", cb: (err: Error) => void): this;
   on(event: "close", cb: (hadError?: boolean) => void): this;
+}
+
+/**
+ * Bridges a raw Node socket (`net.Socket` / `tls.TLSSocket`) onto the
+ * engine's `SessionTransport` interface. Both socket types already
+ * structurally implement `write` / `end(data?)` / `destroy(err?)` / `on`,
+ * so the cast is safe; the named function makes the boundary explicit
+ * and gives wrapper modules a single place to reason about "this is the
+ * raw-socket leaf of the transport stack." Lives here (next to
+ * `SessionTransport`) rather than in any single protocol's transport
+ * module so neither protocol has to import across the boundary to
+ * reach it.
+ */
+export function socketAsTransport(socket: net.Socket | tls.TLSSocket): SessionTransport {
+  return socket as unknown as SessionTransport;
 }
 
 // =============================================================================

--- a/src/scan-session.ts
+++ b/src/scan-session.ts
@@ -14,8 +14,16 @@ export type SessionTransportFactory = () => Promise<SessionTransport>;
 
 export interface SessionTransport {
   write(buf: Buffer): boolean | void;
-  /** Polite close after normal completion. */
-  end(): void;
+  /**
+   * Polite close after normal completion. The optional `data` payload is
+   * written-then-half-closed in one call — `net.Socket.end(buf)` and
+   * `tls.TLSSocket.end(buf)` both accept this shape, so adapters that need
+   * to flush a final record (e.g. ESC/I-2's UNLOCK on destroy) can do so
+   * without a separate write+end pair that could be reordered after the
+   * FIN. The engine itself only ever calls `end()` with no argument (DONE
+   * entry); the parameter exists for adapter composition.
+   */
+  end(data?: Buffer): void;
   /** Fail-fast destroy for error paths. */
   destroy(err?: Error): void;
 
@@ -43,14 +51,15 @@ export interface Graph<Ctx> {
     (ctx: Ctx, packet: { type: number; payload: Buffer }) => Error | null
   >;
   /**
-   * Pre-dispatch packet filter — returns true to discard. Receives the
-   * current state name as a second arg so a filter can scope itself
-   * (e.g. ESC/I-2 filters empty 0xa000 as "wait for body" pre-data
-   * signals during image flow, but POSTSCAN_*_STAT_DRAIN treats the
-   * same wire shape as the drain-complete reply and bypasses the
-   * filter).
+   * Pre-dispatch packet filter — returns true to discard. Scoped via the
+   * per-state `bypassIgnoreFilter` flag below: graphs declare which states
+   * treat the otherwise-filtered shape as semantically meaningful (e.g.
+   * ESC/I-2 filters empty 0xa000 as a "wait for body" signal during image
+   * flow, but POSTSCAN_*_STAT_DRAIN reads the same wire shape as the
+   * drain-complete reply). The filter itself stays state-agnostic so it
+   * can be a one-line shape predicate.
    */
-  globalIgnoreFilter?: (packet: { type: number; payload: Buffer }, currentState: string) => boolean;
+  globalIgnoreFilter?: (packet: { type: number; payload: Buffer }) => boolean;
   /**
    * States in which a failure is treated as post-image cleanup and
    * recovered to success via the post-scan-save fallback (v0.3.0 §3.3) —
@@ -60,24 +69,68 @@ export interface Graph<Ctx> {
    * states (IMG_META, IMG_DATA, etc.) still reject the session even on
    * page 2 of N — partial multi-page output should not be silently
    * promoted as success.
+   *
+   * `DONE` is implicitly excluded from the fallback because it's reserved
+   * as the engine's terminal state and `g.state("DONE", ...)` throws — a
+   * failure can't reach DONE through the dispatch path. The combination
+   * of the reserved-name guard and the engine's `finalizeAttempted` gate
+   * also ensures a finalize failure inside `doFinalize` is not retried
+   * via this branch.
    */
   cleanupStates?: ReadonlySet<string>;
+  /**
+   * Upper bound on the `payloadSize` field of any IS frame the engine
+   * will accept. A value larger than this means we've lost framing
+   * synchronisation — a header byte landed at the wrong offset, or the
+   * peer is sending corrupt data — and waiting for `payloadSize` more
+   * bytes would manifest as a 30-second timeout-in-state instead of
+   * the genuine "framing desync" diagnostic.
+   *
+   * Default 32 MB. Real fixtures top out around 28 KB (ESC/I-2 IMG
+   * chunks); 32 MB is roughly 1000× that, so legitimate captures never
+   * approach it, but a wild size field (e.g. 0xFFFFFFFF from random
+   * bytes in the size slot) trips the check immediately. Override via
+   * the graph builder if a future protocol genuinely sends bigger
+   * payloads.
+   */
+  maxPayloadBytes?: number;
 }
+
+/**
+ * Default upper bound on IS payload size — see `Graph.maxPayloadBytes`.
+ * Exported for tests that need to assert the default applies to graphs
+ * which don't override it.
+ */
+export const DEFAULT_MAX_PAYLOAD_BYTES = 32 * 1024 * 1024;
 
 /** Single write spec — concrete bytes or a ctx-thunk resolved at dispatch time. */
 export type SendSpec<Ctx> = Buffer | ((ctx: Ctx) => Buffer);
 
-export type GraphState<Ctx> =
-  | {
-      kind: "static";
-      on: Record<number, StaticTransition<Ctx>>;
-      onEnter?: (ctx: Ctx) => Buffer | null;
-    }
-  | {
-      kind: "decision";
-      decide: DecisionFn<Ctx>;
-      onEnter?: (ctx: Ctx) => Buffer | null;
-    };
+/**
+ * Per-state flag that opts THIS state out of `Graph.globalIgnoreFilter` —
+ * the filter still fires on every other state, but packets that reach a
+ * state with `bypassIgnoreFilter: true` are dispatched to its handlers
+ * unfiltered. Used in ESC/I-2 to let POSTSCAN_*_STAT_DRAIN observe the
+ * empty-0xa000 packet that acts as the drain-complete trigger, without
+ * complicating the filter itself with state-name knowledge.
+ */
+export interface CommonStateProps {
+  bypassIgnoreFilter?: true;
+}
+
+export type GraphState<Ctx> = CommonStateProps &
+  (
+    | {
+        kind: "static";
+        on: Record<number, StaticTransition<Ctx>>;
+        onEnter?: (ctx: Ctx) => Buffer | null;
+      }
+    | {
+        kind: "decision";
+        decide: DecisionFn<Ctx>;
+        onEnter?: (ctx: Ctx) => Buffer | null;
+      }
+  );
 
 export interface StaticTransition<Ctx> {
   next: string;
@@ -138,9 +191,7 @@ export interface GraphBuilder<Ctx> {
     handlers: Record<number, (ctx: Ctx, packet: { type: number; payload: Buffer }) => Error | null>,
   ): this;
   /** Set the graph's pre-dispatch packet filter. */
-  globalIgnoreFilter(
-    filter: (packet: { type: number; payload: Buffer }, currentState: string) => boolean,
-  ): this;
+  globalIgnoreFilter(filter: (packet: { type: number; payload: Buffer }) => boolean): this;
   /**
    * Declare the post-image cleanup states. Failures in any of these
    * states are recovered to success via the post-scan-save fallback when
@@ -150,9 +201,11 @@ export interface GraphBuilder<Ctx> {
   build(): Graph<Ctx>;
 }
 
-export type StateDef<Ctx> =
-  | { on: Record<number, StaticTransition<Ctx>>; onEnter?: (ctx: Ctx) => Buffer | null }
-  | DecisionDef<Ctx>;
+export type StateDef<Ctx> = CommonStateProps &
+  (
+    | { on: Record<number, StaticTransition<Ctx>>; onEnter?: (ctx: Ctx) => Buffer | null }
+    | DecisionDef<Ctx>
+  );
 
 export interface DecisionDef<Ctx> {
   __decision: true;
@@ -173,10 +226,21 @@ export function createGraph<Ctx>(initial: string, timeoutMs: number): GraphBuild
         );
       }
       if (states[name]) throw new Error(`Duplicate state name: ${name}`);
+      const bypass = def.bypassIgnoreFilter;
       if ("__decision" in def) {
-        states[name] = { kind: "decision", decide: def.decide, onEnter: def.onEnter };
+        states[name] = {
+          kind: "decision",
+          decide: def.decide,
+          onEnter: def.onEnter,
+          ...(bypass ? { bypassIgnoreFilter: true } : {}),
+        };
       } else {
-        states[name] = { kind: "static", on: def.on, onEnter: def.onEnter };
+        states[name] = {
+          kind: "static",
+          on: def.on,
+          onEnter: def.onEnter,
+          ...(bypass ? { bypassIgnoreFilter: true } : {}),
+        };
       }
       return this;
     },
@@ -564,6 +628,24 @@ export async function runScanSession<Ctx>(
       }
       const type = head.readUInt16BE(2);
       const payloadSize = head.readUInt32BE(6);
+      const cap = graph.maxPayloadBytes ?? DEFAULT_MAX_PAYLOAD_BYTES;
+      if (payloadSize > cap) {
+        // Framing desync — almost certainly a header byte landed at the
+        // wrong offset and we read garbage as the size. Surface the
+        // diagnostic immediately so operators don't see a misleading
+        // "Timeout in state X" 30 seconds later. Captures the first 32
+        // bytes as hex so the report shows what we were looking at.
+        const peek = head.subarray(0, Math.min(32, head.length)).toString("hex");
+        const capMb = (cap / (1024 * 1024)).toFixed(0);
+        settle({
+          ok: false,
+          reason: new Error(
+            `IS payload claims ${payloadSize} bytes, exceeds ${capMb}MB cap — likely framing desync in state ${currentState}. First 32 bytes: ${peek}`,
+          ),
+          finalCtx: ctx,
+        });
+        return null;
+      }
       const totalSize = IS_HEADER_SIZE + payloadSize;
 
       if (recvBytes < totalSize) return null; // need more bytes
@@ -581,10 +663,16 @@ export async function runScanSession<Ctx>(
     async function dispatchPacket(packet: { type: number; payload: Buffer }): Promise<void> {
       // Step 1: globalIgnoreFilter — silently discard packets the protocol
       // wants to filter pre-dispatch (e.g. ESC/I-2 empty 0xa000 envelopes
-      // during image flow). The filter receives `currentState` so it can
-      // bypass itself in states where the otherwise-filtered shape is
-      // semantically meaningful (e.g. POSTSCAN_*_STAT_DRAIN).
-      if (graph.globalIgnoreFilter && graph.globalIgnoreFilter(packet, currentState)) {
+      // during image flow). States with `bypassIgnoreFilter: true` opt out
+      // — the otherwise-filtered shape is semantically meaningful for them
+      // (e.g. POSTSCAN_*_STAT_DRAIN reads the empty 0xa000 as the drain-
+      // complete reply), so the filter never runs there.
+      const state = graph.states[currentState];
+      if (
+        graph.globalIgnoreFilter &&
+        !state.bypassIgnoreFilter &&
+        graph.globalIgnoreFilter(packet)
+      ) {
         return;
       }
 
@@ -602,7 +690,6 @@ export async function runScanSession<Ctx>(
       }
 
       // Step 3: state-specific dispatch
-      const state = graph.states[currentState];
       if (state.kind === "static") {
         const transition = state.on[packet.type];
         if (!transition) {


### PR DESCRIPTION
## Summary

Bundle of mechanical cleanups surfaced by the post-M3 multi-reviewer audit. No public surface change — all edits are either invisible to users or doc/spec only. Replay-tested against the full Frida + pcap fixture matrix.

This is **PR 2 of 3** in the v0.4.0 follow-up sequence (PR 1 = #51, settlement lifecycle hardening, merged). PR 3 will land ET-2750 enablement (\`esci2-plain\` variant + auto-probe) on top of these cleanups.

### What changes

- **2a — Transport adapter split.** \`withEsci2UnlockOnDestroy\` was bundling three concerns (unlock-on-abort, TLS-error labelling, post-end RST swallow). Split into two \`SessionTransport→SessionTransport\` adapters that compose by nesting: \`withTlsErrorLabels\` (TLS-only) and \`withEsci2UnlockOnDestroy\` (transport-blind). Composition order \`withEsci2UnlockOnDestroy(withTlsErrorLabels(socketAsTransport(socket)))\` is locked at the resolve site so the unlock wrapper's destroy-time \`end(unlock)\` flows through the TLS-error wrapper's \`end(data?)\`. \`SessionTransport.end\` widens to \`end(data?: Buffer)\` to make this type-clean (the engine itself only ever calls \`end()\` with no argument).

- **2b — \`onSourceDetected\` lifted from ctx to shell.** \`EsciCtx.source\` is initialized to \`forcedSource ?? \"adf-simplex\"\` before any state runs, so firing the callback inline from STATUS_2 could (in some early-failure paths) produce spurious detections. Replaced with a \`ctx.sourceDetected\` flag set only inside STATUS_2's success branch; the scanner shell reads it post-DONE and fires \`LegacyScanSession.onSourceDetected\` only on \`{ ok: true }\`.

- **2c — \`globalIgnoreFilter\` per-state opt-out.** Replaced the \"filter takes \`currentState\` as a second arg\" wart with a per-state \`bypassIgnoreFilter: true\` flag on \`GraphState\`. Filter stays state-blind (a one-line shape predicate); the two POSTSCAN_*_STAT_DRAIN states declare the bypass.

- **2d — Helper consolidation.** New \`src/graph-helpers.ts\` (\`expectIsType\`, \`expectLength\`, \`ackByte\`) and \`src/commands-fs.ts\` (\`buildFsY\` / \`buildFsX\` / \`buildFsZ\`). Drops the only cross-protocol import (\`esci/graph.ts\` → \`esci2/commands.ts\`). Local \`awaitAck\` → \`awaitReply\` rename in esci2 aligns with the esci helper shape — intentional that they're not lifted to a shared module (each graph parameterises Ctx independently).

- **2e — IS payload sanity cap.** \`Graph.maxPayloadBytes\` defaults to 32 MB (~1000× the max observed in real fixtures, 28 KB). A header declaring a wild payload now settles immediately with a \"likely framing desync in state X\" diagnostic plus first-32-bytes hex dump, instead of timing out 30s later with a misleading \"Timeout in state X\" message.

- **2f — Docs + spec.** JSDoc on \`Graph.cleanupStates\` (DONE-implicit-exclusion + finalize-not-retried), spec §3.1 adapter-split note, §3.2 \`globalIgnoreFilter\` shape, §3.6 IS-payload-cap entry, §6.3/§6.4 named-state-count reality check (post-M3 21 / 17, not the aspirational 14), HOW-IT-WORKS module table refreshed.

### Test changes

- +6 transport tests covering \`withTlsErrorLabels\` (mid-session labelling, post-end ECONNRESET / EPIPE swallow, end(data) forwarding, non-benign error forwarding) and the composition.
- +1 \`bypassIgnoreFilter\` test (rewrite of the old \`currentState\`-arg test).
- +2 IS-payload-cap tests (default cap, custom override).
- Existing 6 ESC/I-2 + 10 ESC/I replay fixtures stay byte-equivalent.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run format:check\` — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test\` — 470 passed, 1 skipped (was 468 pre-PR; +2 net new tests)
- [ ] Hardware smoke: \`PRINTER_PROTOCOL=esci2 npm run scan\` against ET-4950 (TLS path; cert pin honoured)
- [ ] Hardware smoke: \`PRINTER_PROTOCOL=esci npm run scan\` against WF-3620 (legacy plain-TCP path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)