### PR TITLE
test: tighten IPv4 validation + cover network.ts + fix Paperless retention doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If you'd rather POST scans straight into Paperless-ngx's API than drop them into
 | `PAPERLESS_TOKEN_FILE`          |                            | —       | Alternative to `PAPERLESS_TOKEN` — read the token from a file. For Docker secrets / Kubernetes. Takes precedence if both are set.            |
 | `PAPERLESS_DELETE_AFTER_UPLOAD` |                            | `true`  | Delete the local file after a successful upload. Set to `false` to keep a local copy.                                                        |
 
-When both URL and token are set, every scan is uploaded **after** the local file is written. The local file stays by default — the upload is additive. If the upload fails (network blip, Paperless-ngx down), the scan is still safe in `OUTPUT_DIR` and you can re-upload manually or fall back to the consume-folder path.
+When both URL and token are set, every scan is uploaded **after** the local file is written. By default the local file is removed once the upload succeeds; set `PAPERLESS_DELETE_AFTER_UPLOAD=false` to keep a copy alongside the upload. If the upload fails (network blip, Paperless-ngx down), the local file is preserved — the scan is safe in `OUTPUT_DIR` and you can re-upload manually or fall back to the consume-folder path.
 
 Multi-page ADF scans in JPG mode upload one document per page. Pick **PDF** on the printer panel if you'd rather have them grouped into a single Paperless-ngx document.
 

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -492,7 +492,7 @@ Reverse-engineering artifacts:
 
 ## Testing
 
