### PR TITLE
fix(scan-session): guard error handler against post-DONE socket RSTs

### DIFF
--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -995,6 +995,70 @@ describe("runScanSession (engine pump)", () => {
     fs.rmSync(outputDir, { recursive: true, force: true });
   });
 
+  // Regression: a transport `error` event after enterState("DONE") must not
+  // race settle and rm the temp dir while finalizeSession is still reading
+  // from it. Sibling to the prior-state-timer variant above; this one
+  // covers the post-DONE socket-error variant — a printer-side RST after
+  // FIN, the documented Epson firmware quirk on plain-TCP variants
+  // (ET-2750 ESC/I-2-over-plain, WF-3620 legacy ESC/I) where the TLS
+  // adapter's post-end ECONNRESET/EPIPE swallow doesn't apply.
+  it("ignores transport errors after DONE so a slow finalize doesn't race a printer-side RST", async () => {
+    const transport = new FakeTransport();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "engine-test-"));
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "engine-out-"));
+
+    const outputTail = await import("./output-tail.js");
+    const realFinalize = outputTail.finalizeSession;
+    const spy = vi.spyOn(outputTail, "finalizeSession").mockImplementation(async (opts) => {
+      // Hold finalize long enough for a post-DONE error event to land mid-flight.
+      await new Promise((r) => setTimeout(r, 100));
+      await realFinalize(opts);
+    });
+
+    const g = createGraph<Record<string, never>>("PAGE", 5_000);
+    g.state("PAGE", {
+      on: {
+        0xa000: {
+          next: "DONE",
+          flushPage: {
+            side: "front",
+            encode: () => Promise.resolve(Buffer.from([0xff, 0xd8, 0xff, 0xd9])),
+          },
+        },
+      },
+    });
+
+    const promise = runScanSession({
+      graph: g.build(),
+      initialCtx: {},
+      transportFactory: () => Promise.resolve(transport),
+      outputDir,
+      tempDir,
+      sessionTs: new Date(),
+      action: "jpg",
+    });
+
+    // Drive PAGE → DONE, then mid-finalize emit a printer-side RST.
+    setImmediate(() => transport.emit("data", buildIsPacket(0xa000, Buffer.alloc(0))));
+    setTimeout(() => {
+      const rst = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+      transport.emit("error", rst);
+    }, 50);
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      expect(result.reason.message).not.toMatch(/ECONNRESET/);
+    }
+    // outputDir should contain a scan_*.jpg promoted by finalizeSession.
+    const outputs = fs.readdirSync(outputDir);
+    expect(outputs.some((f) => /^scan_.*\.jpg$/.test(f))).toBe(true);
+
+    spy.mockRestore();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  });
+
   // Fix 2: Pump stops dispatching after an error settle.
   it("stops the pump after an error settle even if more packets are buffered", async () => {
     const transport = new FakeTransport();

--- a/src/scan-session.ts
+++ b/src/scan-session.ts
@@ -524,7 +524,19 @@ export async function runScanSession<Ctx>(
       settle({ ok: true, finalCtx: ctx });
     }
 
+    // Error handler — symmetric with the close handler below. The DONE
+    // guard matters on plain-TCP variants (ESC/I-2-over-plain ET-2750,
+    // legacy ESC/I WF-3620) where the printer firmware can RST the socket
+    // after our FIN — a benign post-end event from the engine's point of
+    // view, since enterState("DONE") has already scheduled doFinalize.
+    // Without the guard, that RST races doFinalize for settle() and would
+    // fall through to the unconditional rmSync in settle's failure branch
+    // mid-finalize, wiping the captured pages. The TLS path is shielded
+    // by withTlsErrorLabels swallowing post-end ECONNRESET/EPIPE, but
+    // that adapter doesn't apply to the plain-TCP transports.
     transport.on("error", (err) => {
+      if (settled) return;
+      if (currentState === "DONE") return; // doFinalize handles this path
       settle({ ok: false, reason: err, finalCtx: ctx });
     });
 


### PR DESCRIPTION
## Summary
- Mirrors the close handler's `if (currentState === "DONE") return` guard onto the transport error handler in `runScanSession`.
- Closes a race on plain-TCP variants (ET-2750 ESC/I-2-over-plain, WF-3620 legacy ESC/I) where a printer-side RST after our FIN — a documented Epson firmware quirk — could race `doFinalize` for `settle()`, fall through to the unconditional `rmSync` in settle's failure branch, wipe the captured pages mid-finalize, and report a protocol-successful scan as `{ ok: false, reason: ECONNRESET }`.
- TLS path was already shielded by `withTlsErrorLabels` swallowing post-end ECONNRESET/EPIPE; the plain-TCP adapters (`withEsci2UnlockOnDestroy` alone for esci2-plain, bare `socketAsTransport` for esci) don't.

## Background
Found by `/ultrareview`. The fix is symmetric with the existing close-handler guard at `scan-session.ts:540` and addresses the error-event sibling of the timer-driven race already covered by the regression test at `scan-session.test.ts:934` ("clears prior-state timeout when entering DONE…").

## Test plan
- [x] Added regression test `ignores transport errors after DONE so a slow finalize doesn't race a printer-side RST` — confirmed it failed before the fix (`expected false to be true`) and passes after.
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 517 passed | 1 skipped (was 516 + 1; +1 new regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)