### PR TITLE
fix(lifecycle): log InflightTracker rejections at WARN

### DIFF
--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   createInflightTracker,
   shutdown,
@@ -22,9 +22,33 @@ describe("InflightTracker", () => {
 
   it("settles the tracker slot even when the tracked promise rejects", async () => {
     const tracker = createInflightTracker();
-    const p = tracker.track(Promise.reject(new Error("boom")));
-    await expect(p).resolves.toBeUndefined();
-    expect(tracker.count).toBe(0);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const p = tracker.track(Promise.reject(new Error("boom")));
+      await expect(p).resolves.toBeUndefined();
+      expect(tracker.count).toBe(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("logs at WARN when the tracked promise rejects (issue #66)", async () => {
+    const tracker = createInflightTracker();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const err = new Error("EACCES: permission denied");
+      await tracker.track(Promise.reject(err));
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const callArgs = warnSpy.mock.calls[0];
+      const joined = callArgs.map((a) => (a instanceof Error ? a.message : String(a))).join(" ");
+      expect(joined).toContain("[WARN]");
+      expect(joined).toContain("[lifecycle]");
+      expect(joined).toContain("Tracked scan promise rejected");
+      expect(joined).toContain("EACCES: permission denied");
+      expect(callArgs).toContain(err);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("count reflects concurrent in-flight work", async () => {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -5,8 +5,12 @@ const log = createLogger("lifecycle");
 export interface InflightTracker {
   /**
    * Register an in-flight promise. The returned promise resolves when the
-   * input settles, with rejections swallowed — tracking is about presence,
-   * not success. Errors should already be logged at the source.
+   * input settles — tracking is about presence, not success. Rejections
+   * are logged at WARN at the catch boundary so the outermost scan-promise
+   * failure is never silent (issue #66 — Docker EACCES at temp-dir setup
+   * fired before any per-state log and went unobserved). The log may
+   * duplicate an inner error already logged at the source; that's
+   * acceptable noise to ensure the un-logged path is visible.
    */
   track(p: Promise<void>): Promise<void>;
   /**
@@ -25,8 +29,8 @@ export function createInflightTracker(): InflightTracker {
 
   const track = (p: Promise<void>): Promise<void> => {
     const wrapper = p
-      .catch(() => {
-        /* swallow — see JSDoc */
+      .catch((err: unknown) => {
+        log.warn("Tracked scan promise rejected", err);
       })
       .finally(() => {
         set.delete(wrapper);


### PR DESCRIPTION
## Summary

Resolves [#66](https://github.com/mtheuma/epson2paperless/issues/66).

`InflightTracker.track` was swallowing scan-promise rejections on the assumption that "errors are already logged at the source." That assumption breaks for failures **before** the protocol state machine starts — utf8please's report is the canonical case: an `EACCES` from `fs.mkdirSync` during session-temp-dir setup fired before any per-state debug log and went entirely unobserved, costing the reporter hours of Wireshark debugging on what turned out to be a Docker UID mismatch.

**Fix:** log at the catch boundary in `track()`. WARN level so the un-logged path becomes visible at the default log level; the inner-logged path now emits a duplicate WARN, which is acceptable noise (easily filtered in a log aggregator) vs the silent-failure footgun.

JSDoc updated to reflect the new contract. The settlement behaviour (rejections still settle the tracker slot cleanly) is unchanged.

## Test plan

- [x] New test `logs at WARN when the tracked promise rejects (issue #66)` asserts a `console.warn` with the `[WARN] [lifecycle] Tracked scan promise rejected` prefix and the error object as a structured arg
- [x] Pre-existing test `settles the tracker slot even when the tracked promise rejects` still passes (settlement contract unchanged)
- [x] Full suite: 512 passed (was 511), +1 from the new test, no regressions
- [x] Lint + Prettier clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)