-The test suite uses Vitest and runs with `npm test` (512 passing tests plus 1 skipped test across 27 files, completing in roughly 5 seconds).
+The test suite uses Vitest and runs with `npm test` (515 passing tests plus 1 skipped test across 27 files, completing in roughly 5 seconds).
 
 **The replay harnesses** are the most important test files. They run in two modes — see [The byte-for-byte replay test](#the-byte-for-byte-replay-test) above for the full account. In short: `src/esci2/scanner.test.ts` runs `runEsci2Scan` against a `FakeTlsSocket` for the ET-4950 Frida captures and asserts byte-for-byte equality on every host send; for the ET-2750 (`runEsci2ScanOverPlain` against `FakePlainSocket`) the harness feeds only printer-side fixture events and asserts on-disk output, not host-byte equality. `src/esci/scanner.test.ts` follows the same behavioural pattern for the WF-3620 ESC/I path using pcap-derived JSONL fixtures. On-disk output is asserted in both modes — JPEG files for JPG-mode runs (including EXIF orientation verification), and a composed PDF for PDF-mode runs (including page count and `/Rotate` metadata on back pages).
 

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -492,7 +492,7 @@ Reverse-engineering artifacts:
 
 ## Testing
 
-The test suite uses Vitest and runs with `npm test` (497 passing tests plus 1 skipped test across 26 files, completing in roughly 5 seconds).
+The test suite uses Vitest and runs with `npm test` (512 passing tests plus 1 skipped test across 27 files, completing in roughly 5 seconds).
 
 **The replay harnesses** are the most important test files. They run in two modes — see [The byte-for-byte replay test](#the-byte-for-byte-replay-test) above for the full account. In short: `src/esci2/scanner.test.ts` runs `runEsci2Scan` against a `FakeTlsSocket` for the ET-4950 Frida captures and asserts byte-for-byte equality on every host send; for the ET-2750 (`runEsci2ScanOverPlain` against `FakePlainSocket`) the harness feeds only printer-side fixture events and asserts on-disk output, not host-byte equality. `src/esci/scanner.test.ts` follows the same behavioural pattern for the WF-3620 ESC/I path using pcap-derived JSONL fixtures. On-disk output is asserted in both modes — JPEG files for JPG-mode runs (including EXIF orientation verification), and a composed PDF for PDF-mode runs (including page count and `/Rotate` metadata on back pages).
 
@@ -503,6 +503,7 @@ The test suite uses Vitest and runs with `npm test` (497 passing tests plus 1 sk
 - `src/protocol-probe.test.ts` — three-arm probe (TLS / plain-TCP-welcome / `ESC @`), cache rules, override paths.
 - `src/startup.test.ts` — `dispatchScanSession` routing: each `Variant` selects the right scanner shell and threads config fields (`scanDestId`, `tempDir`, `printerCertFingerprint`, `esciForceSource`, `jpegQuality`, `diagnoseProtocol`, `paperless`) through correctly.
 - `src/keepalive.test.ts` — announcement parsing, keepalive packet construction, burst timing.
+- `src/network.test.ts` — `getLocalIpForTarget` UDP `connect()` mock: success returns OS-selected local address; error path closes the socket and rejects with target-IP context.
 - `src/pushscan.test.ts` — SOAP request parsing, `PushScanIDIn` decoding, `x-uid` echo, action resolution.
 - `src/esci2/commands.test.ts` — ESC/I-2 command builders, PARA payload byte-exact assertions (TLS + plain), token parser.
 - `src/esci2/graph.test.ts` — ESC/I-2 graph shape, key state transitions, source-detect heuristic, `bypassIgnoreFilter` flags on POSTSCAN drains.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -69,6 +69,34 @@ describe("loadConfig", () => {
     expect(() => loadConfig()).toThrow();
   });
 
+  // Table-driven octet-range checks. The earlier regex `(\d{1,3}\.){3}\d{1,3}`
+  // accepted any 4-component dotted decimal regardless of octet value; that
+  // let `999.999.999.999` and similar through, only failing later at socket
+  // connect time with a far less helpful error. The tightened regex bounds
+  // each octet to 0-255 at config validation.
+  it.each([
+    ["256.0.0.0", "octet just above max"],
+    ["999.999.999.999", "all-out-of-range"],
+    ["0.0.0.300", "trailing octet over 255"],
+    ["1.2.3", "only three octets"],
+    ["1.2.3.4.5", "five components"],
+    ["", "empty string"],
+  ])("rejects PRINTER_IP=%s (%s)", (value) => {
+    process.env.PRINTER_IP = value;
+    expect(() => loadConfig()).toThrow(/PRINTER_IP/);
+  });
+
+  it.each([
+    ["0.0.0.0", "all zeros"],
+    ["255.255.255.255", "all max"],
+    ["192.168.1.1", "common LAN"],
+    ["10.0.0.255", "broadcast-end"],
+  ])("accepts PRINTER_IP=%s (%s)", (value) => {
+    process.env.PRINTER_IP = value;
+    const config = loadConfig();
+    expect(config.printerIp).toBe(value);
+  });
+
   it("defaults previewAction to 'reject'", () => {
     process.env.PRINTER_IP = "192.0.2.58";
     const config = loadConfig();

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -81,6 +81,13 @@ describe("loadConfig", () => {
     ["1.2.3", "only three octets"],
     ["1.2.3.4.5", "five components"],
     ["", "empty string"],
+    // Leading zeros: Node's dgram.connect() silently resolves these to
+    // 0.0.0.0 instead of the intended address, so a confusing "binds to
+    // 0.0.0.0" failure appears later in network.ts rather than a clear
+    // startup error. Reject at the config layer instead.
+    ["001.002.003.004", "leading zeros on every octet"],
+    ["192.168.01.1", "leading zero in third octet"],
+    ["010.0.0.1", "leading zero in first octet"],
   ])("rejects PRINTER_IP=%s (%s)", (value) => {
     process.env.PRINTER_IP = value;
     expect(() => loadConfig()).toThrow(/PRINTER_IP/);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,15 @@
 import { readFileSync } from "node:fs";
 import { z } from "zod";
 
-// IPv4 dotted-quad — each octet bounded to 0-255. Leading zeros allowed
-// for compatibility with operators who paste pre-formatted addresses.
+// IPv4 dotted-quad — each octet bounded to 0-255 with no leading zeros on
+// multi-digit values. Leading zeros are rejected at this layer because
+// Node's `dgram.connect()` does NOT treat strings like `001.002.003.004`
+// as IPv4 literals — it silently picks `0.0.0.0` as the local interface,
+// and `getLocalIpForTarget()` returns `0.0.0.0` rather than failing
+// loudly. Catching them here surfaces a clear "must be a valid IPv4
+// address" error at startup instead of a confusing late binding failure.
 const ipv4Regex =
-  /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+  /^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$/;
 
 const configSchema = z
   .object({

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from "node:fs";
 import { z } from "zod";
 
-const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}$/;
+// IPv4 dotted-quad — each octet bounded to 0-255. Leading zeros allowed
+// for compatibility with operators who paste pre-formatted addresses.
+const ipv4Regex =
+  /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
 
 const configSchema = z
   .object({

--- a/src/network.test.ts
+++ b/src/network.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import dgram from "node:dgram";
+import { getLocalIpForTarget } from "./network.js";
+
+/**
+ * Behaviorally-rich fake `dgram.Socket` for the UDP `connect()` path that
+ * `getLocalIpForTarget` uses to discover which local interface can reach
+ * a given target. Only the surface `getLocalIpForTarget` actually touches
+ * is modeled — `connect`, `address`, `close`, plus `'error'` events from
+ * the EventEmitter base.
+ */
+class FakeUdpSocket extends EventEmitter {
+  private behavior:
+    | { kind: "success"; localAddress: string }
+    | { kind: "error"; code: string; message: string };
+  closed = false;
+  connectCalls: { port: number; host: string }[] = [];
+
+  constructor(behavior: FakeUdpSocket["behavior"]) {
+    super();
+    this.behavior = behavior;
+  }
+
+  connect(port: number, host: string, cb: () => void): void {
+    this.connectCalls.push({ port, host });
+    if (this.behavior.kind === "success") {
+      // Real dgram.connect fires the callback async; mimic with setImmediate
+      // so getLocalIpForTarget's resolve + close ordering is realistic.
+      setImmediate(cb);
+    } else {
+      const err = new Error(this.behavior.message) as Error & { code?: string };
+      err.code = this.behavior.code;
+      setImmediate(() => this.emit("error", err));
+    }
+  }
+
+  address(): dgram.AddressInfo {
+    if (this.behavior.kind !== "success") {
+      throw new Error("FakeUdpSocket.address() called on error-path fake");
+    }
+    return { address: this.behavior.localAddress, family: "IPv4", port: 12345 };
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+function mockCreateSocket(fake: FakeUdpSocket): void {
+  vi.spyOn(dgram, "createSocket").mockImplementation(
+    (..._args: unknown[]) => fake as unknown as dgram.Socket,
+  );
+}
+
+describe("getLocalIpForTarget", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves with the local interface address chosen by the OS", async () => {
+    const fake = new FakeUdpSocket({ kind: "success", localAddress: "10.0.0.42" });
+    mockCreateSocket(fake);
+
+    await expect(getLocalIpForTarget("192.0.2.58")).resolves.toBe("10.0.0.42");
+    expect(fake.closed).toBe(true);
+    expect(fake.connectCalls).toEqual([{ port: 1, host: "192.0.2.58" }]);
+  });
+
+  it("rejects with target-IP context when the underlying socket errors", async () => {
+    const fake = new FakeUdpSocket({
+      kind: "error",
+      code: "EHOSTUNREACH",
+      message: "host is unreachable",
+    });
+    mockCreateSocket(fake);
+
+    await expect(getLocalIpForTarget("203.0.113.99")).rejects.toThrow(
+      /Cannot determine local IP for target 203\.0\.113\.99/,
+    );
+  });
+
+  it("includes the underlying error message in the rejection", async () => {
+    const fake = new FakeUdpSocket({
+      kind: "error",
+      code: "ENETUNREACH",
+      message: "network is unreachable",
+    });
+    mockCreateSocket(fake);
+
+    await expect(getLocalIpForTarget("198.51.100.1")).rejects.toThrow(/network is unreachable/);
+  });
+
+  it("closes the socket on the error path (no leak)", async () => {
+    const fake = new FakeUdpSocket({
+      kind: "error",
+      code: "EHOSTUNREACH",
+      message: "boom",
+    });
+    mockCreateSocket(fake);
+
+    await expect(getLocalIpForTarget("192.0.2.99")).rejects.toThrow();
+    expect(fake.closed).toBe(true);
+  });
+
+  it("requests an IPv4 socket from dgram.createSocket", async () => {
+    const fake = new FakeUdpSocket({ kind: "success", localAddress: "10.0.0.1" });
+    const spy = vi
+      .spyOn(dgram, "createSocket")
+      .mockImplementation((..._args: unknown[]) => fake as unknown as dgram.Socket);
+
+    await getLocalIpForTarget("192.0.2.5");
+    expect(spy).toHaveBeenCalledWith("udp4");
+  });
+});


### PR DESCRIPTION
## Summary

PR C of the v0.4.0 test audit. Closes the **Medium-priority** gaps from [`.reference/reviews/2026-05-08-test-coverage-review.md`](https://github.com/mtheuma/epson2paperless/blob/dev/.reference/reviews/2026-05-08-test-coverage-review.md) and a documentation inconsistency the same review surfaced.

## What landed

### IPv4 validation tightened (`src/config.ts` + `src/config.test.ts`)

The old regex `^(\d{1,3}\.){3}\d{1,3}$` accepted any four-component dotted decimal regardless of octet value, so `999.999.999.999`, `256.0.0.0`, `0.0.0.300` etc. all passed config validation and only failed later at socket-connect time with a far less helpful error.

New regex bounds each octet to 0-255:

```
/^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
```

Leading zeros are still allowed (defensive — operators sometimes paste zero-padded addresses).

Table-driven tests in `src/config.test.ts`:
- Rejects: `256.0.0.0`, `999.999.999.999`, `0.0.0.300`, `1.2.3` (only three octets), `1.2.3.4.5` (five components), empty string.
- Accepts: `0.0.0.0`, `255.255.255.255`, `192.168.1.1`, `10.0.0.255`.

### `src/network.test.ts` (new, 5 tests)

`getLocalIpForTarget` was the largest untested module — the UDP `connect()` trick that picks which local interface can reach the printer. Mocked `dgram.createSocket` with a `FakeUdpSocket` that mirrors the surface `getLocalIpForTarget` actually uses:

- Success path resolves with the OS-selected local address.
- Error path rejects with target-IP context wrapping the underlying socket error.
- Underlying error message survives the rejection (e.g. `EHOSTUNREACH` / `ENETUNREACH`).
- Socket is closed on the error path (no leak).
- IPv4 socket type is requested.

### README Paperless retention doc fix

The Paperless section had a contradiction the reviewer caught: the env-var table row says \`PAPERLESS_DELETE_AFTER_UPLOAD\` defaults to \`true\` (matches code at [`src/config.ts:33`](src/config.ts:33)), but the explanatory paragraph below claimed *\"the local file stays by default — the upload is additive.\"* Reworded the paragraph to match the actual default: the local file is removed once the upload succeeds; failed uploads preserve the local file. The \"additive\" framing dropped because it was conflating two concepts (consume-folder fallback compat vs file retention).

## Coordination with PRs #57 and #58

This PR branches from \`dev\` (pre-PR-A and pre-PR-B) and bumps the test count 484 → 499. Whichever of #57 / #58 / #59 merges last will hit a one-line conflict on the test-count blurb in \`docs/HOW-IT-WORKS.md\`; resolution is mechanical (add the deltas — final count after all three: 512).

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run format:check\`
- [x] \`npm test\` — 499 passing, 1 skipped (was 484+1; +10 config table-driven, +5 network)
- [x] Spot-checked the regex by running with \`PRINTER_IP=999.999.999.999\`: rejected with \"PRINTER_IP must be a valid IPv4 address\" before any socket activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)