### PR TITLE
fix(output-tail): guard Paperless upload boundary against rejection

### DIFF
--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -492,7 +492,7 @@ Reverse-engineering artifacts:
 
 ## Testing
 
-The test suite uses Vitest and runs with `npm test` (515 passing tests plus 1 skipped test across 27 files, completing in roughly 5 seconds).
+The test suite uses Vitest and runs with `npm test` (516 passing tests plus 1 skipped test across 27 files, completing in roughly 5 seconds).
 
 **The replay harnesses** are the most important test files. They run in two modes — see [The byte-for-byte replay test](#the-byte-for-byte-replay-test) above for the full account. In short: `src/esci2/scanner.test.ts` runs `runEsci2Scan` against a `FakeTlsSocket` for the ET-4950 Frida captures and asserts byte-for-byte equality on every host send; for the ET-2750 (`runEsci2ScanOverPlain` against `FakePlainSocket`) the harness feeds only printer-side fixture events and asserts on-disk output, not host-byte equality. `src/esci/scanner.test.ts` follows the same behavioural pattern for the WF-3620 ESC/I path using pcap-derived JSONL fixtures. On-disk output is asserted in both modes — JPEG files for JPG-mode runs (including EXIF orientation verification), and a composed PDF for PDF-mode runs (including page count and `/Rotate` metadata on back pages).
 

--- a/src/output-tail.test.ts
+++ b/src/output-tail.test.ts
@@ -161,6 +161,39 @@ describe("output-tail", () => {
     expect(paths[0]).toMatch(/\.jpg$/);
   });
 
+  it("preserves the local scan when uploadAllToPaperless rejects (defense-in-depth)", async () => {
+    // Pin the contract: a thrown rejection from uploadAllToPaperless must
+    // not turn a completed local scan into a failed scan from the
+    // dispatcher's perspective. one-shot.ts maps any rejection from the
+    // scan promise to exit code 1; without the catch around this await,
+    // a future refactor that lets uploadAllToPaperless throw would
+    // silently break user-facing semantics.
+    uploadMock.mockRejectedValueOnce(new Error("network blip"));
+
+    const fakeJpeg = Buffer.from("ffd8ffe000104a464946", "hex");
+    writeFileSync(path.join(tempDir, "page_001.jpg"), fakeJpeg);
+
+    await expect(
+      finalizeSession({
+        sessionTempDir: tempDir,
+        outputDir,
+        sessionTs: new Date("2026-07-07T07:07:07Z"),
+        action: "jpg",
+        backPageIndices: [],
+        paperless: PAPERLESS_OPTS,
+      }),
+    ).resolves.toBeUndefined();
+
+    // Local file is still on disk, exactly as written.
+    const files = readdirSync(outputDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^scan_2026-07-07_070707\.jpg$/);
+    expect(readFileSync(path.join(outputDir, files[0]))).toEqual(fakeJpeg);
+
+    // Temp dir was still cleaned up (the finally block ran).
+    expect(() => readdirSync(tempDir)).toThrow(/ENOENT/);
+  });
+
   it("removes the temp dir even when promotion fails", async () => {
     // Point outputDir at a plain file so mkdirSync inside writeOutputFile throws
     const blockingFile = path.join(outputDir, "not-a-dir");

--- a/src/output-tail.ts
+++ b/src/output-tail.ts
@@ -45,7 +45,20 @@ export async function finalizeSession(args: FinalizeSessionArgs): Promise<void> 
       }
     }
     if (paperless) {
-      await uploadAllToPaperless(savedPaths, paperless);
+      // Defense-in-depth: `uploadAllToPaperless` is engineered to never
+      // reject (per-file errors are .catch-wrapped inside the module), but
+      // a future refactor or a bug above the per-file catch would otherwise
+      // turn a completed local scan into a failed scan from one-shot's
+      // perspective (it maps any rejection here to exit code 1). Wrap the
+      // boundary so the local file is treated as authoritative.
+      try {
+        await uploadAllToPaperless(savedPaths, paperless);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.error(
+          `Paperless upload threw — local scan preserved at ${savedPaths.join(", ")}: ${msg}`,
+        );
+      }
     }
   } finally {
     fs.rmSync(sessionTempDir, { recursive: true, force: true });


### PR DESCRIPTION
**Re-creates [#60](https://github.com/mtheuma/epson2paperless/pull/60) (approved, auto-closed when its base branch was deleted on PR #58 squash-merge).** Same commit, rebased onto current \`dev\` (which now includes #57, #58, #59).

## Summary

Closes the partial gap on Item 2 of [`.reference/reviews/2026-05-08-test-coverage-review.md`](https://github.com/mtheuma/epson2paperless/blob/dev/.reference/reviews/2026-05-08-test-coverage-review.md). The review's invariant — *\"upload failure does not turn a completed local scan into a failed scan\"* — held in production only because [`paperless-upload.ts:72-76`](src/paperless-upload.ts:72) engineers each per-file upload to \`.catch\` internally. The finalize boundary trusted that internal discipline silently via an unguarded \`await\`.

That was fragile because [`one-shot.ts`](src/one-shot.ts) maps any rejection from the scan promise to **exit code 1**. A future refactor that lets \`uploadAllToPaperless\` reject would silently turn a successful local scan into a user-visible \"scan failed\" without breaking any test.

## What landed

[src/output-tail.ts](src/output-tail.ts) — defensive try/catch with a clear error log:

```ts
if (paperless) {
  try {
    await uploadAllToPaperless(savedPaths, paperless);
  } catch (err) {
    const msg = err instanceof Error ? err.message : String(err);
    log.error(\`Paperless upload threw — local scan preserved at \${savedPaths.join(\", \")}: \${msg}\`);
  }
}
```

New regression test in [src/output-tail.test.ts](src/output-tail.test.ts) — mocks \`uploadAllToPaperless\` to reject; asserts \`finalizeSession\` resolves cleanly, the local file is on disk, and the temp dir is cleaned up.

**Verified the test fails without the catch** (temporary revert): the unguarded \`await\` propagates the rejection, breaking \`.resolves.toBeUndefined()\`.

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run format:check\`
- [x] \`npm test\` — 516 passing, 1 skipped (was 515+1 after #57/#58/#59; +1 new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)