### PR TITLE
test: dispatcher routing + finalize-tail Paperless + PDF fallback coverage

### DIFF
--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -492,7 +492,7 @@ Reverse-engineering artifacts:
 
 ## Testing
 
-The test suite uses Vitest and runs with `npm test` (484 passing tests plus 1 skipped test across 25 files, completing in roughly 5 seconds).
+The test suite uses Vitest and runs with `npm test` (494 passing tests plus 1 skipped test across 26 files, completing in roughly 5 seconds).
 
 **The replay harnesses** are the most important test files. They run in two modes — see [The byte-for-byte replay test](#the-byte-for-byte-replay-test) above for the full account. In short: `src/esci2/scanner.test.ts` runs `runEsci2Scan` against a `FakeTlsSocket` for the ET-4950 Frida captures and asserts byte-for-byte equality on every host send; for the ET-2750 (`runEsci2ScanOverPlain` against `FakePlainSocket`) the harness feeds only printer-side fixture events and asserts on-disk output, not host-byte equality. `src/esci/scanner.test.ts` follows the same behavioural pattern for the WF-3620 ESC/I path using pcap-derived JSONL fixtures. On-disk output is asserted in both modes — JPEG files for JPG-mode runs (including EXIF orientation verification), and a composed PDF for PDF-mode runs (including page count and `/Rotate` metadata on back pages).
 
@@ -501,6 +501,7 @@ The test suite uses Vitest and runs with `npm test` (484 passing tests plus 1 sk
 - `src/scan-session.test.ts` — engine pump: graph dispatch, decision-state evaluation, flushPage barrier, settlement lifecycle, IS-payload sanity-cap, `bypassIgnoreFilter` per-state opt-out.
 - `src/protocol.test.ts` — IS-frame encode/decode round-trips, all packet builder variants.
 - `src/protocol-probe.test.ts` — three-arm probe (TLS / plain-TCP-welcome / `ESC @`), cache rules, override paths.
+- `src/startup.test.ts` — `dispatchScanSession` routing: each `Variant` selects the right scanner shell and threads config fields (`scanDestId`, `tempDir`, `printerCertFingerprint`, `esciForceSource`, `jpegQuality`, `diagnoseProtocol`, `paperless`) through correctly.
 - `src/keepalive.test.ts` — announcement parsing, keepalive packet construction, burst timing.
 - `src/pushscan.test.ts` — SOAP request parsing, `PushScanIDIn` decoding, `x-uid` echo, action resolution.
 - `src/esci2/commands.test.ts` — ESC/I-2 command builders, PARA payload byte-exact assertions (TLS + plain), token parser.
@@ -510,7 +511,7 @@ The test suite uses Vitest and runs with `npm test` (484 passing tests plus 1 sk
 - `src/esci/graph.test.ts` — ESC/I graph shape, STATUS_2 source-detect, gamma cycle, IMG_RECEIVING flush logic.
 - `src/esci/raw-to-jpeg.test.ts` — raw 24-bit GBR → RGB permutation + JPEG encoding round-trip.
 - `src/esci/scanner-diagnose.test.ts` — `DIAGNOSE_PROTOCOL` mode: ESC @ NAK + FS Y probe behaviour.
-- `src/output-tail.test.ts` — finalize pipeline (JPG promote, PDF compose, temp-dir cleanup on failure). Paperless upload coverage is in `src/paperless-upload.test.ts`.
+- `src/output-tail.test.ts` — finalize pipeline (JPG promote, PDF compose, PDF compose-failure → JPG fallback, Paperless upload boundary, temp-dir cleanup on failure). Per-upload mechanics live in `src/paperless-upload.test.ts`.
 - `src/output.test.ts` — filename generation, sorted page file enumeration.
 - `src/paperless-upload.test.ts` — multipart POST, retention-flag handling, error paths.
 - `src/pdf.test.ts` — PDF composition from sample JPEGs, page-count and rotation assertions.

--- a/src/output-tail.test.ts
+++ b/src/output-tail.test.ts
@@ -1,10 +1,24 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
+
+vi.mock("./paperless-upload.js", () => ({
+  uploadAllToPaperless: vi.fn(() => Promise.resolve()),
+}));
+
 import { finalizeSession } from "./output-tail.js";
+import { uploadAllToPaperless, type PaperlessUploadOptions } from "./paperless-upload.js";
 
 const SAMPLE_JPEG_PATH = "test-fixtures/sample-page.jpg";
+
+const PAPERLESS_OPTS: PaperlessUploadOptions = {
+  url: "http://paperless.test",
+  token: "test-token",
+  deleteAfterUpload: true,
+};
+
+const uploadMock = vi.mocked(uploadAllToPaperless);
 
 describe("output-tail", () => {
   let tempDir: string;
@@ -13,6 +27,7 @@ describe("output-tail", () => {
   beforeEach(() => {
     tempDir = mkdtempSync(path.join(os.tmpdir(), "out-tail-tmp-"));
     outputDir = mkdtempSync(path.join(os.tmpdir(), "out-tail-out-"));
+    uploadMock.mockReset().mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -58,6 +73,92 @@ describe("output-tail", () => {
     const files = readdirSync(outputDir);
     expect(files).toHaveLength(1);
     expect(files[0]).toMatch(/^scan_2026-02-02_020202\.pdf$/);
+  });
+
+  it("uploads JPG outputs to Paperless when paperless options are configured", async () => {
+    const fakeJpeg = Buffer.from("ffd8ffe000104a464946", "hex");
+    writeFileSync(path.join(tempDir, "page_001.jpg"), fakeJpeg);
+    writeFileSync(path.join(tempDir, "page_002.jpg"), fakeJpeg);
+
+    await finalizeSession({
+      sessionTempDir: tempDir,
+      outputDir,
+      sessionTs: new Date("2026-03-03T03:03:03Z"),
+      action: "jpg",
+      backPageIndices: [],
+      paperless: PAPERLESS_OPTS,
+    });
+
+    expect(uploadMock).toHaveBeenCalledTimes(1);
+    const [paths, opts] = uploadMock.mock.calls[0];
+    expect(paths).toHaveLength(2);
+    expect(paths[0]).toMatch(/scan_2026-03-03_030303_01\.jpg$/);
+    expect(paths[1]).toMatch(/scan_2026-03-03_030303_02\.jpg$/);
+    expect(opts).toBe(PAPERLESS_OPTS);
+  });
+
+  it("uploads composed PDF to Paperless when paperless options are configured", async () => {
+    const sampleJpeg = readFileSync(SAMPLE_JPEG_PATH);
+    writeFileSync(path.join(tempDir, "page_001.jpg"), sampleJpeg);
+
+    await finalizeSession({
+      sessionTempDir: tempDir,
+      outputDir,
+      sessionTs: new Date("2026-04-04T04:04:04Z"),
+      action: "pdf",
+      backPageIndices: [],
+      paperless: PAPERLESS_OPTS,
+    });
+
+    expect(uploadMock).toHaveBeenCalledTimes(1);
+    const [paths] = uploadMock.mock.calls[0];
+    expect(paths).toHaveLength(1);
+    expect(paths[0]).toMatch(/scan_2026-04-04_040404\.pdf$/);
+  });
+
+  it("does NOT call paperless upload when paperless options are undefined", async () => {
+    const fakeJpeg = Buffer.from("ffd8ffe000104a464946", "hex");
+    writeFileSync(path.join(tempDir, "page_001.jpg"), fakeJpeg);
+
+    await finalizeSession({
+      sessionTempDir: tempDir,
+      outputDir,
+      sessionTs: new Date("2026-05-05T05:05:05Z"),
+      action: "jpg",
+      backPageIndices: [],
+      paperless: undefined,
+    });
+
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to JPG promote when PDF composition fails (and uploads the JPGs)", async () => {
+    // Write a 4-byte non-JPEG "ffd8ffd9" — pdf-lib's embedJpg will reject
+    // it because there's no SOF segment. The output-tail catch should kick
+    // in and run the JPG fallback path.
+    const garbage = Buffer.from("ffd8ffd9", "hex");
+    writeFileSync(path.join(tempDir, "page_001.jpg"), garbage);
+
+    await finalizeSession({
+      sessionTempDir: tempDir,
+      outputDir,
+      sessionTs: new Date("2026-06-06T06:06:06Z"),
+      action: "pdf",
+      backPageIndices: [],
+      paperless: PAPERLESS_OPTS,
+    });
+
+    // No PDF was produced — the fallback wrote a JPG.
+    const files = readdirSync(outputDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^scan_2026-06-06_060606\.jpg$/);
+    expect(readFileSync(path.join(outputDir, files[0]))).toEqual(garbage);
+
+    // Paperless upload sees the JPG fallback path, not a PDF.
+    expect(uploadMock).toHaveBeenCalledTimes(1);
+    const [paths] = uploadMock.mock.calls[0];
+    expect(paths).toHaveLength(1);
+    expect(paths[0]).toMatch(/\.jpg$/);
   });
 
   it("removes the temp dir even when promotion fails", async () => {

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./protocol-probe.js", () => ({
+  detectVariant: vi.fn(),
+}));
+vi.mock("./esci2/scanner.js", () => ({
+  runEsci2Scan: vi.fn(() => Promise.resolve()),
+  runEsci2ScanOverPlain: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("./esci/scanner.js", () => ({
+  runEsciScan: vi.fn(() => Promise.resolve()),
+}));
+
+import { dispatchScanSession } from "./startup.js";
+import { detectVariant } from "./protocol-probe.js";
+import { runEsci2Scan, runEsci2ScanOverPlain } from "./esci2/scanner.js";
+import { runEsciScan } from "./esci/scanner.js";
+import type { Config } from "./config.js";
+import type { PaperlessUploadOptions } from "./paperless-upload.js";
+
+const detectVariantMock = vi.mocked(detectVariant);
+const runEsci2ScanMock = vi.mocked(runEsci2Scan);
+const runEsci2ScanOverPlainMock = vi.mocked(runEsci2ScanOverPlain);
+const runEsciScanMock = vi.mocked(runEsciScan);
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    printerIp: "192.0.2.5",
+    scanDestName: "Paperless",
+    scanDestId: 0x02,
+    outputDir: "/test-output",
+    healthPort: 3000,
+    logLevel: "info",
+    logFormat: "text",
+    language: "en",
+    jpegQuality: 90,
+    previewAction: "reject",
+    printerProtocol: "auto",
+    diagnoseProtocol: false,
+    tempDir: "",
+    shutdownTimeoutMs: 30000,
+    paperlessDeleteAfterUpload: true,
+    ...overrides,
+  };
+}
+
+const PAPERLESS_OPTS: PaperlessUploadOptions = {
+  url: "http://paperless.test",
+  token: "test-token",
+  deleteAfterUpload: true,
+};
+
+describe("dispatchScanSession", () => {
+  beforeEach(() => {
+    detectVariantMock.mockReset();
+    runEsci2ScanMock.mockReset().mockResolvedValue(undefined);
+    runEsci2ScanOverPlainMock.mockReset().mockResolvedValue(undefined);
+    runEsciScanMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("forwards the configured override + IP to detectVariant", async () => {
+    detectVariantMock.mockResolvedValue("esci2");
+    const config = makeConfig({ printerProtocol: "esci2", printerIp: "203.0.113.7" });
+    await dispatchScanSession({ config, duplex: false, action: "jpg", paperless: undefined });
+
+    expect(detectVariantMock).toHaveBeenCalledTimes(1);
+    expect(detectVariantMock).toHaveBeenCalledWith({
+      printerIp: "203.0.113.7",
+      port: 1865,
+      override: "esci2",
+      timeoutMs: 3000,
+    });
+  });
+
+  it("variant=esci2 routes to runEsci2Scan with cert fingerprint threaded through", async () => {
+    detectVariantMock.mockResolvedValue("esci2");
+    const fp =
+      "AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89:AB:CD:EF:01:23:45:67:89";
+    const config = makeConfig({
+      printerProtocol: "esci2",
+      printerCertFingerprint: fp,
+      tempDir: "/tmp/scan",
+      scanDestId: 0x05,
+    });
+    await dispatchScanSession({
+      config,
+      duplex: true,
+      action: "pdf",
+      paperless: PAPERLESS_OPTS,
+    });
+
+    expect(runEsci2ScanMock).toHaveBeenCalledTimes(1);
+    expect(runEsci2ScanOverPlainMock).not.toHaveBeenCalled();
+    expect(runEsciScanMock).not.toHaveBeenCalled();
+    expect(runEsci2ScanMock).toHaveBeenCalledWith({
+      printerIp: "192.0.2.5",
+      port: 1865,
+      destId: 0x05,
+      outputDir: "/test-output",
+      tempDir: "/tmp/scan",
+      duplex: true,
+      action: "pdf",
+      paperless: PAPERLESS_OPTS,
+      printerCertFingerprint: fp,
+    });
+  });
+
+  it("variant=esci2-plain routes to runEsci2ScanOverPlain WITHOUT cert fingerprint", async () => {
+    detectVariantMock.mockResolvedValue("esci2-plain");
+    const config = makeConfig({ printerProtocol: "esci2-plain" });
+    await dispatchScanSession({
+      config,
+      duplex: false,
+      action: "jpg",
+      paperless: PAPERLESS_OPTS,
+    });
+
+    expect(runEsci2ScanOverPlainMock).toHaveBeenCalledTimes(1);
+    expect(runEsci2ScanMock).not.toHaveBeenCalled();
+    expect(runEsciScanMock).not.toHaveBeenCalled();
+    const call = runEsci2ScanOverPlainMock.mock.calls[0][0];
+    expect(call).not.toHaveProperty("printerCertFingerprint");
+    expect(call.paperless).toBe(PAPERLESS_OPTS);
+    expect(call.duplex).toBe(false);
+    expect(call.action).toBe("jpg");
+  });
+
+  it("variant=esci routes to runEsciScan with forcedSource + jpegQuality + diagnoseProtocol", async () => {
+    detectVariantMock.mockResolvedValue("esci");
+    const config = makeConfig({
+      printerProtocol: "esci",
+      esciForceSource: "adf-duplex",
+      jpegQuality: 75,
+      diagnoseProtocol: true,
+    });
+    await dispatchScanSession({
+      config,
+      duplex: true,
+      action: "pdf",
+      paperless: PAPERLESS_OPTS,
+    });
+
+    expect(runEsciScanMock).toHaveBeenCalledTimes(1);
+    expect(runEsci2ScanMock).not.toHaveBeenCalled();
+    expect(runEsci2ScanOverPlainMock).not.toHaveBeenCalled();
+    expect(runEsciScanMock).toHaveBeenCalledWith({
+      printerIp: "192.0.2.5",
+      port: 1865,
+      outputDir: "/test-output",
+      tempDir: "",
+      duplex: true,
+      forcedSource: "adf-duplex",
+      format: "pdf",
+      jpegQuality: 75,
+      paperless: PAPERLESS_OPTS,
+      diagnoseProtocol: true,
+    });
+  });
+
+  it("variant=esci passes forcedSource=null when esciForceSource is unset", async () => {
+    detectVariantMock.mockResolvedValue("esci");
+    const config = makeConfig({ printerProtocol: "esci" });
+    await dispatchScanSession({ config, duplex: false, action: "jpg", paperless: undefined });
+
+    const call = runEsciScanMock.mock.calls[0][0];
+    expect(call.forcedSource).toBeNull();
+  });
+
+  it("propagates scanner rejection to the caller", async () => {
+    detectVariantMock.mockResolvedValue("esci2");
+    const boom = new Error("scan failed");
+    runEsci2ScanMock.mockRejectedValueOnce(boom);
+    const config = makeConfig({ printerProtocol: "esci2" });
+
+    await expect(
+      dispatchScanSession({ config, duplex: false, action: "jpg", paperless: undefined }),
+    ).rejects.toThrow("scan failed");
+  });
+});


### PR DESCRIPTION
## Summary

PR B of the v0.4.0 test audit. Closes the three **High-priority** gaps from [`.reference/reviews/2026-05-08-test-coverage-review.md`](https://github.com/mtheuma/epson2paperless/blob/dev/.reference/reviews/2026-05-08-test-coverage-review.md) by exercising boundaries that the existing suite treats as black boxes:

- **Dispatcher routing** — probe + scanners are tested separately, but the production handoff between them isn't.
- **`finalizeSession` + Paperless** — `paperless-upload.ts` covered below the finalize boundary, never with the boundary itself.
- **PDF fallback** — the JPG promote `try/finally` is covered; the PDF branch's compose-then-fall-back-to-JPG path isn't directly tested.

## What landed

### New `src/startup.test.ts` (6 tests)

Mocks `protocol-probe`, `esci2/scanner`, and `esci/scanner` modules; calls `dispatchScanSession` with each `Variant` and asserts the right scanner is called with the right fields:

- Probe call carries configured `printerProtocol` + `printerIp`.
- `esci2` → `runEsci2Scan` with `printerCertFingerprint` threaded through.
- `esci2-plain` → `runEsci2ScanOverPlain`, no `printerCertFingerprint` field passed.
- `esci` → `runEsciScan` with `forcedSource` / `format` / `jpegQuality` / `diagnoseProtocol`.
- `forcedSource` defaults to `null` when unset.
- Scanner rejection propagates to the dispatcher caller.

### Extended `src/output-tail.test.ts` (4 new tests, 7 total)

Mocks `paperless-upload.uploadAllToPaperless`:

- JPG action + Paperless options → upload called with the saved JPG paths and configured options.
- PDF action + Paperless options → upload called with the composed PDF path.
- Paperless options undefined → upload not called.
- **PDF compose-failure → JPG fallback path uploads the JPG.** Writing 4-byte non-JPEG bytes to `page_001.jpg` makes pdf-lib's `embedJpg` throw with `Offset is outside the bounds of the DataView`; the catch path runs JPG promote, writes the JPG to outputDir, and Paperless sees the JPG (not a phantom PDF).

## Coordination with PR #57

PR #57 (PR A: \`esci2-plain\` unit coverage, +3 tests) is in review and bumps the test count to 487. This PR (+10 tests) bumps the count to 494 from a base of 484. **The HOW-IT-WORKS.md test-count line will conflict on whichever PR merges second; the resolution is to add the deltas — final count after both: 497.**

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run format:check\`
- [x] \`npm test\` — 494 passing, 1 skipped (was 484+1; +6 startup, +4 output-tail)
- [x] PDF compose-failure path verified by log output during test run: \`PDF composition failed: Offset is outside the bounds of the DataView. Falling back to JPG output.\` followed by the JPG fallback completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)