### PR TITLE
docs: drop pcap-capture block from compat issue template (take 2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility.yml
@@ -68,29 +68,3 @@ body:
       label: epson2paperless version
       description: e.g. `v0.2.0` or a commit SHA.
       placeholder: v0.2.0
-
-  - type: markdown
-    attributes:
-      value: |
-        ### Sharing a Wireshark capture (optional)
-
-        For "Partially works" or "Doesn't work" reports, a `.pcap` of one
-        scan attempt is the fastest way to a fix.
-
-        1. Print the project's [`compatibility-test-page.pdf`](../../blob/main/tools/test-page/compatibility-test-page.pdf) and feed that page through the scan. It's a neutral test target, so the capture won't contain anything sensitive.
-        2. Capture with Wireshark's "Capture filter" field (or `tshark -f`) set to:
-            ```
-            host <PRINTER_IP>
-            ```
-        3. Email the `.pcap` to `epson2paperless.vineyard182@passmail.com`. (For larger captures, host it wherever and send the link.)
-
-        **Optional: encrypt before sending.** If you'd rather not put the
-        raw `.pcap` through unencrypted email, encrypt with my GitHub SSH
-        key as an age recipient:
-
-        ```bash
-        curl -s https://github.com/mtheuma.keys > matt.pubkey
-        age --recipients-file matt.pubkey -o capture.pcap.age capture.pcap
-        ```
-
-        Then send the `.age` file the same way.


### PR DESCRIPTION
## Summary

Take 2 of [#75](https://github.com/mtheuma/epson2paperless/pull/75). The first attempt merged but didn't actually drop the block.

**What went wrong with #75:** my branch was based off `dev` (which had [#73](https://github.com/mtheuma/epson2paperless/pull/73) adding the pcap block), and `main` had the same block added independently via [#74](https://github.com/mtheuma/epson2paperless/pull/74) (the dev → main forward). When GitHub's *Update branch with merge commit* ran the 3-way merge between my branch and main, git couldn't recognise the deletion on my side as "undoing the addition on main's side" — the two additions had different SHAs (different commits, identical content), so git treated them as independent. The update-branch merge re-added the block (+26 lines onto the PR branch); the squash then collapsed everything to zero net change.

**This PR:** branched off current `main` (post-#75), single-commit deletion of the same block. No shared-content quirk for the merge to trip on this time.

## Test plan

- [x] `git diff main..HEAD --stat` shows one file changed, 26 deletions
- [x] Lint + Prettier pass locally (no source touched)
- [ ] CI green on PR
- [ ] Post-merge: verify `compatibility.yml` on `main` no longer contains the *Sharing a Wireshark capture (optional)* section

🤖 Generated with [Claude Code](https://claude.com/claude-code)