### PR TITLE
docs: project email alias + compat-capture sharing note

### DIFF
--- a/.github/ISSUE_TEMPLATE/compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility.yml
@@ -68,3 +68,29 @@ body:
       label: epson2paperless version
       description: e.g. `v0.2.0` or a commit SHA.
       placeholder: v0.2.0
+
+  - type: markdown
+    attributes:
+      value: |
+        ### Sharing a Wireshark capture (optional)
+
+        For "Partially works" or "Doesn't work" reports, a `.pcap` of one
+        scan attempt is the fastest way to a fix.
+
+        1. Print the project's [`compatibility-test-page.pdf`](../../blob/main/tools/test-page/compatibility-test-page.pdf) and feed that page through the scan. It's a neutral test target, so the capture won't contain anything sensitive.
+        2. Capture with Wireshark's "Capture filter" field (or `tshark -f`) set to:
+            ```
+            host <PRINTER_IP>
+            ```
+        3. Email the `.pcap` to `epson2paperless.vineyard182@passmail.com`. (For larger captures, host it wherever and send the link.)
+
+        **Optional: encrypt before sending.** If you'd rather not put the
+        raw `.pcap` through unencrypted email, encrypt with my GitHub SSH
+        key as an age recipient:
+
+        ```bash
+        curl -s https://github.com/mtheuma.keys > matt.pubkey
+        age --recipients-file matt.pubkey -o capture.pcap.age capture.pcap
+        ```
+
+        Then send the `.age` file the same way.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,6 +21,6 @@ Within that trust boundary, be aware of two deliberate design choices:
 If you believe you've found a security issue in this code, please **do not open a public issue**. Instead:
 
 - Open a [GitHub security advisory](https://github.com/mtheuma/epson2paperless/security/advisories/new) (preferred — private by default), **or**
-- Email the author at `matt.theuma@gmail.com` with `epson2paperless security` in the subject.
+- Email the author at `epson2paperless.vineyard182@passmail.com` with `epson2paperless security` in the subject.
 
 This is a personal project (see `CONTRIBUTING.md`), so response times are best-effort. I'll acknowledge within a reasonable window and credit reporters who'd like to be named once a fix is public.


### PR DESCRIPTION
## Summary

Two related doc changes.

### 1. Project email alias replaces personal Gmail

\`SECURITY.md\`'s vulnerability-reporting line now points at \`epson2paperless.vineyard182@passmail.com\` (Proton Pass alias) instead of the maintainer's personal Gmail. Keeps the personal inbox out of public-facing project surface area and future-proofs against alias retirement or project handoff.

The corresponding edit to the [#65 reply comment](https://github.com/mtheuma/epson2paperless/issues/65) is being done manually on the GitHub UI.

### 2. Compat-issue template gains a \"Sharing a Wireshark capture\" block

Compat reports flagged as \"Partially works\" / \"Doesn't work\" are the fastest path to a fix when paired with a \`.pcap\`, but the template didn't tell reporters how to send one. New markdown block at the end walks through:

- Print + scan the project's [\`compatibility-test-page.pdf\`](../blob/main/tools/test-page/compatibility-test-page.pdf) so the capture content is neutral (eliminates document-sensitivity concern at zero cost).
- Capture filter \`host <PRINTER_IP>\` so we get everything the printer talks on, not just port 1865.
- Email the \`.pcap\` to the project alias.
- **Optional** age-via-SSH-key encryption recipe for reporters who'd rather not send raw captures unencrypted.

The encryption ceremony is explicitly opt-in. The default path is plain email of a test-page capture, since a neutral test page eliminates the bulk of the sensitivity surface at zero cost. Encryption is for the ~10% of reporters (e.g. utf8please on #65) who specifically ask for it.

## What this deliberately doesn't change

- The README compat-table doesn't reference the email address anywhere, so no swap needed there.
- The encryption workflow is documented inline in the template rather than in a separate doc, because the template is where reporters actually look.
- SECURITY.md keeps the GSA-or-email structure for vulnerability reports separate from the compat-template's email-for-captures path. Same alias, different paths, different audiences.

## Test plan

- [x] \`npm run format:check\`
- [x] Confirmed \`tools/test-page/compatibility-test-page.pdf\` exists at the linked path
- [x] age workflow end-to-end tested 2026-05-11 (round-trip with the fetched-from-GitHub SSH key)
- [x] No source code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)