### PR TITLE
fix(esci): polite-close gate for raw-socket transport

### DIFF
--- a/src/esci/scanner.ts
+++ b/src/esci/scanner.ts
@@ -11,6 +11,7 @@ import { resolveSessionTimestamp } from "../output.js";
 import { esciGraph, type EsciCtx } from "./graph.js";
 import type { Source, Format } from "./commands.js";
 import type { PaperlessUploadOptions } from "../paperless-upload.js";
+import { withRawSocketCleanClose } from "./transport.js";
 
 export { appendImageChunk } from "./graph.js";
 
@@ -50,16 +51,13 @@ function makeTcpTransportFactory(
 ): SessionTransportFactory {
   return () =>
     new Promise<SessionTransport>((resolve, reject) => {
-      // Plain TCP needs no app-level wrapper (no TLS pin, no
-      // unlock-on-destroy semantics peculiar to ESC/I-2). The
-      // socketAsTransport bridge is just an explicit-cast shim so the
-      // engine's SessionTransport.end(data?) signature is honoured —
-      // net.Socket.end has its own overload set that doesn't directly
-      // satisfy the interface as a structural subtype. If a future
-      // ESC/I quirk needs a wrapper, introduce a sibling
-      // src/esci/transport.ts.
+      // socketAsTransport bridges net.Socket → SessionTransport (its
+      // end() overload set isn't a structural subtype). withRawSocketCleanClose
+      // adds the polite-close gate so the engine's mandatory post-DONE
+      // destroy() doesn't RST the printer mid-FIN handshake (issue #72,
+      // symmetric to the TLS path's withEsci2UnlockOnDestroy gate).
       const socket = socketFactory(session.printerIp, session.port, () => {
-        resolve(socketAsTransport(socket));
+        resolve(withRawSocketCleanClose(socketAsTransport(socket)));
       });
       socket.once("error", reject);
     });

--- a/src/esci/transport.test.ts
+++ b/src/esci/transport.test.ts
@@ -129,6 +129,36 @@ describe("withRawSocketCleanClose wrapper", () => {
     expect(seen).toEqual([false, true]);
   });
 
+  it("inner.end() throws — politelyClosed stays false, subsequent destroy() forwards (PR #78 review)", () => {
+    // Reviewer's catch on PR #78: if inner.end() throws, we must NOT
+    // have entered the polite-close state — otherwise the engine's
+    // follow-up destroy() in settle() no-ops and the socket leaks.
+    const calls = { end: 0, destroy: 0 };
+    const stub: SessionTransport = {
+      write() {
+        return true;
+      },
+      end() {
+        calls.end += 1;
+        throw new Error("inner.end blew up");
+      },
+      destroy() {
+        calls.destroy += 1;
+      },
+      on() {
+        return stub;
+      },
+    };
+    const wrapped = withRawSocketCleanClose(stub);
+    expect(() => wrapped.end()).toThrow(/inner\.end blew up/);
+    expect(calls.end).toBe(1);
+    // Now the engine's mandatory post-DONE destroy() must reach inner —
+    // if politelyClosed had been flipped before inner.end() ran, this
+    // call would be a no-op and the socket handle would leak.
+    wrapped.destroy();
+    expect(calls.destroy).toBe(1);
+  });
+
   it("destroy() forwards an error arg in the true-error path", () => {
     const calls: Array<Error | undefined> = [];
     const stub: SessionTransport = {

--- a/src/esci/transport.test.ts
+++ b/src/esci/transport.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { SessionTransport } from "../scan-session.js";
+import { withRawSocketCleanClose } from "./transport.js";
+
+/** Stub inner transport with end/destroy counters and a `close` trigger. */
+function makeStubTransport() {
+  const calls = { end: 0, destroy: 0, endData: null as Buffer | null };
+  let closeListener: ((hadError?: boolean) => void) | null = null;
+  const stub: SessionTransport = {
+    write() {
+      return true;
+    },
+    end(data?: Buffer) {
+      calls.end += 1;
+      if (data) calls.endData = data;
+    },
+    destroy() {
+      calls.destroy += 1;
+    },
+    on(event: string, cb: (...args: unknown[]) => void) {
+      if (event === "close") closeListener = cb;
+      return stub;
+    },
+  };
+  return {
+    transport: stub,
+    calls,
+    fireClose(hadError?: boolean) {
+      closeListener?.(hadError);
+    },
+  };
+}
+
+describe("withRawSocketCleanClose wrapper", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("destroy() is a no-op after end() — prevents post-FIN RST (issue #72)", () => {
+    // Engine's healthy DONE flow: transport.end() sends FIN, then
+    // settle() calls transport.destroy(). The wrapper must NOT pass
+    // that destroy through, or the FIN-RST race surfaces.
+    const { transport, calls } = makeStubTransport();
+    const wrapped = withRawSocketCleanClose(transport);
+    wrapped.end();
+    expect(calls.end).toBe(1);
+    wrapped.destroy();
+    expect(calls.destroy).toBe(0);
+  });
+
+  it("destroy() forwards when end() was never called (true error path)", () => {
+    const { transport, calls } = makeStubTransport();
+    const wrapped = withRawSocketCleanClose(transport);
+    wrapped.destroy();
+    expect(calls.destroy).toBe(1);
+    expect(calls.end).toBe(0);
+  });
+
+  it("destroy() forwards once close has fired (cleanup is safe post-close)", () => {
+    const { transport, calls, fireClose } = makeStubTransport();
+    const wrapped = withRawSocketCleanClose(transport);
+    wrapped.on("close", () => {});
+    wrapped.end();
+    fireClose(false);
+    wrapped.destroy();
+    expect(calls.destroy).toBe(1);
+  });
+
+  it("forwards end(data?) buffer to inner", () => {
+    const { transport, calls } = makeStubTransport();
+    const wrapped = withRawSocketCleanClose(transport);
+    const payload = Buffer.from([0x1b, 0x40]);
+    wrapped.end(payload);
+    expect(calls.end).toBe(1);
+    expect(calls.endData?.equals(payload)).toBe(true);
+  });
+
+  it("end() is idempotent — second call does not restart the fallback timer", () => {
+    const { transport, calls } = makeStubTransport();
+    const wrapped = withRawSocketCleanClose(transport);
+    wrapped.end();
+    wrapped.end();
+    expect(calls.end).toBe(1);
+  });
+
+  it("fallback timer fires inner.destroy() when close never lands", () => {
+    // Engine's promise has already settled by this point — the fallback
+    // is purely socket-hygiene cleanup so a misbehaving peer can't leak
+    // a socket per scan.
+    const { transport, calls } = makeStubTransport();
+    const wrapped = withRawSocketCleanClose(transport);
+    wrapped.end();
+    expect(calls.destroy).toBe(0);
+    vi.advanceTimersByTime(5000);
+    expect(calls.destroy).toBe(1);
+  });
+
+  it("fallback timer is cleared when close fires naturally", () => {
+    const { transport, calls, fireClose } = makeStubTransport();
+    const wrapped = withRawSocketCleanClose(transport);
+    wrapped.on("close", () => {});
+    wrapped.end();
+    fireClose(false);
+    vi.advanceTimersByTime(10_000);
+    expect(calls.destroy).toBe(0);
+  });
+
+  it("forwards the close event to the engine listener", () => {
+    const { transport, fireClose } = makeStubTransport();
+    const wrapped = withRawSocketCleanClose(transport);
+    const seen: Array<boolean | undefined> = [];
+    wrapped.on("close", (hadError?: boolean) => seen.push(hadError));
+    fireClose(false);
+    fireClose(true);
+    expect(seen).toEqual([false, true]);
+  });
+
+  it("destroy() forwards an error arg in the true-error path", () => {
+    const calls: Array<Error | undefined> = [];
+    const stub: SessionTransport = {
+      write() {
+        return true;
+      },
+      end() {},
+      destroy(err?: Error) {
+        calls.push(err);
+      },
+      on() {
+        return stub;
+      },
+    };
+    const wrapped = withRawSocketCleanClose(stub);
+    const err = new Error("ECONNREFUSED");
+    wrapped.destroy(err);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe(err);
+  });
+});

--- a/src/esci/transport.test.ts
+++ b/src/esci/transport.test.ts
@@ -79,14 +79,23 @@ describe("withRawSocketCleanClose wrapper", () => {
   });
 
   it("end() is idempotent — second call does not restart the fallback timer", () => {
-    const { transport, calls } = makeStubTransport();
+    const { transport, calls, fireClose } = makeStubTransport();
     const wrapped = withRawSocketCleanClose(transport);
+    wrapped.on("close", () => {});
     wrapped.end();
+    // Advance past half the fallback window, then call end() again.
+    // If the second end() restarted the timer, close would have to wait
+    // another full window before destroy fires.
+    vi.advanceTimersByTime(3000);
     wrapped.end();
     expect(calls.end).toBe(1);
+    // Close naturally — clears the (original) timer.
+    fireClose(false);
+    vi.advanceTimersByTime(10_000);
+    expect(calls.destroy).toBe(0);
   });
 
-  it("fallback timer fires inner.destroy() when close never lands", () => {
+  it("fallback timer fires inner.destroy() after the window when close never lands", () => {
     // Engine's promise has already settled by this point — the fallback
     // is purely socket-hygiene cleanup so a misbehaving peer can't leak
     // a socket per scan.
@@ -94,8 +103,10 @@ describe("withRawSocketCleanClose wrapper", () => {
     const wrapped = withRawSocketCleanClose(transport);
     wrapped.end();
     expect(calls.destroy).toBe(0);
-    vi.advanceTimersByTime(5000);
-    expect(calls.destroy).toBe(1);
+    vi.advanceTimersByTime(4999);
+    expect(calls.destroy).toBe(0); // not before the window
+    vi.advanceTimersByTime(1);
+    expect(calls.destroy).toBe(1); // fires exactly at the window
   });
 
   it("fallback timer is cleared when close fires naturally", () => {

--- a/src/esci/transport.ts
+++ b/src/esci/transport.ts
@@ -1,0 +1,92 @@
+import type { SessionTransport } from "../scan-session.js";
+
+const CLEAN_CLOSE_FALLBACK_MS = 5000;
+
+/**
+ * Polite-close gate for raw-TCP transports (legacy ESC/I path; issue #72).
+ *
+ * The engine's `settle()` unconditionally calls `transport.destroy()` as
+ * its final cleanup step (see `scan-session.ts` settle comment). On a TLS
+ * transport that's harmless after `end()` because `withEsci2UnlockOnDestroy`
+ * already gates destroy on `politelyClosed`. On a bare raw socket there's
+ * no such gate, so the engine's mandatory destroy can RST the connection
+ * before the peer's FIN reaches us — Epson firmware has shown surprising
+ * reactions to mid-handshake RSTs in prior bugs (panel-error class), so
+ * the same gate belongs on the plain-TCP legacy path.
+ *
+ * Behaviour:
+ *
+ * 1. **`end()`**: flips `politelyClosed`, forwards to inner, starts a
+ *    fallback timer that force-destroys if `close` never lands within
+ *    {@link CLEAN_CLOSE_FALLBACK_MS}. Without the fallback a misbehaving
+ *    peer could leak a socket per scan (the engine's post-DONE destroy
+ *    being a no-op leaves it to TCP to drain — most printers send FIN
+ *    promptly, but we don't want to rely on that for resource safety).
+ *
+ * 2. **`destroy()`**: no-op when `politelyClosed && !closed` (the engine's
+ *    redundant post-DONE destroy). Forwards in every other case — true
+ *    error path (no `end()` was reached) and the post-close cleanup path
+ *    (close already fired, inner.destroy() is a no-op anyway).
+ *
+ * Sniffs the inner's `close` event so its own `closed` flag stays in
+ * sync; the `close` callback passed to `on()` is still forwarded
+ * unchanged, so the engine's close-handler sees identical semantics.
+ */
+export function withRawSocketCleanClose(inner: SessionTransport): SessionTransport {
+  let politelyClosed = false;
+  let closed = false;
+  let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearFallback = () => {
+    if (fallbackTimer !== null) {
+      clearTimeout(fallbackTimer);
+      fallbackTimer = null;
+    }
+  };
+
+  const wrapped: SessionTransport = {
+    write(buf: Buffer) {
+      return inner.write(buf);
+    },
+    end: (data?: Buffer) => {
+      if (politelyClosed) {
+        // Idempotent — engine should only call end() once, but guard
+        // anyway so a double-call doesn't restart the fallback timer.
+        return;
+      }
+      politelyClosed = true;
+      inner.end(data);
+      fallbackTimer = setTimeout(() => {
+        if (!closed) inner.destroy();
+      }, CLEAN_CLOSE_FALLBACK_MS);
+      // .unref() so the fallback doesn't keep the daemon's event loop
+      // alive past a clean shutdown.
+      fallbackTimer.unref?.();
+    },
+    destroy(err?: Error) {
+      if (politelyClosed && !closed) {
+        // Engine's mandatory post-DONE destroy. No-op so the FIN we
+        // just queued isn't pre-empted by a RST.
+        return;
+      }
+      clearFallback();
+      inner.destroy(err);
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    on(event: string, cb: (...args: any[]) => void) {
+      if (event === "close") {
+        inner.on("close", (hadError?: boolean) => {
+          closed = true;
+          clearFallback();
+          (cb as (hadError?: boolean) => void)(hadError);
+        });
+      } else if (event === "data") {
+        inner.on("data", cb as (chunk: Buffer) => void);
+      } else if (event === "error") {
+        inner.on("error", cb as (err: Error) => void);
+      }
+      return wrapped;
+    },
+  };
+  return wrapped;
+}

--- a/src/esci/transport.ts
+++ b/src/esci/transport.ts
@@ -49,19 +49,15 @@ export function withRawSocketCleanClose(inner: SessionTransport): SessionTranspo
       return inner.write(buf);
     },
     end: (data?: Buffer) => {
-      if (politelyClosed) {
-        // Idempotent — engine should only call end() once, but guard
-        // anyway so a double-call doesn't restart the fallback timer.
-        return;
-      }
+      if (politelyClosed) return;
       politelyClosed = true;
       inner.end(data);
       fallbackTimer = setTimeout(() => {
         if (!closed) inner.destroy();
       }, CLEAN_CLOSE_FALLBACK_MS);
-      // .unref() so the fallback doesn't keep the daemon's event loop
-      // alive past a clean shutdown.
-      fallbackTimer.unref?.();
+      // .unref() so a pending fallback doesn't keep the daemon's event
+      // loop alive past a graceful shutdown.
+      fallbackTimer.unref();
     },
     destroy(err?: Error) {
       if (politelyClosed && !closed) {

--- a/src/esci/transport.ts
+++ b/src/esci/transport.ts
@@ -50,7 +50,11 @@ export function withRawSocketCleanClose(inner: SessionTransport): SessionTranspo
     },
     end: (data?: Buffer) => {
       if (politelyClosed) return;
-      politelyClosed = true;
+      // Forward to inner FIRST. If it throws, we propagate the throw and
+      // leave politelyClosed=false so the engine's mandatory follow-up
+      // destroy() (or any caller's catch-and-destroy) still cleans up
+      // the socket. Setting the flag before this would no-op those
+      // destroys and leak the handle.
       inner.end(data);
       fallbackTimer = setTimeout(() => {
         if (!closed) inner.destroy();
@@ -58,6 +62,7 @@ export function withRawSocketCleanClose(inner: SessionTransport): SessionTranspo
       // .unref() so a pending fallback doesn't keep the daemon's event
       // loop alive past a graceful shutdown.
       fallbackTimer.unref();
+      politelyClosed = true;
     },
     destroy(err?: Error) {
       if (politelyClosed && !closed) {


### PR DESCRIPTION
## Summary

Resolves [#72](https://github.com/mtheuma/epson2paperless/issues/72). Symmetric counterpart to [#64](https://github.com/mtheuma/epson2paperless/pull/64).

The legacy ESC/I path resolved its transport as a bare `socketAsTransport(socket)`, commenting that plain TCP needed no app-level wrapper. But the engine's `settle()` unconditionally calls `transport.destroy()` as its final cleanup, and on a raw socket that destroy RSTs the connection if it lands before the peer's FIN. Epson firmware has shown surprising reactions to mid-handshake RSTs in prior bugs (panel-error class), so a printer-side RST during finalize is a real concern even though our captured pages are safe on disk by the time settle runs.

The ESC/I-2-over-TLS path is shielded by `withEsci2UnlockOnDestroy`'s `politelyClosed` gate. The ESC/I-2-over-plain-TCP path (ET-2750) gets the same gate from composing the unlock adapter. The legacy raw-socket path had neither.

## What's new

**`src/esci/transport.ts`** (the location reserved by the prior comment at `scanner.ts:60`) — `withRawSocketCleanClose(inner)`:

- `end(data?)`: flips `politelyClosed`, forwards to inner, starts a 5s `.unref()`'d fallback timer that force-destroys if `close` never lands — resource safety for misbehaving peers so a stuck socket doesn't leak per scan.
- `destroy()`: no-op when `politelyClosed && !closed`; forwards in every other case (true error path, post-close cleanup).
- `on("close", ...)`: intercepts inner's close to flip `closed` and cancel the fallback timer; engine-side close handler still receives the event unchanged.

**`src/esci/scanner.ts`**: composes the wrapper at the resolve site. Old comment about plain TCP needing no wrapper updated.

## Test plan

- [x] 9 new unit tests in `src/esci/transport.test.ts`:
  - destroy no-op after end (the main invariant)
  - destroy forwards in true error path (no end())
  - destroy forwards once close fires
  - end(data?) buffer passthrough
  - end() idempotence
  - fallback timer fires when close never lands
  - fallback timer is cleared when close fires naturally
  - close event forwards to engine listener
  - destroy error arg passthrough in true-error path
- [x] Existing legacy ESC/I replay shield (`src/esci/scanner.test.ts`, 10 fixtures) unaffected — the new wrapper is transport-blind, no wire bytes changed
- [x] Lint + Prettier clean
- [x] Full suite: 521 passed (was 512, +9 new), no regressions
- [ ] CI green
- [ ] **Hardware smoke (WF-3620 multi-page) deferred** — unit-test layer proves the adapter is well-formed, but the issue's acceptance criterion *"no printer-side RST visible in tshark"* needs real hardware. Validate against the released image when WF-3620 is next available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)