### PR TITLE
fix(probe): disambiguate WF-3620 welcome + factual doc audit

### DIFF
--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -281,10 +281,10 @@ The temp directory is removed in a `finally` block regardless of outcome.
 Three protocol variants ride on port 1865, decided per scan session by `src/protocol-probe.ts`:
 
 1. **TLS handshake** against `1865`. Success → `esci2` (ET-4950 family). The probe socket is destroyed before the real scan begins.
-2. **Plain TCP connect**, await an unsolicited IS-`0x8000` welcome packet within the timeout, then disambiguate by the welcome's payload byte 2: WF-3620 emits `0x02` here on every committed WF-3620 fixture and is rejected; the ET-2750 emits `0x04` and is accepted. The ET-4950 also sends a welcome immediately, but only inside its TLS tunnel — connecting to an ET-4950 over plain TCP yields no `0x8000` and the arm times out. Success → `esci2-plain`.
+2. **Plain TCP connect**, await an unsolicited IS-`0x8000` welcome packet within the timeout, then disambiguate by the welcome's payload byte 1 (frame offset 13): WF-3620 emits `0x02` here on every committed WF-3620 fixture and is rejected; the ET-2750 emits `0x04` and is accepted. Real fixture payloads are `01 02 00 00 00` (WF-3620) and `01 04 00 00 00` (ET-2750). The ET-4950 also sends a welcome immediately, but only inside its TLS tunnel — connecting to an ET-4950 over plain TCP yields no `0x8000` and the arm times out. Success → `esci2-plain`.
 3. **Plain TCP connect**, send `ESC @` (`1b 40`), await a 1-byte `0x06` ACK. Success → `esci` (WF-3620).
 
-The byte-2 discriminator in arm 2 is the load-bearing piece: a real WF-3620 also sends an unsolicited `0x8000` welcome on plain TCP (a misconception in the original probe design said it stayed silent until prompted), so welcomes alone don't separate the two families. The check is encoded as a negative — accept any `0x8000` whose payload[2] is NOT the WF-3620 byte — because the WF-3620 anchor is well-supported (the byte is `0x02` across every committed WF-3620 fixture) while the ET-2750 anchor has only one capture, so a hypothetical future ET-2750-class device that emits a different byte at payload[2] would still be accepted.
+The byte-1 discriminator in arm 2 is the load-bearing piece: a real WF-3620 also sends an unsolicited `0x8000` welcome on plain TCP (a misconception in the original probe design said it stayed silent until prompted), so welcomes alone don't separate the two families. The check is encoded as a negative — accept any `0x8000` whose payload[1] is NOT the WF-3620 byte — because the WF-3620 anchor is well-supported (the byte is `0x02` across every committed WF-3620 fixture) while the ET-2750 anchor has only one capture, so a hypothetical future ET-2750-class device that emits a different byte at payload[1] would still be accepted.
 
 If all three arms fail, the dispatcher resolves to `esci` so the legacy scanner's connect path can surface the underlying socket error in a meaningful way (rather than throwing a generic "no protocol matched" message).
 
@@ -492,7 +492,7 @@ Reverse-engineering artifacts:
 
 ## Testing
 
