### PR TITLE
chore(release): prep v0.4.0 (version bump + XP-7100 partial compat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ What you get:
 
 ## Compatible printers
 
-| Model                 | Status      | Notes                                                 |
-| --------------------- | ----------- | ----------------------------------------------------- |
-| **ET-3950**           | ✅ Verified |                                                       |
-| **ET-4950 / ET-4956** | ✅ Verified |                                                       |
-| **WF-3620**           | ✅ Verified | Plain TCP scanner, no TLS pinning                     |
-| **ET-2750**           | ✅ Verified | Flatbed-only hardware; ESC/I-2 over plain TCP, no TLS |
+| Model                 | Status      | Notes                                                                                                                            |
+| --------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **ET-3950**           | ✅ Verified |                                                                                                                                  |
+| **ET-4950 / ET-4956** | ✅ Verified |                                                                                                                                  |
+| **WF-3620**           | ✅ Verified | Plain TCP scanner, no TLS pinning                                                                                                |
+| **ET-2750**           | ✅ Verified | Flatbed-only hardware; ESC/I-2 over plain TCP, no TLS                                                                            |
+| **XP-7100**           | 🟡 Partial  | Flatbed works; ADF support pending ([#65](https://github.com/mtheuma/epson2paperless/issues/65)). ESC/I-2 over plain TCP, no TLS |
 
 Compatibility reports are welcome whether your model works or doesn't. [Open an issue](https://github.com/mtheuma/epson2paperless/issues/new?template=compatibility.yml) using the compatibility template.
 
@@ -173,7 +174,7 @@ Equally valuable: reporting your printer's compatibility so the [Compatible prin
 
 MIT. See [`LICENSE`](LICENSE) for the full text.
 
-**Not affiliated with Seiko Epson Corporation.** This project is an independent, clean-room re-implementation of the network behavior of an Epson "Scan to Computer" workflow, developed by analyzing the wire protocol of a device the author owns. No Epson source code, firmware, or binaries are included or distributed. "EPSON", "EcoTank", and "WorkForce" are trademarks of Seiko Epson Corporation, used here descriptively to identify the hardware this software interoperates with.
+**Not affiliated with Seiko Epson Corporation.** This project is an independent, clean-room re-implementation of the network behavior of an Epson "Scan to Computer" workflow, developed by analyzing the wire protocol of a device the author owns. No Epson source code, firmware, or binaries are included or distributed. "EPSON", "EcoTank", "Expression", and "WorkForce" are trademarks of Seiko Epson Corporation, used here descriptively to identify the hardware this software interoperates with.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epson2paperless",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "epson2paperless",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "pdf-lib": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epson2paperless",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Epson Scan to Computer protocol emulator — delivers scans to Paperless-ngx",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Cut-prep for v0.4.0. Three small changes:

1. **Version bump:** \`package.json\` and \`package-lock.json\` from \`0.3.1\` → \`0.4.0\`.
2. **XP-7100 compat-table row:** 🟡 Partial status — flatbed works flawlessly, ADF support pending. Per the report from utf8please in [#65](https://github.com/mtheuma/epson2paperless/issues/65).
3. **Trademark notice:** added \"Expression\" to the series-names list to cover XP-7100. Consistent with the post-#68 trim toward series names rather than per-model enumeration.

## ADF-on-esci2-plain is the v0.4.1 headline

The current \`esci2-plain\` profile bakes in an \"ET-2750 is flatbed-only hardware\" assumption at four layers:

- Shell pre-sets \`source: \"flatbed\"\` in \`initialCtx\`.
- \`INIT_POLL_STAT\` skips source-detect on \`ctx.profile === \"esci2-plain\"\`.
- \`config.ts\` Zod rejects \`esci2-plain + ESCI_FORCE_SOURCE\`.
- \`buildParaPayload\` only has a flatbed blob (\`buildParaFlatbedPlain\`); no ADF equivalent.

XP-7100 is the first \`esci2-plain\` printer with an ADF, so all four assumptions need lifting in v0.4.1. Gated on captures from utf8please.

## Next steps after this lands

1. Cut PR \`dev\` → \`main\` (release notes drafted in that PR body).
2. After merge: \`git tag v0.4.0 && git push origin v0.4.0\`.
3. \`gh release create v0.4.0\` — \`docker.yml\` publishes the GHCR image on the tag, but not the GitHub Release entry; that's the manual step.

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run format:check\`
- [x] \`npm test\` — 517 passing, 1 skipped (no test changes; the post-#68 dev baseline includes #64's test that bumped the count to 517)
- [x] ET-4950 11-row smoke completed 2026-05-11 against \`dev\` head before the version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)