-The test suite uses Vitest and runs with `npm test` (482 passing tests plus 1 skipped test across 25 files, completing in roughly 5 seconds).
+The test suite uses Vitest and runs with `npm test` (484 passing tests plus 1 skipped test across 25 files, completing in roughly 5 seconds).
 
 **The replay harnesses** are the most important test files. They run in two modes — see [The byte-for-byte replay test](#the-byte-for-byte-replay-test) above for the full account. In short: `src/esci2/scanner.test.ts` runs `runEsci2Scan` against a `FakeTlsSocket` for the ET-4950 Frida captures and asserts byte-for-byte equality on every host send; for the ET-2750 (`runEsci2ScanOverPlain` against `FakePlainSocket`) the harness feeds only printer-side fixture events and asserts on-disk output, not host-byte equality. `src/esci/scanner.test.ts` follows the same behavioural pattern for the WF-3620 ESC/I path using pcap-derived JSONL fixtures. On-disk output is asserted in both modes — JPEG files for JPG-mode runs (including EXIF orientation verification), and a composed PDF for PDF-mode runs (including page count and `/Rotate` metadata on back pages).
 

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -2,7 +2,7 @@
 
 Epson's "Scan to Computer" feature for the ET-4950 is a proprietary, closed-source protocol implemented by a vendor driver stack. The vendor software is available for Windows, macOS, and Linux; the reverse-engineering work for this project was done against the Windows build, where the driver chain is `EEventManager.exe` / `es2projectrunner.exe` / `ES2Command.dll`. On the wire, the printer speaks a layered protocol: a UDP multicast beacon for destination registration, a SOAP-ish HTTP push notification to announce a scan trigger, and a TLS session on port 1865 that carries the actual image data via a command framing system called "IS" with an embedded command language called ESC/I-2.
 
-This project reverse-engineers that stack and re-implements it as a Node.js/TypeScript service. Instead of requiring a desktop machine running Epson's driver GUI, the service runs headless on Linux or in Docker and presents itself to the printer as a named scan destination called "Paperless." When the user presses Scan on the panel, the service captures the image and writes a JPEG or composed PDF to disk. The primary motivation is headless ingestion into a Paperless-ngx document management system, but the service's scope ends at file output.
+This project reverse-engineers that stack and re-implements it as a Node.js/TypeScript service. Instead of requiring a desktop machine running Epson's driver GUI, the service runs headless on Linux or in Docker and presents itself to the printer as a named scan destination called "Paperless." When the user presses Scan on the panel, the service captures the image and writes a JPEG or composed PDF to disk. When `PAPERLESS_URL` and `PAPERLESS_TOKEN` are configured, completed scans are also POSTed to Paperless-ngx and (by default) deleted locally after a successful upload.
 
 The implementation is derived from three complementary sources: Wireshark packet captures of the discovery and push-scan phases, Frida dynamic instrumentation of `ES2Command.dll` to extract the plaintext TLS payload byte-for-byte, and Ghidra static analysis of the same DLL to understand the IS type-code map, the async-event dispatch table, and the lock/unlock framing. This document explains the protocol, the code structure, and the reverse-engineering methodology so that someone working on a related device could follow the same approach.
 
@@ -47,13 +47,13 @@ The SOAP body's `<PushScanIDIn>` element is the only channel through which the p
 
 The service must reply with an HTTP 200 OK. The response must echo the request's `x-uid` header value verbatim. The printer increments this counter on each scan and uses it to verify the response came from the correct session. A mismatched `x-uid` causes the printer to display "Scanning Error" on the panel after the scan completes — even though the scan data transfers correctly and the output file is produced. This is a panel-state signal, not a data-integrity issue; the root cause and fix are documented in the panel-error investigation (see Reverse Engineering below).
 
-After the push-scan response is sent, the service parses the `PushScanIDIn` value and opens the scan-session connection to the printer on port 1865. In `PRINTER_PROTOCOL=auto` mode the dispatcher probes that port first and chooses the TLS ESC/I-2, plain-TCP ESC/I-2, or legacy ESC/I scanner. The push-scan TCP connection is then closed with a FIN (not RST — using RST causes the printer to tear down its end aggressively).
+The service parses the `PushScanIDIn` value from the request body, sends the HTTP 200 OK response, and half-closes the push-scan TCP connection with a FIN (not RST — using RST causes the printer to tear down its end aggressively). Once that response has been written, the daemon's callback opens the scan-session connection to the printer on port 1865. In `PRINTER_PROTOCOL=auto` mode the dispatcher probes that port first and chooses the TLS ESC/I-2, plain-TCP ESC/I-2, or legacy ESC/I scanner.
 
 Implemented in `src/pushscan.ts`. `parsePushScanRequest` extracts the SOAP fields; `buildPushScanResponse` constructs the echoed response; `resolveEffectiveAction` maps the raw action bitmask to one of `jpg`, `pdf`, or `preview`, applying the `PREVIEW_ACTION` env-var gate (default: reject preview silently; `jpg`/`pdf` redirect it to a real scan).
 
 ### The scan session (TLS + ESC/I-2 over "IS" framing)
 
-The actual image transfer happens over a TLS 1.2 session that the service initiates outbound to the printer on port 1865. TLS chain validation is disabled — the printer presents a self-signed certificate and there is no trust chain to validate against. As an opt-in alternative, setting `PRINTER_CERT_FINGERPRINT` pins the peer's SHA-256 fingerprint and aborts the scan at handshake time on mismatch (see `README.md`).
+The actual image transfer happens over a TLS 1.2 session that the service initiates outbound to the printer on port 1865. TLS chain validation is disabled — the printer presents a self-signed certificate and there is no trust chain to validate against. As an opt-in alternative, setting `PRINTER_CERT_FINGERPRINT` pins the peer's SHA-256 fingerprint and aborts the scan at handshake time on mismatch (see `README.md`). Pinning requires `PRINTER_PROTOCOL=esci2` set explicitly — under `auto` (or either of the non-TLS variants), the combination is rejected at startup, since a probe failure could downgrade silently to a non-TLS path and bypass the pin.
 
 Inside the TLS tunnel, all traffic is wrapped in Epson's proprietary **IS framing**. Every message — in both directions — is an IS packet:
 
@@ -70,7 +70,7 @@ Offset  Len  Field
 
 The data-offset field is asymmetric: host-side is always `0x000C` (12); printer-side is always `0x300C` — confirmed across all seven ET-4950 Frida captures and the ET-2750 pcap. The `0x300C` is a printer-firmware constant that the SANE `epsonds` source treats as opaque too. Our builders write `0x000C` on outbound; our parser reads only the type and length fields and ignores offset 4-5 on inbound, so the asymmetry requires no code change.
 
-The packet type field determines the semantics of the payload:
+The packet type field determines the semantics of the payload. The ESC/I-2 path uses these types:
 
 | Type   | Direction      | Meaning                                                 |
 | ------ | -------------- | ------------------------------------------------------- |
@@ -82,6 +82,8 @@ The packet type field determines the semantics of the payload:
 | 0x2000 | Host → printer | Passthru command (sends a command, declares reply size) |
 | 0x2100 | Host → printer | Lock request                                            |
 | 0x2101 | Host → printer | Unlock request                                          |
+
+The legacy ESC/I path (WF-3620) reuses `0x8000`, `0xa000`, `0xa100`/`0xa101`, and `0x2000`/`0x2100`/`0x2101` with the same meaning, plus two extra types: `0x2200` (host → printer stream config) and `0xa200` (printer → host unsolicited image-stream chunks). It does not use `0x9000` async events.
 
 `0x9000` async events carry a single dispatch byte in the payload: `0x01` = ScanStart, `0x02` = Disconnect, `0x03` = ScanCancel, `0x04` = Stop, `0x80` = Timeout, `0xa0` = ServerError. A `0x9000`/`0xa0` (ServerError) means the printer rejected the last command and has torn down the session — there is no recovery path. This type-code map was established by Ghidra decompilation of `CISProtocolStream::DidReceiveAsyncEvent` in `ES2Command.dll`.
 
@@ -107,7 +109,7 @@ The command bytes are either:
 - **ESC/I-2** — 12-byte ASCII headers of the form `NAMEx0000000`, where `NAME` is a 4-character command name (right-padded with spaces if needed) and `0000000` is a 7-hex-digit parameter block length. Commands include `STAT`, `FIN `, `TRDT`, `IMG `, and `PARA`.
 - **Raw parameter bytes** — the `PARA` command's second phase sends the raw scan parameter blob (928–940 bytes depending on source and mode) as a separate passthru with no ESC/I-2 header wrapper.
 
-**PARA is sent in two passthru packets**, not one. The first packet carries the 12-byte `PARAx<hex-len>` header with `reply_size=0`. The second carries the raw parameter bytes with `reply_size=64`. The printer responds only to the second packet, with a 64-byte `PARAx0000000#parOK…` reply if the parameters were accepted or `#parFAIL` if not. This two-phase structure was discovered from the Frida capture: the Windows driver never batches the two sends into a single passthru.
+**PARA is sent in two passthru packets**, not one. The first packet carries the 12-byte `PARAx<hex-len>` header with `reply_size=0`. The second carries the raw parameter bytes with `reply_size=64`. The printer acks the first packet with an empty `0xa000` reply, then responds to the second with a 64-byte `PARAx0000000#parOK…` reply if the parameters were accepted (or `#parNG…` if not). This two-phase structure was discovered from the Frida capture: the Windows driver never batches the two sends into a single passthru.
 
 ESC/I-2 command builders are in `src/esci2/commands.ts`. The legacy 2-byte initialization commands (`buildFsY`, `buildFsX`, `buildFsZ`) live in `src/commands-fs.ts` and are shared with the WF-3620 ESC/I path (which uses `buildFsY` for the `DIAGNOSE_PROTOCOL` probe). `buildEsci2Command` builds the generic 12-byte ESC/I-2 header. `buildParaHeader` and `buildParaPayload` build the two PARA phases. Reply parsing is done by `parseEsci2ReplyHeader` (extracts the 12-byte reply header's `cmd` and `length` fields) and `parseTokens` (splits the `#KEY value` token stream from reply bodies).
 
@@ -127,11 +129,11 @@ Each protocol variant lives in a thin orchestration shell that builds a `Session
 
 The shells / graphs / transports map to the variants like so:
 
-| Variant       | Shell entry point       | Graph             | Transport composition                                                                                                               |
-| ------------- | ----------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `esci2-tls`   | `runEsci2Scan`          | `src/esci2/graph` | `withEsci2UnlockOnDestroy(withTlsErrorLabels(socketAsTransport(tls.connect(...))))` — see [Transport adapters](#transport-adapters) |
-| `esci2-plain` | `runEsci2ScanOverPlain` | `src/esci2/graph` | `withEsci2UnlockOnDestroy(socketAsTransport(net.connect(...)))` — same graph, profile-conditional decisions                         |
-| `esci`        | `runEsciScan`           | `src/esci/graph`  | `socketAsTransport(net.connect(...))` — no adapters, no LOCK/UNLOCK record on the wire                                              |
+| Variant       | Shell entry point       | Graph             | Transport composition                                                                                                                                |
+| ------------- | ----------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `esci2-tls`   | `runEsci2Scan`          | `src/esci2/graph` | `withEsci2UnlockOnDestroy(withTlsErrorLabels(socketAsTransport(tls.connect(...))))` — see [Transport adapters](#transport-adapters)                  |
+| `esci2-plain` | `runEsci2ScanOverPlain` | `src/esci2/graph` | `withEsci2UnlockOnDestroy(socketAsTransport(net.connect(...)))` — same graph, profile-conditional decisions                                          |
+| `esci`        | `runEsciScan`           | `src/esci/graph`  | `socketAsTransport(net.connect(...))` — no transport adapters; UNLOCK is sent from the graph's `UNLOCKING` state rather than via a destroy-time hook |
 
 Both ESC/I-2 entry points share the same graph via an `Esci2Profile = "esci2-tls" | "esci2-plain"` discriminator threaded through `Esci2Ctx`. The deterministic single-IS-packet-per-transition contract holds for all three.
 
@@ -181,7 +183,8 @@ FIN_AFTER_IMG    ← send FIN, await reply
   │  POSTSCAN × 2:                                                    │
   │    POSTSCAN_FS_Y  ← send FS Y, await ACK                         │
   │    POSTSCAN_STAT  ← send STAT, await reply                       │
-  │    POSTSCAN_DRAIN ← pure-read(12) to drain #ERRADF PE status     │
+  │    POSTSCAN_DRAIN ← pure-read(declared length) to drain          │
+  │                     #ERRADF PE status (12 bytes in practice)     │
   │    POSTSCAN_FIN   ← send FIN, await reply                        │
   └───────────────────────────────────────────────────────────────────┘
   (flatbed skips POSTSCAN entirely)
@@ -193,16 +196,16 @@ DONE             ← compose/promote output files, then resolve
 
 **INIT_POLL iterations.** The init poll runs three times on `esci2-tls` and twice on `esci2-plain` (ET-2750's host driver only loops twice before sending FS X — sending a third FS Y after the printer has moved on returns a non-ACK that fails MODE_SWITCH validation). The Windows driver ran the ET-4950 loop up to 14 times in one capture because the printer was still waking up; three iterations is sufficient for a printer that is already active. The loop is driven by a counter, not a ready-state signal from the printer — the status values returned by STAT during INIT_POLL are not examined for readiness; they are simply consumed.
 
-**Async events.** At any point during the session, the printer can send an IS `0x9000` async event packet. The graph's `globalAbortHandlers` entry for `0x9000` inspects the dispatch byte and returns `null` (info-only) for `0x01` (ScanStart) and `0x04` (Stop), or an `Error` for `0x03` (ScanCancel — cancel) and the fatal set `0x02`/`0x80`/`0xa0` (Disconnect/Timeout/ServerError). The engine settles with `{ ok: false, reason }` on any returned `Error`, regardless of which fatal it was. The handler runs at the graph level, before any transport-specific logic, so it applies equally to all three protocol variants. In practice, a `0x9000`/`0xa0` ServerError always means the printer rejected a command (typically a malformed PARA or an unexpected command sequence), and the session connection closes within milliseconds of the event.
+**Async events.** At any point during the session, the printer can send an IS `0x9000` async event packet. The ESC/I-2 graph's `globalAbortHandlers` entry for `0x9000` inspects the dispatch byte and returns `null` (info-only) for `0x01` (ScanStart) and `0x04` (Stop), or an `Error` for `0x03` (ScanCancel — cancel) and the fatal set `0x02`/`0x80`/`0xa0` (Disconnect/Timeout/ServerError). The engine settles with `{ ok: false, reason }` on any returned `Error`, regardless of which fatal it was. The handler is registered at the ESC/I-2 graph level — it applies to both ESC/I-2 variants (TLS and plain-TCP) but not to the legacy ESC/I (WF-3620) graph, which does not register a global async handler. In practice, a `0x9000`/`0xa0` ServerError always means the printer rejected a command (typically a malformed PARA or an unexpected command sequence), and the session connection closes within milliseconds of the event.
 
-**IMG loop mechanics.** Each `IMG` command returns a 64-byte metadata envelope whose `IMGx<hex-length>` prefix declares the byte count of the following image data chunk. The scanner issues a pure-read (passthru with `cmd_size=0`, `reply_size=chunk_length`) to pull those bytes, which accumulate into the in-memory JPEG buffer for the current page. Zero-length replies (`IMG x0000000`) indicate the printer is not ready yet — the scanner retries up to 2,000 times before treating it as a timeout. When the IMG metadata reply contains a `#pen` token in its token stream, the current page-side has ended and the accumulated JPEG buffer is flushed to a `page_NN.jpg` file in the session temp directory.
+**IMG loop mechanics.** Each `IMG` command returns a 64-byte metadata envelope whose `IMGx<hex-length>` prefix declares the byte count of the following image data chunk. The scanner issues a pure-read (passthru with `cmd_size=0`, `reply_size=chunk_length`) to pull those bytes, which accumulate into the in-memory JPEG buffer for the current page. Zero-length replies (`IMG x0000000`) indicate the printer is not ready yet — the scanner retries up to 2,000 times before treating it as a timeout. When IMG metadata reports a `#pen` token, the current page-side has ended; after the final pixel chunk for that page has been received in the next IMG_DATA step (or, in the zero-length-pen edge case, immediately from IMG_META), the accumulated JPEG buffer is flushed to a `page_NN.jpg` file in the session temp directory.
 
 The IMG loop's termination condition differs by source:
 
 - **ADF**: `#pen` is terminal only if the same reply also contains `#lftd000` ("zero pages left"). A `#pen` without `#lftd000` signals a page boundary — the scanner flushes the current page to the temp directory and continues issuing `IMG` commands for the next page.
 - **Flatbed**: any `#pen` is terminal, because the glass holds a single page.
 
-**POSTSCAN drain.** After ADF scans the printer queues a final `#ERRADF PE` (ADF Paper End) status message in its output buffer. If this message is not consumed before the session closes, the printer's internal state machine does not advance cleanly, and the panel displays "Scanning Error" on subsequent scans. The two POSTSCAN cycles (`FS Y → STAT → pure-read(12) → FIN`, twice) drain this queued status. Each cycle's `STAT` reply declares a length of 12, and the subsequent pure-read consumes those 12 bytes (`#ERRADF PE  `). The structure mirrors the `INIT_POLL_STAT_DRAIN` mechanism: the printer uses the IS payload-length field as a general signal that the host should issue a drain read before continuing. Flatbed scans do not produce an ADF status message and skip these two POSTSCAN cycles entirely, going directly from `FIN_AFTER_IMG` to `UNLOCKING`.
+**POSTSCAN drain.** After ADF scans the printer queues a final `#ERRADF PE` (ADF Paper End) status message in its output buffer. If this message is not consumed before the session closes, the printer's internal state machine does not advance cleanly, and the panel displays "Scanning Error" on subsequent scans. The two POSTSCAN cycles (`FS Y → STAT → pure-read(declared length) → FIN`, twice) drain this queued status. The drain consumes the length declared by the STAT reply — 12 bytes (`#ERRADF PE  `) on every captured ADF post-scan, but the implementation reads the declared length verbatim rather than hardcoding 12. The structure mirrors the `INIT_POLL_STAT_DRAIN` mechanism: the printer uses the IS payload-length field as a general signal that the host should issue a drain read before continuing. Flatbed scans do not produce an ADF status message and skip these two POSTSCAN cycles entirely, going directly from `FIN_AFTER_IMG` to `UNLOCKING`.
 
 **Source detection.** The push-scan SOAP body does not indicate whether the printer will scan from the ADF or the flatbed glass — the panel does not expose a source selector. Instead, the printer detects its own source (via the ADF paper sensor) and signals the result in the first `@STAT` reply during INIT_POLL cycle 1. On the `esci2-tls` profile (ET-4950 family), an ADF-mode printer returns a zero-length `STATx0000000` reply and a flatbed-mode printer returns a 12-byte `STATx000000C` reply with filler content. The scanner reads this length field and sets its internal `source` variable, which governs the PARA blob selection, the IMG loop terminator, and the POSTSCAN branching.
 
@@ -217,7 +220,7 @@ The engine consumes a generic `SessionTransport` interface (`write` / `end(data?
 
 The TLS factory composes both: `withEsci2UnlockOnDestroy(withTlsErrorLabels(socketAsTransport(socket)))`. The unlock wrapper is OUTER so its destroy-time `inner.end(buildUnlockPacket())` flows through the TLS-error wrapper, setting that wrapper's `endCalled` flag before bytes leave the host. The plain-TCP factory (ET-2750) composes only the unlock adapter — there's no TLS layer to label or to swallow post-FIN resets from.
 
-The WF-3620 ESC/I path uses no adapters: plain TCP with no LOCK/UNLOCK record on the wire (the protocol manages session teardown differently).
+The WF-3620 ESC/I path uses no transport-shape adapters. It still emits LOCK and UNLOCK packets on the wire (the same `0x2100` / `0x2101` types the ESC/I-2 path uses), but UNLOCK is sent from the graph's `UNLOCKING.onEnter` rather than via a destroy-time hook, so it doesn't need the polite-close gating that `withEsci2UnlockOnDestroy` provides.
 
 ---
 
@@ -258,7 +261,7 @@ Flatbed scans are always single-sided regardless of the `PushScanIDIn[0]` value.
 
 The panel's Action selection is the second character of `PushScanIDIn`, interpreted as a bitmask: `1` = JPG, `2` = PDF, `4` = Preview on Computer. The service resolves this to an effective action via `resolveEffectiveAction` in `src/pushscan.ts`.
 
-A key protocol finding for the ESC/I-2 path (ET-4950 family + ET-2750): **the wire traffic is identical for JPG and PDF panel selections**. The printer always streams JPEG-encoded image data regardless of the panel's Action setting; PDF is composed on the host side using pdf-lib after all pages have been received. This was confirmed by capturing a PDF-mode scan with Frida and comparing its TLS payload byte-for-byte against a JPG-mode scan from the same printer — the payloads are identical.
+A key protocol finding for the ESC/I-2 path (ET-4950 family + ET-2750): **the printer is unaware of the JPG-vs-PDF distinction.** It always streams JPEG-encoded image data regardless of the panel's Action setting; PDF is composed on the host side using pdf-lib after all pages have been received. The ADF replay tests assert this directly — the same Frida JPG capture is reused as the fixture for both `action='jpg'` and `action='pdf'` test runs, and the state machine produces the expected outputs in both cases. (The committed JPG and PDF flatbed captures are separate Frida sessions and so differ slightly in capture-time polling cadence, but the protocol structure is the same.)
 
 The ESC/I path (WF-3620) is different: the firmware locks the scan resolution to the panel's format choice (600 DPI for JPG, 300 DPI for PDF), so the wire bytes do differ between the two — see [ESC/I variant (WF-3620)](#esci-variant-wf-3620) below. Composition still happens host-side via pdf-lib in PDF mode, but the underlying pixel stream is captured at the lower resolution.
 
@@ -266,7 +269,7 @@ Preview on Computer (`PushScanIDIn[1] = 4`) is rejected by default (the scan doe
 
 After `DONE`, the engine calls `transport.end()` to queue the FIN synchronously and then schedules the end-of-scan step via `setImmediate` — it does **not** wait for the socket's `'close'` event (the close handler is a no-op on the DONE path). The `setImmediate` exists to give any in-flight microtasks — notably the previous `flushPage`'s file-write resolving its Promise — a tick to settle before the synchronous finalize step runs:
 
-- `action='jpg'`: `promoteTempPagesToOutput` renames `page_NN.jpg` files in the session temp directory to `scan_<timestamp>[_NN].jpg` in the output directory.
+- `action='jpg'`: `promoteTempPagesToOutput` reads each `page_NN.jpg` from the session temp directory, writes it to `scan_<timestamp>[_NN].jpg` in the output directory (with collision-suffix handling), and unlinks the temp page. Reading + writing rather than `rename` lets temp and output directories live on different filesystems.
 - `action='pdf'`: `composePdfFromJpegs` in `src/pdf.ts` embeds each temp JPEG into a pdf-lib `PDFDocument`, applies `/Rotate = 180` on back-side pages, and writes `scan_<timestamp>.pdf`. If composition fails, it falls back to the JPEG promote path.
 
 The temp directory is removed in a `finally` block regardless of outcome.
@@ -278,8 +281,10 @@ The temp directory is removed in a `finally` block regardless of outcome.
 Three protocol variants ride on port 1865, decided per scan session by `src/protocol-probe.ts`:
 
 1. **TLS handshake** against `1865`. Success → `esci2` (ET-4950 family). The probe socket is destroyed before the real scan begins.
-2. **Plain TCP connect**, await an unsolicited IS-`0x8000` welcome packet within the timeout. The ET-2750 sends one immediately after the TCP handshake completes; the ET-4950 also sends a welcome but only inside its TLS tunnel, so this plain-TCP arm doesn't see it — connecting to an ET-4950 over plain TCP yields no `0x8000` and the arm times out. Success → `esci2-plain` (matches ET-2750-class hardware only).
+2. **Plain TCP connect**, await an unsolicited IS-`0x8000` welcome packet within the timeout, then disambiguate by the welcome's payload byte 2: WF-3620 emits `0x02` here on every captured session (n=11) and is rejected; the ET-2750 emits `0x04` and is accepted. The ET-4950 also sends a welcome immediately, but only inside its TLS tunnel — connecting to an ET-4950 over plain TCP yields no `0x8000` and the arm times out. Success → `esci2-plain`.
 3. **Plain TCP connect**, send `ESC @` (`1b 40`), await a 1-byte `0x06` ACK. Success → `esci` (WF-3620).
+
+The byte-2 discriminator in arm 2 is the load-bearing piece: a real WF-3620 also sends an unsolicited `0x8000` welcome on plain TCP (a misconception in the original probe design said it stayed silent until prompted), so welcomes alone don't separate the two families. The check is encoded as a negative — accept any `0x8000` whose payload[2] is NOT the WF-3620 byte — because the WF-3620 anchor has 11 captures backing it while the ET-2750 anchor has only one, so a hypothetical future ET-2750-class device that emits a different byte at payload[2] would still be accepted.
 
 If all three arms fail, the dispatcher resolves to `esci` so the legacy scanner's connect path can surface the underlying socket error in a meaningful way (rather than throwing a generic "no protocol matched" message).
 
@@ -310,14 +315,20 @@ elicits a 1-byte ACK from a WF-3620-class device.
 Key wire differences (full table in
 `.reference/wireshark-captures/wf-3620/protocol-decode.md`):
 
-- Init is `ESC @` (`1b 40`), not `FS Y`.
-- Source select is `ESC e <byte>` (0=flatbed, 1=ADF simplex, 2=ADF duplex)
-  separately from the FS W block, not encoded in PARA tokens.
+- Init is `ESC @` (`1b 40`), not `FS Y`. The printer also emits an
+  unsolicited IS-`0x8000` welcome on plain TCP (same as the ET-2750), so
+  the auto-probe disambiguates by the welcome's payload-byte 2 — see
+  [Protocol probe](#protocol-probe-three-arms).
+- Source select is sent as `ESC e <byte>` (0=flatbed, 1=ADF simplex,
+  2=ADF duplex) before scan setup. The same byte is also written into
+  byte 26 of the 64-byte FS W parameter block. Not encoded in PARA tokens
+  (there are no PARA tokens — see below).
 - Scan parameters fit in a 64-byte little-endian binary block after `FS W`,
   not a 936-byte ASCII PARA blob.
-- The printer pushes raw 24-bit RGB pixels in IS-0xa200 chunks at
-  600 DPI (JPEG) / 300 DPI (PDF) — the firmware locks the resolution to
-  the panel's format choice.
+- The printer pushes raw 24-bit GBR-interleaved pixels (bytes per pixel
+  are `[G, B, R]`; the host permutes to RGB before sharp encodes them) in
+  IS-0xa200 chunks at 600 DPI (JPG) / 300 DPI (PDF) — the firmware locks
+  the resolution to the panel's format choice.
 - ADF pages are terminated by a host-sent `0x0c 0x00` page-eject. Duplex
   produces two cycles per sheet; the back side comes out 180°-rotated and
   the host applies EXIF Orientation=3 / `/Rotate 180` accordingly.
@@ -397,7 +408,7 @@ Each captured session is written to a JSONL file in `tools/frida-capture/capture
 | `2026-04-24T09-05-08-flatbed-1p-jpg.jsonl`     | 1-page flatbed JPG                |
 | `2026-04-24T09-06-37-flatbed-1p-pdf.jsonl`     | 1-page flatbed PDF                |
 
-The PDF capture was particularly diagnostic: its TLS payload is byte-identical to the JPG baseline capture, confirming that PDF is entirely a host-side composition step and that the printer has no knowledge of the format distinction.
+The PDF capture was particularly diagnostic. The printer streams JPEG image data regardless of the panel's format choice, so the protocol-level traffic is the same on JPG and PDF runs — confirmed by reusing the JPG capture file as the fixture for the PDF replay test (see `pdfFixtures` in `src/esci2/scanner.test.ts`). Capture-to-capture byte equality holds at the protocol-flow level; literal byte-equality between JPG and PDF capture _files_ depends on capture-time polling cadence and is not guaranteed.
 
 ### Step 3: Ghidra on ES2Command.dll
 
@@ -419,51 +430,52 @@ Investigation via paired Wireshark captures (one from the Epson driver, one from
 
 ### The byte-for-byte replay test
 
-`src/esci2/scanner.test.ts` is the regression shield for the ESC/I-2 path. It loads a capture JSONL file, connects the real shell entry point (`runEsci2Scan` for the TLS path, `runEsci2ScanOverPlain` for the plain-TCP path) to the matching fake socket (`FakeTlsSocket` or `FakePlainSocket` from `src/esci2/test-support/`), feeds the captured printer-side records one-by-one, and asserts that every byte the state machine sends matches the corresponding host-side record from the capture. Any state-machine edit that changes the outgoing byte sequence will fail this test.
+`src/esci2/scanner.test.ts` is the regression shield for the ESC/I-2 path. It runs in two modes:
 
-The TLS suite runs eight parametrized replay entries: 1p-simplex, 3p-simplex, 1p-duplex (ADF), and 1p-flatbed each in both JPG and PDF mode. The ADF entries reuse a single capture per scenario with `action='jpg'` and `action='pdf'`; the flatbed entries use separate captures for each format because the original Frida session captured them as distinct runs. JPG replay entries assert JPEG files on disk with correct EXIF orientation on back-side pages; PDF replay entries assert a single composed PDF with correct page count and `/Rotate = 180` on back pages.
+- **TLS replay (byte-for-byte).** For the ET-4950 Frida captures, the test feeds the captured printer-side records to a `FakeTlsSocket` one-by-one and asserts that every byte the state machine writes matches the corresponding host-side record from the capture. Any edit that changes the outgoing byte sequence will fail. Eight parametrized entries run here: 1p-simplex, 3p-simplex, 1p-duplex (ADF), and 1p-flatbed each in both JPG and PDF mode. The ADF entries reuse a single capture per scenario across `action='jpg'` and `action='pdf'`; the flatbed entries use separate captures for each format because the original Frida session captured them as distinct runs.
+- **Plain-TCP replay (behavioural).** For the ET-2750 (`runEsci2ScanOverPlain`), the helper in `src/esci2/test-support/replay.ts` feeds only the printer-side events from a pcap-extracted fixture to a `FakePlainSocket` and asserts the session's on-disk output and end-state, not per-host-byte equality. The fixture is roughly 3.9 MB — a couple of orders of magnitude larger than the WF-3620 fixtures (8-30 KB each) — because ET-2750's IMG cycles wrap pixel data in `0xa000` ESC/I-2 frames; there's no `0xa200` image-stream summary path to fold the per-chunk records into a single summary line like the WF-3620 extractor uses.
 
-The same file adds an ET-2750 replay entry (`runEsci2ScanOverPlain` — `esci2-plain` profile) driven by a pcap-extracted JSONL fixture in `tools/pcap-extract/captures/et-2750/`. The fixture is roughly 3.9 MB — a couple of orders of magnitude larger than the WF-3620 fixtures (8-30 KB each) — because ET-2750's IMG cycles wrap pixel data in `0xa000` ESC/I-2 frames; there's no `0xa200` image-stream summary path to fold the per-chunk records into a single summary line like the WF-3620 extractor uses.
+JPG replay entries assert JPEG files on disk with the correct EXIF Orientation byte on back-side pages; PDF replay entries assert a single composed PDF with correct page count and `/Rotate = 180` on back pages.
 
-`src/esci/scanner.test.ts` applies the same replay approach to the WF-3620 ESC/I path using ten pcap-derived JSONL fixtures in `tools/pcap-extract/captures/wf-3620/` (single-page, 2-page duplex, 3-page simplex, 4-page duplex, and flatbed-single-page, each in JPG and PDF mode).
+`src/esci/scanner.test.ts` applies the same behavioural replay approach to the WF-3620 ESC/I path, using ten pcap-derived JSONL fixtures in `tools/pcap-extract/captures/wf-3620/` (single-page, 2-page duplex, 3-page simplex, 4-page duplex, and flatbed-single-page, each in JPG and PDF mode). It also feeds only printer-side events; host bytes are not asserted equal to the fixture.
 
-Because the protocol was built from these captures, the replay tests are both regression tests and specifications: each state machine is, by construction, correct if and only if it produces the exact byte sequence that the Windows driver produced on the same printer.
+The TLS replay's byte-for-byte guarantee is the strongest regression shield in the suite: that state machine is, by construction, correct if and only if it produces the exact byte sequence that the Windows driver produced on the same printer. The pcap-based behavioural replays are weaker (multiple host-side sequences could in principle pass) but cover the variants for which Frida captures aren't available.
 
 ---
 
 ## Code layout
 
-| File                      | Responsibility                                                                                                |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `src/index.ts`            | Service entry point — long-running daemon. Wires modules together and starts the event loop.                  |
-| `src/one-shot.ts`         | One-shot CLI variant of the daemon (`npm run scan`). Same wire behaviour, exits after the first scan.         |
-| `src/startup.ts`          | Startup banner + scan dispatcher: routes each push-scan to the right scanner shell based on detected variant. |
-| `src/config.ts`           | Zod-validated configuration from environment variables.                                                       |
-| `src/keepalive.ts`        | UDP multicast listener and keepalive responder.                                                               |
-| `src/pushscan.ts`         | TCP server for push-scan trigger, SOAP parsing, x-uid echo.                                                   |
-| `src/protocol.ts`         | IS-frame encode/decode, lock/unlock/passthru/pureread packet builders.                                        |
-| `src/protocol-probe.ts`   | Three-arm probe (TLS → plain-TCP-await-`0x8000` → `ESC @` ACK) classifying each scan's protocol variant.      |
-| `src/scan-session.ts`     | Generic graph-driven scan-session engine. Walks a `Graph<Ctx>` one IS packet at a time; protocol-blind.       |
-| `src/esci2/scanner.ts`    | Orchestration shell for the ESC/I-2 path (TLS + plain-TCP entry points). Builds the transport, calls engine.  |
-| `src/esci2/graph.ts`      | ESC/I-2 protocol graph (states, transitions, PARA dispatch). Driven by `src/scan-session.ts`.                 |
-| `src/esci2/commands.ts`   | ESC/I-2 command builders, PARA payload blobs (TLS + plain), reply parsers.                                    |
-| `src/esci2/transport.ts`  | TLS-error-label and ESC/I-2 unlock-on-destroy adapters that wrap a raw socket as a `SessionTransport`.        |
-| `src/esci/scanner.ts`     | Orchestration shell for the WF-3620 ESC/I path. Plain TCP, no transport adapters.                             |
-| `src/esci/graph.ts`       | ESC/I (WF-3620) protocol graph.                                                                               |
-| `src/esci/commands.ts`    | ESC/I command builders and reply parsers.                                                                     |
-| `src/esci/luts.ts`        | Gamma LUT tables for the ESC/I scan path.                                                                     |
-| `src/esci/raw-to-jpeg.ts` | Raw 24-bit RGB → JPEG encoding via sharp (ESC/I path only).                                                   |
-| `src/commands-fs.ts`      | Legacy 2-byte `FS Y` / `FS X` / `FS Z` builders shared by both protocols.                                     |
-| `src/graph-helpers.ts`    | Shared graph-state helpers (`expectIsType`, `expectLength`, `ackByte`).                                       |
-| `src/exif.ts`             | JPEG EXIF APP1 injection for back-side orientation.                                                           |
-| `src/pdf.ts`              | PDF composition from per-page JPEGs using pdf-lib.                                                            |
-| `src/output.ts`           | Output filename generation and temp-file promotion.                                                           |
-| `src/output-tail.ts`      | End-of-scan finalize pipeline: JPG promote / PDF compose, EXIF / `/Rotate` injection, Paperless upload.       |
-| `src/paperless-upload.ts` | Paperless-ngx HTTP upload + post-upload local-file cleanup (when `PAPERLESS_URL` + `PAPERLESS_TOKEN` set).    |
-| `src/health.ts`           | HTTP health-check endpoint on port 3000.                                                                      |
-| `src/logger.ts`           | Hand-rolled structured logger; text or JSON output via `LOG_FORMAT`.                                          |
-| `src/lifecycle.ts`        | Graceful shutdown coordination.                                                                               |
-| `src/network.ts`          | Resolves the local IP that can reach the printer (UDP `connect()` trick).                                     |
+| File                      | Responsibility                                                                                                                                                                                                                               |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/index.ts`            | Service entry point — long-running daemon. Wires modules together and starts the event loop.                                                                                                                                                 |
+| `src/one-shot.ts`         | One-shot CLI variant of the daemon (`npm run scan`). Same scanning wire behaviour as the daemon, but no health endpoint; exits after the first scan completes.                                                                               |
+| `src/startup.ts`          | Startup banner + scan dispatcher: routes each push-scan to the right scanner shell based on detected variant.                                                                                                                                |
+| `src/config.ts`           | Zod-validated configuration from environment variables.                                                                                                                                                                                      |
+| `src/keepalive.ts`        | UDP multicast listener and keepalive responder.                                                                                                                                                                                              |
+| `src/pushscan.ts`         | TCP server for push-scan trigger, SOAP parsing, x-uid echo.                                                                                                                                                                                  |
+| `src/protocol.ts`         | IS-frame encode/decode, lock/unlock/passthru/pureread packet builders.                                                                                                                                                                       |
+| `src/protocol-probe.ts`   | Three-arm probe (TLS → plain-TCP-await-`0x8000` → `ESC @` ACK) classifying each scan's protocol variant.                                                                                                                                     |
+| `src/scan-session.ts`     | Generic graph-driven scan-session engine. Walks a `Graph<Ctx>` one IS packet at a time; protocol-blind.                                                                                                                                      |
+| `src/esci2/scanner.ts`    | Orchestration shell for the ESC/I-2 path (TLS + plain-TCP entry points). Builds the transport, calls engine.                                                                                                                                 |
+| `src/esci2/graph.ts`      | ESC/I-2 protocol graph (states, transitions, PARA dispatch). Driven by `src/scan-session.ts`.                                                                                                                                                |
+| `src/esci2/commands.ts`   | ESC/I-2 command builders, PARA payload blobs (TLS + plain), reply parsers.                                                                                                                                                                   |
+| `src/esci2/transport.ts`  | TLS-error-label and ESC/I-2 unlock-on-destroy adapters that wrap a raw socket as a `SessionTransport`.                                                                                                                                       |
+| `src/esci/scanner.ts`     | Orchestration shell for the WF-3620 ESC/I path. Plain TCP, no transport adapters.                                                                                                                                                            |
+| `src/esci/graph.ts`       | ESC/I (WF-3620) protocol graph.                                                                                                                                                                                                              |
+| `src/esci/commands.ts`    | ESC/I command builders and reply parsers.                                                                                                                                                                                                    |
+| `src/esci/luts.ts`        | Gamma LUT tables for the ESC/I scan path.                                                                                                                                                                                                    |
+| `src/esci/raw-to-jpeg.ts` | Raw 24-bit RGB → JPEG encoding via sharp (ESC/I path only).                                                                                                                                                                                  |
+| `src/commands-fs.ts`      | Legacy 2-byte `FS Y` / `FS X` / `FS Z` builders shared by both protocols.                                                                                                                                                                    |
+| `src/graph-helpers.ts`    | Shared graph-state helpers (`expectIsType`, `expectLength`, `ackByte`).                                                                                                                                                                      |
+| `src/exif.ts`             | JPEG EXIF APP1 injection for back-side orientation.                                                                                                                                                                                          |
+| `src/pdf.ts`              | PDF composition from per-page JPEGs using pdf-lib.                                                                                                                                                                                           |
+| `src/output.ts`           | Output filename generation and temp-file promotion.                                                                                                                                                                                          |
+| `src/output-tail.ts`      | End-of-scan finalize pipeline: JPG promote / PDF compose with `/Rotate=180` on back pages, optional Paperless upload, temp-dir cleanup. (JPG EXIF injection happens earlier, in the engine's flushPage barrier — see `src/scan-session.ts`.) |
+| `src/paperless-upload.ts` | Paperless-ngx HTTP upload + post-upload local-file cleanup (when `PAPERLESS_URL` + `PAPERLESS_TOKEN` set).                                                                                                                                   |
+| `src/health.ts`           | HTTP health-check endpoint (port from `HEALTH_PORT`, default 3000). Daemon-only — `one-shot.ts` does not start it.                                                                                                                           |
+| `src/logger.ts`           | Hand-rolled structured logger; text or JSON output via `LOG_FORMAT`.                                                                                                                                                                         |
+| `src/lifecycle.ts`        | Graceful shutdown coordination.                                                                                                                                                                                                              |
+| `src/network.ts`          | Resolves the local IP that can reach the printer (UDP `connect()` trick).                                                                                                                                                                    |
 
 Test files mirror the module they cover (`src/esci2/scanner.test.ts`, `src/esci/scanner.test.ts`, `src/keepalive.test.ts`, etc.). The replay test harness support code lives in `src/esci2/test-support/` and `src/esci/test-support/`.
 
@@ -480,7 +492,7 @@ Reverse-engineering artifacts:
 
 ## Testing
 
-The test suite uses Vitest and runs with `npm test` (481 passing tests plus 1 skipped test across 25 files, completing in roughly 5 seconds).
+The test suite uses Vitest and runs with `npm test` (482 passing tests plus 1 skipped test across 25 files, completing in roughly 5 seconds).
 
 **The replay harnesses** are the most important test files. `src/esci2/scanner.test.ts` instantiates the real shell entry points — `runEsci2Scan` against a `FakeTlsSocket` for the ET-4950 TLS suite, and `runEsci2ScanOverPlain` against a `FakePlainSocket` for the ET-2750 plain-TCP entry — and replays printer-side bytes from a capture, advancing one IS packet at a time, while recording every byte the state machine sends. After the session completes, the test asserts byte-for-byte equality against the host-side bytes from the capture. On-disk output files are also asserted — JPEG files for JPG-mode runs (including EXIF orientation verification), and a composed PDF for PDF-mode runs (including page count and `/Rotate` metadata on back pages). `src/esci/scanner.test.ts` applies the same approach to the WF-3620 ESC/I path using pcap-derived JSONL fixtures.
 
@@ -498,7 +510,7 @@ The test suite uses Vitest and runs with `npm test` (481 passing tests plus 1 sk
 - `src/esci/graph.test.ts` — ESC/I graph shape, STATUS_2 source-detect, gamma cycle, IMG_RECEIVING flush logic.
 - `src/esci/raw-to-jpeg.test.ts` — raw 24-bit RGB → JPEG encoding round-trip.
 - `src/esci/scanner-diagnose.test.ts` — `DIAGNOSE_PROTOCOL` mode: ESC @ NAK + FS Y probe behaviour.
-- `src/output-tail.test.ts` — finalize pipeline (JPG promote / PDF compose / Paperless upload).
+- `src/output-tail.test.ts` — finalize pipeline (JPG promote, PDF compose, temp-dir cleanup on failure). Paperless upload coverage is in `src/paperless-upload.test.ts`.
 - `src/output.test.ts` — filename generation, sorted page file enumeration.
 - `src/paperless-upload.test.ts` — multipart POST, retention-flag handling, error paths.
 - `src/pdf.test.ts` — PDF composition from sample JPEGs, page-count and rotation assertions.
@@ -512,7 +524,7 @@ The test suite uses Vitest and runs with `npm test` (481 passing tests plus 1 sk
 
 The test fixture for `src/pdf.test.ts` is `test-fixtures/sample-page.jpg`, a small JPEG extracted from the 1p-simplex Frida capture by `tools/extract-test-jpeg.ts`.
 
-CI runs `npm install` followed by the same lint + format:check + test trio that the local pre-push hook enforces, on every push to `dev` / `main` and every pull request targeting `main` (see `.github/workflows/test.yml`). The workflow uses `npm install` rather than `npm ci` because the lockfile is generated on Windows and lacks Linux-only optional native dependencies; running `npm ci` on Linux would fail with a missing-dependency error.
+CI runs `npm install` followed by the same lint + format:check + test trio that the local pre-push hook enforces, on every push to `dev` / `main` and every pull request targeting `dev` or `main` (see `.github/workflows/test.yml`). The workflow uses `npm install` rather than `npm ci` because the lockfile is generated on Windows and lacks Linux-only optional native dependencies; running `npm ci` on Linux would fail with a missing-dependency error.
 
 To run a single test file with verbose output:
 

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -49,7 +49,7 @@ The service must reply with an HTTP 200 OK. The response must echo the request's
 
 The service parses the `PushScanIDIn` value from the request body, sends the HTTP 200 OK response, and half-closes the push-scan TCP connection with a FIN (not RST — using RST causes the printer to tear down its end aggressively). Once that response has been written, the daemon's callback opens the scan-session connection to the printer on port 1865. In `PRINTER_PROTOCOL=auto` mode the dispatcher probes that port first and chooses the TLS ESC/I-2, plain-TCP ESC/I-2, or legacy ESC/I scanner.
 
-Implemented in `src/pushscan.ts`. `parsePushScanRequest` extracts the SOAP fields; `buildPushScanResponse` constructs the echoed response; `resolveEffectiveAction` maps the raw action bitmask to one of `jpg`, `pdf`, or `preview`, applying the `PREVIEW_ACTION` env-var gate (default: reject preview silently; `jpg`/`pdf` redirect it to a real scan).
+Implemented in `src/pushscan.ts`. `parsePushScanRequest` extracts the SOAP fields; `buildPushScanResponse` constructs the echoed response. Action handling is two-stage: `computeActionFromId` decodes the raw `PushScanIDIn` action bitmask into one of `jpg`, `pdf`, `preview`, or `unknown`; `resolveEffectiveAction` then applies the `PREVIEW_ACTION` env-var gate and returns `jpg`, `pdf`, or `null` (default: reject preview silently → `null`; `PREVIEW_ACTION=jpg`/`pdf` redirects preview into a real scan).
 
 ### The scan session (TLS + ESC/I-2 over "IS" framing)
 
@@ -281,10 +281,10 @@ The temp directory is removed in a `finally` block regardless of outcome.
 Three protocol variants ride on port 1865, decided per scan session by `src/protocol-probe.ts`:
 
 1. **TLS handshake** against `1865`. Success → `esci2` (ET-4950 family). The probe socket is destroyed before the real scan begins.
-2. **Plain TCP connect**, await an unsolicited IS-`0x8000` welcome packet within the timeout, then disambiguate by the welcome's payload byte 2: WF-3620 emits `0x02` here on every captured session (n=11) and is rejected; the ET-2750 emits `0x04` and is accepted. The ET-4950 also sends a welcome immediately, but only inside its TLS tunnel — connecting to an ET-4950 over plain TCP yields no `0x8000` and the arm times out. Success → `esci2-plain`.
+2. **Plain TCP connect**, await an unsolicited IS-`0x8000` welcome packet within the timeout, then disambiguate by the welcome's payload byte 2: WF-3620 emits `0x02` here on every committed WF-3620 fixture and is rejected; the ET-2750 emits `0x04` and is accepted. The ET-4950 also sends a welcome immediately, but only inside its TLS tunnel — connecting to an ET-4950 over plain TCP yields no `0x8000` and the arm times out. Success → `esci2-plain`.
 3. **Plain TCP connect**, send `ESC @` (`1b 40`), await a 1-byte `0x06` ACK. Success → `esci` (WF-3620).
 
-The byte-2 discriminator in arm 2 is the load-bearing piece: a real WF-3620 also sends an unsolicited `0x8000` welcome on plain TCP (a misconception in the original probe design said it stayed silent until prompted), so welcomes alone don't separate the two families. The check is encoded as a negative — accept any `0x8000` whose payload[2] is NOT the WF-3620 byte — because the WF-3620 anchor has 11 captures backing it while the ET-2750 anchor has only one, so a hypothetical future ET-2750-class device that emits a different byte at payload[2] would still be accepted.
+The byte-2 discriminator in arm 2 is the load-bearing piece: a real WF-3620 also sends an unsolicited `0x8000` welcome on plain TCP (a misconception in the original probe design said it stayed silent until prompted), so welcomes alone don't separate the two families. The check is encoded as a negative — accept any `0x8000` whose payload[2] is NOT the WF-3620 byte — because the WF-3620 anchor is well-supported (the byte is `0x02` across every committed WF-3620 fixture) while the ET-2750 anchor has only one capture, so a hypothetical future ET-2750-class device that emits a different byte at payload[2] would still be accepted.
 
 If all three arms fail, the dispatcher resolves to `esci` so the legacy scanner's connect path can surface the underlying socket error in a meaningful way (rather than throwing a generic "no protocol matched" message).
 
@@ -464,7 +464,7 @@ The TLS replay's byte-for-byte guarantee is the strongest regression shield in t
 | `src/esci/graph.ts`       | ESC/I (WF-3620) protocol graph.                                                                                                                                                                                                              |
 | `src/esci/commands.ts`    | ESC/I command builders and reply parsers.                                                                                                                                                                                                    |
 | `src/esci/luts.ts`        | Gamma LUT tables for the ESC/I scan path.                                                                                                                                                                                                    |
-| `src/esci/raw-to-jpeg.ts` | Raw 24-bit RGB → JPEG encoding via sharp (ESC/I path only).                                                                                                                                                                                  |
+| `src/esci/raw-to-jpeg.ts` | Raw 24-bit GBR (wire order) → permute to RGB → JPEG encoding via sharp (ESC/I path only).                                                                                                                                                    |
 | `src/commands-fs.ts`      | Legacy 2-byte `FS Y` / `FS X` / `FS Z` builders shared by both protocols.                                                                                                                                                                    |
 | `src/graph-helpers.ts`    | Shared graph-state helpers (`expectIsType`, `expectLength`, `ackByte`).                                                                                                                                                                      |
 | `src/exif.ts`             | JPEG EXIF APP1 injection for back-side orientation.                                                                                                                                                                                          |
@@ -494,7 +494,7 @@ Reverse-engineering artifacts:
 
 The test suite uses Vitest and runs with `npm test` (482 passing tests plus 1 skipped test across 25 files, completing in roughly 5 seconds).
 
-**The replay harnesses** are the most important test files. `src/esci2/scanner.test.ts` instantiates the real shell entry points — `runEsci2Scan` against a `FakeTlsSocket` for the ET-4950 TLS suite, and `runEsci2ScanOverPlain` against a `FakePlainSocket` for the ET-2750 plain-TCP entry — and replays printer-side bytes from a capture, advancing one IS packet at a time, while recording every byte the state machine sends. After the session completes, the test asserts byte-for-byte equality against the host-side bytes from the capture. On-disk output files are also asserted — JPEG files for JPG-mode runs (including EXIF orientation verification), and a composed PDF for PDF-mode runs (including page count and `/Rotate` metadata on back pages). `src/esci/scanner.test.ts` applies the same approach to the WF-3620 ESC/I path using pcap-derived JSONL fixtures.
+**The replay harnesses** are the most important test files. They run in two modes — see [The byte-for-byte replay test](#the-byte-for-byte-replay-test) above for the full account. In short: `src/esci2/scanner.test.ts` runs `runEsci2Scan` against a `FakeTlsSocket` for the ET-4950 Frida captures and asserts byte-for-byte equality on every host send; for the ET-2750 (`runEsci2ScanOverPlain` against `FakePlainSocket`) the harness feeds only printer-side fixture events and asserts on-disk output, not host-byte equality. `src/esci/scanner.test.ts` follows the same behavioural pattern for the WF-3620 ESC/I path using pcap-derived JSONL fixtures. On-disk output is asserted in both modes — JPEG files for JPG-mode runs (including EXIF orientation verification), and a composed PDF for PDF-mode runs (including page count and `/Rotate` metadata on back pages).
 
 **Unit tests** cover each module independently:
 
@@ -508,7 +508,7 @@ The test suite uses Vitest and runs with `npm test` (482 passing tests plus 1 sk
 - `src/esci2/transport.test.ts` — `withEsci2UnlockOnDestroy` + `withTlsErrorLabels` adapters and their composition.
 - `src/esci/commands.test.ts` — ESC/I command builders, FS W block, gamma LUTs, FS G reply parser.
 - `src/esci/graph.test.ts` — ESC/I graph shape, STATUS_2 source-detect, gamma cycle, IMG_RECEIVING flush logic.
-- `src/esci/raw-to-jpeg.test.ts` — raw 24-bit RGB → JPEG encoding round-trip.
+- `src/esci/raw-to-jpeg.test.ts` — raw 24-bit GBR → RGB permutation + JPEG encoding round-trip.
 - `src/esci/scanner-diagnose.test.ts` — `DIAGNOSE_PROTOCOL` mode: ESC @ NAK + FS Y probe behaviour.
 - `src/output-tail.test.ts` — finalize pipeline (JPG promote, PDF compose, temp-dir cleanup on failure). Paperless upload coverage is in `src/paperless-upload.test.ts`.
 - `src/output.test.ts` — filename generation, sorted page file enumeration.

--- a/src/protocol-probe.test.ts
+++ b/src/protocol-probe.test.ts
@@ -110,15 +110,22 @@ class FakeNetSocket extends EventEmitter {
   }
 }
 
-/** Build an `IS` welcome frame: 12-byte header, type=0x8000, payload size 5. */
-function welcomeBytes(): Buffer {
+/**
+ * Build an `IS` welcome frame: 12-byte header, type=0x8000, payload size 5.
+ * Payload shape matches real fixtures: `00 01 <discriminator> 00 00`.
+ *   - `discriminator = 0x04` → ET-2750 (default, matches
+ *     `tools/pcap-extract/captures/et-2750/flatbed-single-page-pdf.jsonl`).
+ *   - `discriminator = 0x02` → WF-3620 (matches every capture in
+ *     `tools/pcap-extract/captures/wf-3620/`).
+ */
+function welcomeBytes(discriminator: number = 0x04): Buffer {
   const header = Buffer.alloc(12);
   header[0] = 0x49;
   header[1] = 0x53;
   header.writeUInt16BE(0x8000, 2);
   header.writeUInt16BE(0x300c, 4);
   header.writeUInt32BE(5, 6);
-  const payload = Buffer.from([0x00, 0x00, 0x01, 0x04, 0x00]);
+  const payload = Buffer.from([0x00, 0x01, discriminator, 0x00, 0x00]);
   return Buffer.concat([header, payload]);
 }
 
@@ -189,6 +196,26 @@ describe("protocol-probe", () => {
       timeoutMs: 100,
     });
     expect(variant).toBe("esci2-plain");
+  });
+
+  it("returns esci when TLS fails and plain-TCP welcome carries the WF-3620 discriminator (payload[2]=0x02)", async () => {
+    // Regression guard: a real WF-3620 emits an unsolicited 0x8000 welcome
+    // on plain TCP (every wf-3620 fixture under tools/pcap-extract/captures/
+    // begins with one). The plain-esci2 arm must reject it on the byte-2
+    // discriminator and fall through to the legacy ESC @ probe.
+    vi.spyOn(tls, "connect").mockReturnValue(tlsError("ERR_SSL_WRONG_VERSION_NUMBER"));
+    mockNetConnect(
+      new FakeNetSocket({ kind: "welcome", bytes: welcomeBytes(0x02) }), // WF-3620 shape
+      new FakeNetSocket({ kind: "ack", bytes: Buffer.from([0x06]) }), // legacy probe ACKs
+    );
+
+    const variant = await detectVariant({
+      printerIp: "10.0.0.9",
+      port: 1865,
+      override: "auto",
+      timeoutMs: 50,
+    });
+    expect(variant).toBe("esci");
   });
 
   it("returns esci when TLS fails, plain-TCP gives no welcome, and ESC @ ACKs", async () => {

--- a/src/protocol-probe.test.ts
+++ b/src/protocol-probe.test.ts
@@ -112,11 +112,13 @@ class FakeNetSocket extends EventEmitter {
 
 /**
  * Build an `IS` welcome frame: 12-byte header, type=0x8000, payload size 5.
- * Payload shape matches real fixtures: `00 01 <discriminator> 00 00`.
- *   - `discriminator = 0x04` → ET-2750 (default, matches
- *     `tools/pcap-extract/captures/et-2750/flatbed-single-page-pdf.jsonl`).
- *   - `discriminator = 0x02` → WF-3620 (matches every capture in
- *     `tools/pcap-extract/captures/wf-3620/`).
+ * Payload shape matches real fixtures: `01 <discriminator> 00 00 00`.
+ * The discriminator sits at payload[1] / frame offset 13 — verified against
+ *   - `tools/pcap-extract/captures/et-2750/flatbed-single-page-pdf.jsonl`
+ *     line 1: `49538000300c0000000500000104000000` (discriminator = 0x04)
+ *   - `tools/pcap-extract/captures/wf-3620/*.jsonl` line 1
+ *     (e.g. `adf-single-page-jpeg.jsonl`):
+ *     `49538000300c0000000500000102000000` (discriminator = 0x02)
  */
 function welcomeBytes(discriminator: number = 0x04): Buffer {
   const header = Buffer.alloc(12);
@@ -125,9 +127,15 @@ function welcomeBytes(discriminator: number = 0x04): Buffer {
   header.writeUInt16BE(0x8000, 2);
   header.writeUInt16BE(0x300c, 4);
   header.writeUInt32BE(5, 6);
-  const payload = Buffer.from([0x00, 0x01, discriminator, 0x00, 0x00]);
+  const payload = Buffer.from([0x01, discriminator, 0x00, 0x00, 0x00]);
   return Buffer.concat([header, payload]);
 }
+
+/** Real fixture welcomes — load the literal first line from each pcap fixture
+ * and feed THOSE bytes through the probe. Anchors the test to wire reality so
+ * an off-by-one in `welcomeBytes()` (or in the probe) can't go undetected. */
+const WF3620_REAL_WELCOME_HEX = "49538000300c0000000500000102000000";
+const ET2750_REAL_WELCOME_HEX = "49538000300c0000000500000104000000";
 
 /** Install a `net.connect` mock that hands out the given fakes in order. */
 function mockNetConnect(...fakes: FakeNetSocket[]): void {
@@ -198,11 +206,11 @@ describe("protocol-probe", () => {
     expect(variant).toBe("esci2-plain");
   });
 
-  it("returns esci when TLS fails and plain-TCP welcome carries the WF-3620 discriminator (payload[2]=0x02)", async () => {
+  it("returns esci when TLS fails and plain-TCP welcome carries the WF-3620 discriminator (synthetic frame)", async () => {
     // Regression guard: a real WF-3620 emits an unsolicited 0x8000 welcome
     // on plain TCP (every wf-3620 fixture under tools/pcap-extract/captures/
-    // begins with one). The plain-esci2 arm must reject it on the byte-2
-    // discriminator and fall through to the legacy ESC @ probe.
+    // begins with one). The plain-esci2 arm must reject it on the
+    // payload[1] discriminator and fall through to the legacy ESC @ probe.
     vi.spyOn(tls, "connect").mockReturnValue(tlsError("ERR_SSL_WRONG_VERSION_NUMBER"));
     mockNetConnect(
       new FakeNetSocket({ kind: "welcome", bytes: welcomeBytes(0x02) }), // WF-3620 shape
@@ -216,6 +224,47 @@ describe("protocol-probe", () => {
       timeoutMs: 50,
     });
     expect(variant).toBe("esci");
+  });
+
+  it("returns esci when fed the actual WF-3620 fixture welcome bytes (wire-anchored regression)", async () => {
+    // Strongest anchor: feed the literal first IS frame from a committed
+    // WF-3620 pcap-extract fixture into the probe. If `welcomeBytes()` ever
+    // drifts off by a byte (or the probe reads the wrong offset), this
+    // test fails because synthetic and real shapes diverge.
+    vi.spyOn(tls, "connect").mockReturnValue(tlsError("ERR_SSL_WRONG_VERSION_NUMBER"));
+    mockNetConnect(
+      new FakeNetSocket({
+        kind: "welcome",
+        bytes: Buffer.from(WF3620_REAL_WELCOME_HEX, "hex"),
+      }),
+      new FakeNetSocket({ kind: "ack", bytes: Buffer.from([0x06]) }),
+    );
+
+    const variant = await detectVariant({
+      printerIp: "10.0.0.10",
+      port: 1865,
+      override: "auto",
+      timeoutMs: 50,
+    });
+    expect(variant).toBe("esci");
+  });
+
+  it("returns esci2-plain when fed the actual ET-2750 fixture welcome bytes (wire-anchored regression)", async () => {
+    vi.spyOn(tls, "connect").mockReturnValue(tlsError("ERR_SSL_WRONG_VERSION_NUMBER"));
+    mockNetConnect(
+      new FakeNetSocket({
+        kind: "welcome",
+        bytes: Buffer.from(ET2750_REAL_WELCOME_HEX, "hex"),
+      }),
+    );
+
+    const variant = await detectVariant({
+      printerIp: "10.0.0.11",
+      port: 1865,
+      override: "auto",
+      timeoutMs: 50,
+    });
+    expect(variant).toBe("esci2-plain");
   });
 
   it("returns esci when TLS fails, plain-TCP gives no welcome, and ESC @ ACKs", async () => {

--- a/src/protocol-probe.ts
+++ b/src/protocol-probe.ts
@@ -118,7 +118,8 @@ function probeTls(host: string, port: number, timeoutMs: number): Promise<boolea
 }
 
 /** WF-3620 family discriminator at IS-`0x8000` payload byte 2 (frame offset 14).
- * Stable across 11 captured WF-3620 sessions; ET-2750 emits `0x04` here. */
+ * Stable across every committed WF-3620 fixture in
+ * `tools/pcap-extract/captures/wf-3620/`; ET-2750 emits `0x04` here. */
 const WF3620_WELCOME_DISCRIMINATOR = 0x02;
 
 /**
@@ -133,10 +134,11 @@ const WF3620_WELCOME_DISCRIMINATOR = 0x02;
  * Returns true on any `0x8000` welcome whose payload byte 2 is NOT the
  * WF-3620 marker; false on the WF-3620 marker, timeout, connection
  * refused, peer RST, or any other inbound type. The negative-form check
- * is deliberate: we have one ET-2750 capture but eleven WF-3620 captures,
- * so the WF-3620 byte is the better-evidenced anchor. A future ET-2750-
- * class device that emits something other than `0x04` here is still
- * accepted, as long as it isn't the WF-3620 shape.
+ * is deliberate: the WF-3620 byte is consistent across every committed
+ * WF-3620 fixture, while we have only one ET-2750 capture, so the WF-3620
+ * byte is the better-evidenced anchor. A future ET-2750-class device that
+ * emits something other than `0x04` here is still accepted, as long as
+ * it isn't the WF-3620 shape.
  */
 function probePlainEsci2(host: string, port: number, timeoutMs: number): Promise<boolean> {
   return new Promise((resolve) => {

--- a/src/protocol-probe.ts
+++ b/src/protocol-probe.ts
@@ -117,23 +117,26 @@ function probeTls(host: string, port: number, timeoutMs: number): Promise<boolea
   });
 }
 
+/** WF-3620 family discriminator at IS-`0x8000` payload byte 2 (frame offset 14).
+ * Stable across 11 captured WF-3620 sessions; ET-2750 emits `0x04` here. */
+const WF3620_WELCOME_DISCRIMINATOR = 0x02;
+
 /**
- * Plain-TCP probe: connect, then wait for an inbound IS frame. ET-2750
- * sends an unsolicited `0x8000` welcome packet (5-byte payload)
- * immediately after the TCP handshake completes. WF-3620 doesn't send
- * anything until it receives `ESC @` — so on a legacy printer this
- * probe times out, returns false, and the caller falls through to the
- * legacy probe. (ET-4950 also sends a welcome immediately, but only
- * inside its TLS tunnel; this plain-TCP arm doesn't see it — connecting
- * to an ET-4950 over plain TCP yields no `0x8000` and the arm times
- * out, so this arm matches ET-2750-class hardware only.)
+ * Plain-TCP probe: connect, then wait for an inbound IS-`0x8000` welcome
+ * frame. Both ET-2750 and WF-3620 emit one unsolicited on TCP connect
+ * (the original plan to use the welcome's *presence* as the ET-2750
+ * signal turned out wrong — the WF-3620 emits one too). Disambiguates by
+ * the welcome's payload byte 2: WF-3620 = `0x02`, ET-2750 = `0x04`. ET-4950
+ * also sends a welcome immediately, but only inside its TLS tunnel; this
+ * plain-TCP arm doesn't see it.
  *
- * Returns true if a `0x8000` IS frame is observed within `timeoutMs`,
- * false otherwise (timeout, connection refused, peer RST, or any other
- * inbound type). Only the IS magic and type field are validated; the
- * offset-4 data-offset byte is `0x300C` on the printer side for both
- * ET-2750 and ET-4950 (host-side is always `0x000C`), so it carries no
- * disambiguating signal and the parser ignores it.
+ * Returns true on any `0x8000` welcome whose payload byte 2 is NOT the
+ * WF-3620 marker; false on the WF-3620 marker, timeout, connection
+ * refused, peer RST, or any other inbound type. The negative-form check
+ * is deliberate: we have one ET-2750 capture but eleven WF-3620 captures,
+ * so the WF-3620 byte is the better-evidenced anchor. A future ET-2750-
+ * class device that emits something other than `0x04` here is still
+ * accepted, as long as it isn't the WF-3620 shape.
  */
 function probePlainEsci2(host: string, port: number, timeoutMs: number): Promise<boolean> {
   return new Promise((resolve) => {
@@ -167,18 +170,23 @@ function probePlainEsci2(host: string, port: number, timeoutMs: number): Promise
     socket.on("data", (chunk: Buffer) => {
       recvChunks.push(chunk);
       recvBytes += chunk.length;
-      if (recvBytes < 12) return; // need full IS header before deciding
+      // Need 12 bytes (IS header) + 3 payload bytes to read the
+      // family-discriminator at payload[2] (frame offset 14).
+      if (recvBytes < 15) return;
       const head = recvChunks.length === 1 ? recvChunks[0] : Buffer.concat(recvChunks, recvBytes);
       const isMagic = head[0] === 0x49 && head[1] === 0x53;
       const type = head.readUInt16BE(2);
-      const isWelcome = isMagic && type === 0x8000;
-      settle(isWelcome, () => {
+      const discriminator = head[14];
+      const isEsci2Welcome =
+        isMagic && type === 0x8000 && discriminator !== WF3620_WELCOME_DISCRIMINATOR;
+      settle(isEsci2Welcome, () => {
         clearTimeout(timer);
         socket.destroy();
-        if (!isWelcome) {
+        if (!isEsci2Welcome) {
           const typeHex = `0x${type.toString(16).padStart(4, "0")}`;
+          const discHex = `0x${discriminator.toString(16).padStart(2, "0")}`;
           log.debug(
-            `Plain-esci2 probe got non-welcome packet from ${host}:${port}: magic=${isMagic} type=${typeHex}`,
+            `Plain-esci2 probe got non-esci2-welcome packet from ${host}:${port}: magic=${isMagic} type=${typeHex} payload[2]=${discHex}`,
           );
         }
       });

--- a/src/protocol-probe.ts
+++ b/src/protocol-probe.ts
@@ -117,9 +117,11 @@ function probeTls(host: string, port: number, timeoutMs: number): Promise<boolea
   });
 }
 
-/** WF-3620 family discriminator at IS-`0x8000` payload byte 2 (frame offset 14).
+/** WF-3620 family discriminator at IS-`0x8000` payload byte 1 (frame offset 13).
  * Stable across every committed WF-3620 fixture in
- * `tools/pcap-extract/captures/wf-3620/`; ET-2750 emits `0x04` here. */
+ * `tools/pcap-extract/captures/wf-3620/`; ET-2750 emits `0x04` here.
+ * Real fixture payloads are `01 02 00 00 00` (WF-3620) and `01 04 00 00 00`
+ * (ET-2750); the discriminator is the second byte. */
 const WF3620_WELCOME_DISCRIMINATOR = 0x02;
 
 /**
@@ -127,11 +129,11 @@ const WF3620_WELCOME_DISCRIMINATOR = 0x02;
  * frame. Both ET-2750 and WF-3620 emit one unsolicited on TCP connect
  * (the original plan to use the welcome's *presence* as the ET-2750
  * signal turned out wrong — the WF-3620 emits one too). Disambiguates by
- * the welcome's payload byte 2: WF-3620 = `0x02`, ET-2750 = `0x04`. ET-4950
+ * the welcome's payload byte 1: WF-3620 = `0x02`, ET-2750 = `0x04`. ET-4950
  * also sends a welcome immediately, but only inside its TLS tunnel; this
  * plain-TCP arm doesn't see it.
  *
- * Returns true on any `0x8000` welcome whose payload byte 2 is NOT the
+ * Returns true on any `0x8000` welcome whose payload byte 1 is NOT the
  * WF-3620 marker; false on the WF-3620 marker, timeout, connection
  * refused, peer RST, or any other inbound type. The negative-form check
  * is deliberate: the WF-3620 byte is consistent across every committed
@@ -172,13 +174,13 @@ function probePlainEsci2(host: string, port: number, timeoutMs: number): Promise
     socket.on("data", (chunk: Buffer) => {
       recvChunks.push(chunk);
       recvBytes += chunk.length;
-      // Need 12 bytes (IS header) + 3 payload bytes to read the
-      // family-discriminator at payload[2] (frame offset 14).
-      if (recvBytes < 15) return;
+      // Need 12 bytes (IS header) + 2 payload bytes to read the
+      // family-discriminator at payload[1] (frame offset 13).
+      if (recvBytes < 14) return;
       const head = recvChunks.length === 1 ? recvChunks[0] : Buffer.concat(recvChunks, recvBytes);
       const isMagic = head[0] === 0x49 && head[1] === 0x53;
       const type = head.readUInt16BE(2);
-      const discriminator = head[14];
+      const discriminator = head[13];
       const isEsci2Welcome =
         isMagic && type === 0x8000 && discriminator !== WF3620_WELCOME_DISCRIMINATOR;
       settle(isEsci2Welcome, () => {
@@ -188,7 +190,7 @@ function probePlainEsci2(host: string, port: number, timeoutMs: number): Promise
           const typeHex = `0x${type.toString(16).padStart(4, "0")}`;
           const discHex = `0x${discriminator.toString(16).padStart(2, "0")}`;
           log.debug(
-            `Plain-esci2 probe got non-esci2-welcome packet from ${host}:${port}: magic=${isMagic} type=${typeHex} payload[2]=${discHex}`,
+            `Plain-esci2 probe got non-esci2-welcome packet from ${host}:${port}: magic=${isMagic} type=${typeHex} payload[1]=${discHex}`,
           );
         }
       });


### PR DESCRIPTION
## Summary

- **Code fix**: the auto-probe's plain-TCP arm assumed the WF-3620 stayed silent on plain TCP until prompted with `ESC @`, and accepted any unsolicited IS-`0x8000` welcome as `esci2-plain`. Committed WF-3620 fixtures show the printer actually emits an unsolicited welcome on TCP connect (just like the ET-2750), so an `auto`-probed real WF-3620 would have misclassified as `esci2-plain` and hard-failed at the first ESC/I-2 command. Disambiguated by the welcome's payload byte 2: WF-3620 = `0x02` (stable across all 11 captured sessions), ET-2750 = `0x04`. Negative-form check (accept any non-WF-3620 byte) so future ET-2750-class devices that emit a different value still match.
- **New regression test**: drives a WF-3620-shape welcome through arm 2 and asserts fall-through to `esci`. Also corrects an off-by-one in the test's synthetic welcome payload (was `00 00 01 04 00`, real fixture is `00 01 04 00 00`); the discrepancy was masked because the old probe ignored payload bytes entirely.
- **Doc audit**: a three-agent audit of `docs/HOW-IT-WORKS.md` (corroborated by a fourth) surfaced ~12 factual inaccuracies and several clarification gaps against current source. Folded in — see commit message for the full list. Notable fixes: scope mentions Paperless; push-scan parse-then-respond ordering corrected; ESC/I path no longer described as "no LOCK/UNLOCK on the wire"; async `0x9000` handler scope limited to ESC/I-2; PARA failure token `#parNG` not `#parFAIL`; WF-3620 wire pixels are GBR not RGB; replay-test guarantees split (byte-for-byte for TLS, behavioural for pcap); test count updated 481 → 482.

## Test plan

- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` — 482 passing, 1 skipped (was 481+1; the new probe negative test accounts for the +1)
- [x] New probe test verified to fail without the code fix and pass with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)