### PR TITLE
fix(esci): stash trailing image chunks during page encode

### DIFF
--- a/src/esci/graph.test.ts
+++ b/src/esci/graph.test.ts
@@ -363,6 +363,22 @@ describe("esciGraph reset / gamma / window / start cycles", () => {
       // pageCount advanced; ctx.imageBuffer reset.
       expect(ctx.pageCount).toBe(2);
       expect(ctx.imageBufferOffset).toBe(0);
+      // PR #79 review (P2): the overflow branch must still emit IS-0x2200
+      // stream-config before the page-eject — every non-overflow START
+      // path sends IS-0x2200, and skipping it on the overflow path would
+      // make this the only START exit that doesn't.
+      expect(Array.isArray(result.send)).toBe(true);
+      if (Array.isArray(result.send)) {
+        expect(result.send).toHaveLength(2);
+        const first = result.send[0] as Buffer;
+        // IS framing: "IS" magic + 2-byte type (big-endian). 0x2200 = stream-config.
+        expect(first[0]).toBe(0x49); // 'I'
+        expect(first[1]).toBe(0x53); // 'S'
+        expect(first.readUInt16BE(2)).toBe(0x2200);
+        const second = result.send[1] as Buffer;
+        // Page-eject is wrapped in an IS-0x2000 passthru envelope.
+        expect(second.readUInt16BE(2)).toBe(0x2000);
+      }
     }
   });
 

--- a/src/esci/graph.test.ts
+++ b/src/esci/graph.test.ts
@@ -16,6 +16,7 @@ function makeCtx(overrides: Partial<EsciCtx> = {}): EsciCtx {
     geom: null,
     imageBuffer: Buffer.alloc(0),
     imageBufferOffset: 0,
+    deferredImageChunks: [],
     ...overrides,
   };
 }
@@ -323,7 +324,7 @@ describe("esciGraph reset / gamma / window / start cycles", () => {
   });
 });
 
-describe("esciGraph IMG_RECEIVING / PAGE_EJECT_WAIT / cleanup", () => {
+describe("esciGraph IMG_RECEIVING / PAGE_ENCODING_DRAIN / cleanup", () => {
   // Stub geometry sized so widthPx * heightPx * 3 = the test's pre-allocated
   // imageBuffer length. flush.encode() is never invoked from these tests, so
   // dpi / topYOffsetPx values don't matter — only the dimensions feed back
@@ -364,7 +365,7 @@ describe("esciGraph IMG_RECEIVING / PAGE_EJECT_WAIT / cleanup", () => {
     }
   });
 
-  it("IMG_RECEIVING flushes and routes to PAGE_EJECT_WAIT for ADF", () => {
+  it("IMG_RECEIVING flushes and routes to PAGE_ENCODING_DRAIN for ADF", () => {
     const state = esciGraph.states.IMG_RECEIVING;
     if (state.kind === "decision") {
       const ctx = makeCtx({
@@ -376,7 +377,7 @@ describe("esciGraph IMG_RECEIVING / PAGE_EJECT_WAIT / cleanup", () => {
       const chunk = Buffer.concat([Buffer.from([0x01]), Buffer.alloc(6, 0xb0)]);
       const result = state.decide(ctx, { type: 0xa200, payload: chunk });
       if ("error" in result) throw new Error("unexpected error result");
-      expect(result.next).toBe("PAGE_EJECT_WAIT");
+      expect(result.next).toBe("PAGE_ENCODING_DRAIN");
       expect(result.flushPage?.side).toBe("front"); // page 1 = front
     }
   });
@@ -398,13 +399,117 @@ describe("esciGraph IMG_RECEIVING / PAGE_EJECT_WAIT / cleanup", () => {
     }
   });
 
-  it("PAGE_EJECT_WAIT sets inInterPageLoop and routes to STATUS_1A", () => {
-    const state = esciGraph.states.PAGE_EJECT_WAIT;
+  it("PAGE_ENCODING_DRAIN: 0xa000 eject ACK sets inInterPageLoop and routes to STATUS_1A", () => {
+    const state = esciGraph.states.PAGE_ENCODING_DRAIN;
     if (state.kind === "decision") {
       const ctx = makeCtx({ inInterPageLoop: false });
       const result = state.decide(ctx, { type: ESCI_REPLY, payload: Buffer.from([0x06]) });
       expect("next" in result && result.next).toBe("STATUS_1A");
       expect(ctx.inInterPageLoop).toBe(true);
+    }
+  });
+
+  it("PAGE_ENCODING_DRAIN: trailing 0xa200 chunk is stashed and self-loops (issue #71)", () => {
+    // The regression: in duplex / multi-page scans the printer eagerly
+    // streams the next page's first bytes before our flushPage encode
+    // completes. Pre-v0.4.0 absorbed them in a PAGE_ENCODING state; the
+    // v0.4.0 rebuild lost this, sending the chunks to PAGE_EJECT_WAIT
+    // which rejected anything that wasn't a 0xa000 ACK.
+    const state = esciGraph.states.PAGE_ENCODING_DRAIN;
+    if (state.kind === "decision") {
+      const ctx = makeCtx();
+      const chunk = Buffer.concat([Buffer.from([0x01]), Buffer.alloc(12, 0xb0)]);
+      const result = state.decide(ctx, { type: 0xa200, payload: chunk });
+      expect("next" in result && result.next).toBe("PAGE_ENCODING_DRAIN");
+      expect(ctx.deferredImageChunks).toHaveLength(1);
+      expect(ctx.deferredImageChunks[0]).toBe(chunk);
+      // No state mutation that would affect the eject-ACK path.
+      expect(ctx.inInterPageLoop).toBe(false);
+    }
+  });
+
+  it("PAGE_ENCODING_DRAIN: stashes multiple trailing 0xa200 chunks in order", () => {
+    const state = esciGraph.states.PAGE_ENCODING_DRAIN;
+    if (state.kind === "decision") {
+      const ctx = makeCtx();
+      const first = Buffer.concat([Buffer.from([0x01]), Buffer.alloc(4, 0xa0)]);
+      const second = Buffer.concat([Buffer.from([0x01]), Buffer.alloc(4, 0xb0)]);
+      state.decide(ctx, { type: 0xa200, payload: first });
+      state.decide(ctx, { type: 0xa200, payload: second });
+      expect(ctx.deferredImageChunks).toEqual([first, second]);
+    }
+  });
+
+  it("PAGE_ENCODING_DRAIN: rejects unexpected packet types", () => {
+    const state = esciGraph.states.PAGE_ENCODING_DRAIN;
+    if (state.kind === "decision") {
+      const ctx = makeCtx();
+      const result = state.decide(ctx, { type: 0xa100, payload: Buffer.from([0x00]) });
+      expect("error" in result).toBe(true);
+    }
+  });
+
+  it("PAGE_ENCODING_DRAIN: rejects 0xa000 with wrong length", () => {
+    const state = esciGraph.states.PAGE_ENCODING_DRAIN;
+    if (state.kind === "decision") {
+      const ctx = makeCtx();
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload: Buffer.from([0x06, 0x06]) });
+      expect("error" in result).toBe(true);
+    }
+  });
+
+  it("IMG_RECEIVING: drains deferredImageChunks into the new page buffer before processing the incoming chunk", () => {
+    // Engine flow after PAGE_ENCODING_DRAIN exits and the inter-page
+    // loop walks back to IMG_RECEIVING: first incoming 0xa200 triggers
+    // the drain prelude. Both deferred + incoming bytes land in the
+    // fresh imageBuffer.
+    const state = esciGraph.states.IMG_RECEIVING;
+    if (state.kind === "decision") {
+      const deferred = Buffer.concat([Buffer.from([0x01]), Buffer.alloc(5, 0xa0)]);
+      const ctx = makeCtx({
+        imageBuffer: Buffer.alloc(100),
+        imageBufferOffset: 0,
+        deferredImageChunks: [deferred],
+      });
+      const incoming = Buffer.concat([Buffer.from([0x01]), Buffer.alloc(7, 0xb0)]);
+      const result = state.decide(ctx, { type: 0xa200, payload: incoming });
+      expect("next" in result && result.next).toBe("IMG_RECEIVING");
+      // Deferred 5 bytes + incoming 7 bytes = 12 pixel bytes total.
+      expect(ctx.imageBufferOffset).toBe(12);
+      // First five bytes are the deferred chunk's pixel tail.
+      expect(ctx.imageBuffer.subarray(0, 5).every((b) => b === 0xa0)).toBe(true);
+      // Next seven are the incoming chunk's pixel tail.
+      expect(ctx.imageBuffer.subarray(5, 12).every((b) => b === 0xb0)).toBe(true);
+      // Queue is consumed.
+      expect(ctx.deferredImageChunks).toHaveLength(0);
+    }
+  });
+
+  it("IMG_RECEIVING: deferred-chunk drain that fills the page re-stashes the incoming chunk for the next page", () => {
+    // Defensive guard for the (unlikely) case where deferred chunks
+    // alone exceed the new page's buffer. The remaining deferred
+    // entries + the incoming chunk get re-stashed so the next page's
+    // IMG_RECEIVING can drain them.
+    const state = esciGraph.states.IMG_RECEIVING;
+    if (state.kind === "decision") {
+      const stubGeom2 = { dpi: 300, widthPx: 1, heightPx: 4, topYOffsetPx: 0 };
+      const fillsBuffer = Buffer.concat([Buffer.from([0x01]), Buffer.alloc(12, 0xa0)]);
+      const extraDeferred = Buffer.concat([Buffer.from([0x01]), Buffer.alloc(4, 0xc0)]);
+      const ctx = makeCtx({
+        source: "adf-duplex",
+        geom: stubGeom2,
+        imageBuffer: Buffer.alloc(12),
+        imageBufferOffset: 0,
+        deferredImageChunks: [fillsBuffer, extraDeferred],
+      });
+      const incoming = Buffer.concat([Buffer.from([0x01]), Buffer.alloc(4, 0xb0)]);
+      const result = state.decide(ctx, { type: 0xa200, payload: incoming });
+      if ("error" in result) throw new Error("unexpected error result");
+      // Page completes mid-drain → flushPage transition emitted.
+      expect(result.next).toBe("PAGE_ENCODING_DRAIN");
+      expect(result.flushPage?.side).toBe("front");
+      // The unconsumed deferred chunk + the incoming chunk are re-stashed.
+      expect(ctx.deferredImageChunks).toEqual([extraDeferred, incoming]);
     }
   });
 

--- a/src/esci/graph.test.ts
+++ b/src/esci/graph.test.ts
@@ -301,6 +301,71 @@ describe("esciGraph reset / gamma / window / start cycles", () => {
     }
   });
 
+  it("START drains deferred chunks into the new page buffer (issue #71 P1)", () => {
+    // Reviewer's catch on PR #79: if a slow encode let the printer stash
+    // the entire next page during PAGE_ENCODING_DRAIN, no later wire
+    // chunk arrives to trigger IMG_RECEIVING's drain — the scan sits
+    // until timeout. START is the proactive drain point: after the new
+    // page's buffer is allocated, drain the queue before IMG_RECEIVING
+    // is entered.
+    const state = esciGraph.states.START;
+    if (state.kind === "decision") {
+      const deferred = Buffer.concat([Buffer.from([0x01]), Buffer.alloc(50, 0xa0)]);
+      const ctx = makeCtx({
+        source: "adf-duplex",
+        format: "jpg",
+        deferredImageChunks: [deferred],
+      });
+      const payload = Buffer.alloc(14);
+      payload.writeUInt32LE(0x1000, 2);
+      payload.writeUInt32LE(0x06d6, 6);
+      payload.writeUInt32LE(7002, 10);
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload });
+      expect("next" in result && result.next).toBe("IMG_RECEIVING");
+      // 50 pixel bytes from the deferred chunk landed in the new buffer.
+      expect(ctx.imageBufferOffset).toBe(50);
+      expect(ctx.imageBuffer.subarray(0, 50).every((b) => b === 0xa0)).toBe(true);
+      // Queue is drained.
+      expect(ctx.deferredImageChunks).toHaveLength(0);
+    }
+  });
+
+  it("START emits flush transition when deferred chunks alone fill the next page (issue #71 P1)", () => {
+    // The bug scenario the reviewer flagged: encoder is slower than the
+    // printer for a duplex back-page; the entire back-page is stashed
+    // during PAGE_ENCODING_DRAIN. Without START's drain, IMG_RECEIVING
+    // would sit idle until timeout. With it, the page is recognised
+    // complete here and a flush transition fires immediately.
+    //
+    // Geometry is fixed by geometry() — PDF format gives ~26MB
+    // (2478 × 3501 × 3); allocUnsafe makes the deferred chunk effectively
+    // free (pool-allocated, no zero-fill).
+    const state = esciGraph.states.START;
+    if (state.kind === "decision") {
+      const pdfBufferSize = 2478 * 3501 * 3;
+      const overflowing = Buffer.allocUnsafe(pdfBufferSize + 1);
+      overflowing[0] = 0x01; // leading status byte that appendImageChunk strips
+      const ctx = makeCtx({
+        source: "adf-duplex",
+        format: "pdf",
+        pageCount: 1, // about to flush page 2 (back)
+        deferredImageChunks: [overflowing],
+      });
+      const payload = Buffer.alloc(14);
+      payload.writeUInt32LE(0x1000, 2);
+      payload.writeUInt32LE(0x06d6, 6);
+      payload.writeUInt32LE(7002, 10);
+      const result = state.decide(ctx, { type: ESCI_REPLY, payload });
+      if ("error" in result) throw new Error("unexpected error result");
+      // Flush transition fired without any wire chunk needed.
+      expect(result.next).toBe("PAGE_ENCODING_DRAIN");
+      expect(result.flushPage?.side).toBe("back");
+      // pageCount advanced; ctx.imageBuffer reset.
+      expect(ctx.pageCount).toBe(2);
+      expect(ctx.imageBufferOffset).toBe(0);
+    }
+  });
+
   it("START_POLL advances to START_POLL_READY on byte 0 = 0x01", () => {
     const state = esciGraph.states.START_POLL;
     if (state.kind === "decision") {

--- a/src/esci/graph.ts
+++ b/src/esci/graph.ts
@@ -505,13 +505,14 @@ g.state(
     // PAGE_ENCODING_DRAIN. Without this, IMG_RECEIVING would sit on its
     // deferred queue until the engine timeout (#71). The IMG_RECEIVING
     // drain prelude stays as a backstop for fragmented arrivals.
+    const streamConfig = buildIsPacket(0x2200, buildStreamConfigPayload(reply, ctx.format));
     if (drainDeferredIntoBuffer(ctx, null) === "overflowed") {
-      return makeFlushTransition(ctx);
+      // Bundle stream-config with the flush transition so the overflow
+      // path still emits IS-0x2200 — every non-overflow START path
+      // sends it, and the printer expects it before any page-eject.
+      return makeFlushTransition(ctx, streamConfig);
     }
-    return {
-      next: "IMG_RECEIVING",
-      send: buildIsPacket(0x2200, buildStreamConfigPayload(reply, ctx.format)),
-    };
+    return { next: "IMG_RECEIVING", send: streamConfig };
   }),
 );
 
@@ -545,8 +546,15 @@ awaitReply(g, "START_POLL_READY", ESCI_REPLY, length16, "START", passthru(buildF
  * for async encode, reset per-page ctx fields, route to
  * PAGE_ENCODING_DRAIN (ADF) or POST_STATUS (flatbed). Factored out so the
  * deferred-chunk overflow branch can reuse the same construction.
+ *
+ * `preSend` lets START's overflow branch prepend the per-page IS-0x2200
+ * stream-config in front of the staged send. Without it the overflow
+ * path would skip a packet that every non-overflow START path emits
+ * (PR #79 review). Both bytes are written by the engine after encode
+ * resolves, in array order, so the IS-0x2200 still precedes the
+ * page-eject on the wire.
  */
-function makeFlushTransition(ctx: EsciCtx): TransitionResult<EsciCtx> {
+function makeFlushTransition(ctx: EsciCtx, preSend?: SendSpec<EsciCtx>): TransitionResult<EsciCtx> {
   ctx.pageCount += 1;
   const isBack = ctx.source === "adf-duplex" && ctx.pageCount % 2 === 0;
   if (!ctx.geom) {
@@ -562,11 +570,17 @@ function makeFlushTransition(ctx: EsciCtx): TransitionResult<EsciCtx> {
     encode: () => encodeRawGbrToJpeg(rawRgb, widthPx, heightPx, quality),
   };
   if (ctx.source === "flatbed") {
-    return { next: "POST_STATUS", send: sendFsF(), flushPage: flush };
+    const trailing = sendFsF();
+    return {
+      next: "POST_STATUS",
+      send: preSend !== undefined ? [preSend, trailing] : trailing,
+      flushPage: flush,
+    };
   }
+  const trailing = passthru(buildPageEject(), 1);
   return {
     next: "PAGE_ENCODING_DRAIN",
-    send: passthru(buildPageEject(), 1),
+    send: preSend !== undefined ? [preSend, trailing] : trailing,
     flushPage: flush,
   };
 }

--- a/src/esci/graph.ts
+++ b/src/esci/graph.ts
@@ -91,6 +91,16 @@ export interface EsciCtx {
   imageBufferOffset: number;
   /** Cached scan geometry (set in START alongside the imageBuffer allocation). */
   geom: ScanGeometry | null;
+  /**
+   * Trailing IS-0xa200 image chunks captured during the post-page-complete
+   * encoding window. In multi-page / ADF-duplex scans the printer eagerly
+   * streams the next page's first chunks before our flushPage barrier
+   * resolves; they're held here and drained into the next page's buffer on
+   * the next IMG_RECEIVING entry (see PAGE_ENCODING_DRAIN + IMG_RECEIVING
+   * drain prelude). In single-page-final scans the queue is harmless tail
+   * overflow that's never replayed. Issue #71 — regression from v0.4.0.
+   */
+  deferredImageChunks: Buffer[];
 }
 
 export const ESCI_TIMEOUT_MS = 60_000;
@@ -535,6 +545,34 @@ g.state(
         ),
       };
     }
+
+    // Issue #71: drain any chunks deferred during the previous page's
+    // encode window before processing the incoming chunk. In duplex /
+    // multi-page scans the printer eagerly streams the next page's first
+    // bytes while we're encoding the previous page; PAGE_ENCODING_DRAIN
+    // stashed them into ctx.deferredImageChunks. The drain runs only on
+    // the first chunk of the new page (after the first append the queue
+    // is empty for the rest of the page).
+    if (ctx.deferredImageChunks.length > 0) {
+      const chunks = ctx.deferredImageChunks;
+      ctx.deferredImageChunks = [];
+      for (let i = 0; i < chunks.length; i++) {
+        ctx.imageBufferOffset = appendImageChunk(chunks[i], ctx.imageBuffer, ctx.imageBufferOffset);
+        if (ctx.imageBufferOffset >= ctx.imageBuffer.length) {
+          // Deferred chunks alone filled the page (unlikely in practice
+          // — encode is ~100-500ms vs ~1-2s per page on the wire — but
+          // guard for safety). Re-stash the remaining deferred chunks
+          // plus the incoming chunk for the next page, then fall into
+          // the flush-completion branch.
+          for (let j = i + 1; j < chunks.length; j++) {
+            ctx.deferredImageChunks.push(chunks[j]);
+          }
+          ctx.deferredImageChunks.push(packet.payload);
+          return makeFlushTransition(ctx);
+        }
+      }
+    }
+
     ctx.imageBufferOffset = appendImageChunk(
       packet.payload,
       ctx.imageBuffer,
@@ -543,49 +581,73 @@ g.state(
     if (ctx.imageBufferOffset < ctx.imageBuffer.length) {
       return { next: "IMG_RECEIVING" };
     }
-
-    // Increment pageCount BEFORE computing side so pageCount represents the
-    // 1-indexed page we're about to flush; even pageCount → ADF-duplex back
-    // side (1=front, 2=back, 3=front, ...).
-    ctx.pageCount += 1;
-    const isBack = ctx.source === "adf-duplex" && ctx.pageCount % 2 === 0;
-    if (!ctx.geom) {
-      return { error: new Error("IMG_RECEIVING: page complete with no cached geometry") };
-    }
-    const { widthPx, heightPx } = ctx.geom;
-    const rawRgb = ctx.imageBuffer;
-    const quality = ctx.jpegQuality;
-    ctx.imageBuffer = Buffer.alloc(0);
-    ctx.imageBufferOffset = 0;
-
-    const flush = {
-      side: isBack ? ("back" as const) : ("front" as const),
-      encode: () => encodeRawGbrToJpeg(rawRgb, widthPx, heightPx, quality),
-    };
-    if (ctx.source === "flatbed") {
-      return { next: "POST_STATUS", send: sendFsF(), flushPage: flush };
-    }
-    return {
-      next: "PAGE_EJECT_WAIT",
-      send: passthru(buildPageEject(), 1),
-      flushPage: flush,
-    };
+    return makeFlushTransition(ctx);
   }),
 );
 
+/**
+ * Build the page-complete transition out of IMG_RECEIVING: snapshot the
+ * geometry/buffer for async encode, reset the per-page ctx fields, and
+ * route to PAGE_ENCODING_DRAIN (ADF) or POST_STATUS (flatbed) with the
+ * flushPage barrier attached. Factored out so the deferred-chunk overflow
+ * branch can re-use the same construction.
+ */
+function makeFlushTransition(
+  ctx: EsciCtx,
+):
+  | { next: string; send: SendSpec<EsciCtx> | SendSpec<EsciCtx>[]; flushPage: FlushPage }
+  | { error: Error } {
+  ctx.pageCount += 1;
+  const isBack = ctx.source === "adf-duplex" && ctx.pageCount % 2 === 0;
+  if (!ctx.geom) {
+    return { error: new Error("IMG_RECEIVING: page complete with no cached geometry") };
+  }
+  const { widthPx, heightPx } = ctx.geom;
+  const rawRgb = ctx.imageBuffer;
+  const quality = ctx.jpegQuality;
+  ctx.imageBuffer = Buffer.alloc(0);
+  ctx.imageBufferOffset = 0;
+  const flush: FlushPage = {
+    side: isBack ? "back" : "front",
+    encode: () => encodeRawGbrToJpeg(rawRgb, widthPx, heightPx, quality),
+  };
+  if (ctx.source === "flatbed") {
+    return { next: "POST_STATUS", send: sendFsF(), flushPage: flush };
+  }
+  return {
+    next: "PAGE_ENCODING_DRAIN",
+    send: passthru(buildPageEject(), 1),
+    flushPage: flush,
+  };
+}
+
+interface FlushPage {
+  side: "front" | "back";
+  encode: () => Promise<Buffer>;
+}
+
 // =============================================================================
-// PAGE_EJECT_WAIT — ADF only; ACKs the 0x0c 0x00 eject, sets the inter-page
-// flag, and routes back to STATUS_1A which decides whether to continue (more
-// paper) or wrap up (ADF empty). Decision so we can mutate ctx and emit FS F
-// in the same transition.
+// PAGE_ENCODING_DRAIN — ADF only; absorbs trailing IS-0xa200 image chunks
+// that arrive during the flushPage encode window (the printer eagerly
+// streams the next page's first bytes before we ACK the page-eject), then
+// ACKs the 0x0c 0x00 eject and routes back to STATUS_1A. Issue #71 —
+// without this state, trailing 0xa200 chunks landed in PAGE_EJECT_WAIT
+// and tripped its 0xa000-only validator, failing the whole scan.
 // =============================================================================
 
 g.state(
-  "PAGE_EJECT_WAIT",
+  "PAGE_ENCODING_DRAIN",
   decision<EsciCtx>((ctx, packet) => {
-    const typeGuard = expectIsType(packet, ESCI_REPLY, "PAGE_EJECT_WAIT");
+    if (packet.type === 0xa200) {
+      // Next page's pixel data, streamed eagerly by the printer. Stash
+      // for replay on the next IMG_RECEIVING entry; self-loop to keep
+      // absorbing further chunks until the eject ACK lands.
+      ctx.deferredImageChunks.push(packet.payload);
+      return { next: "PAGE_ENCODING_DRAIN" };
+    }
+    const typeGuard = expectIsType(packet, ESCI_REPLY, "PAGE_ENCODING_DRAIN");
     if (typeGuard) return typeGuard;
-    const lengthGuard = expectLength(packet.payload, 1, "PAGE_EJECT_WAIT", "page-eject ACK");
+    const lengthGuard = expectLength(packet.payload, 1, "PAGE_ENCODING_DRAIN", "page-eject ACK");
     if (lengthGuard) return lengthGuard;
     ctx.inInterPageLoop = true;
     return { next: "STATUS_1A", send: sendFsF() };

--- a/src/esci/graph.ts
+++ b/src/esci/graph.ts
@@ -10,7 +10,9 @@ import {
   decision,
   type Graph,
   type GraphBuilder,
+  type PageFlush,
   type SendSpec,
+  type TransitionResult,
 } from "../scan-session.js";
 import {
   buildLockPacket,
@@ -92,13 +94,8 @@ export interface EsciCtx {
   /** Cached scan geometry (set in START alongside the imageBuffer allocation). */
   geom: ScanGeometry | null;
   /**
-   * Trailing IS-0xa200 image chunks captured during the post-page-complete
-   * encoding window. In multi-page / ADF-duplex scans the printer eagerly
-   * streams the next page's first chunks before our flushPage barrier
-   * resolves; they're held here and drained into the next page's buffer on
-   * the next IMG_RECEIVING entry (see PAGE_ENCODING_DRAIN + IMG_RECEIVING
-   * drain prelude). In single-page-final scans the queue is harmless tail
-   * overflow that's never replayed. Issue #71 — regression from v0.4.0.
+   * Trailing IS-0xa200 chunks stashed during the encode window; drained
+   * on next IMG_RECEIVING entry. See PAGE_ENCODING_DRAIN. Issue #71.
    */
   deferredImageChunks: Buffer[];
 }
@@ -535,68 +532,13 @@ awaitReply(g, "START_POLL_READY", ESCI_REPLY, length16, "START", passthru(buildF
 // PAGE_EJECT_WAIT (ADF) or POST_STATUS (flatbed).
 // =============================================================================
 
-g.state(
-  "IMG_RECEIVING",
-  decision<EsciCtx>((ctx, packet) => {
-    if (packet.type !== 0xa200) {
-      return {
-        error: new Error(
-          `IMG_RECEIVING: expected IS-0xa200 image chunk, got 0x${packet.type.toString(16).padStart(4, "0")}`,
-        ),
-      };
-    }
-
-    // Issue #71: drain any chunks deferred during the previous page's
-    // encode window before processing the incoming chunk. In duplex /
-    // multi-page scans the printer eagerly streams the next page's first
-    // bytes while we're encoding the previous page; PAGE_ENCODING_DRAIN
-    // stashed them into ctx.deferredImageChunks. The drain runs only on
-    // the first chunk of the new page (after the first append the queue
-    // is empty for the rest of the page).
-    if (ctx.deferredImageChunks.length > 0) {
-      const chunks = ctx.deferredImageChunks;
-      ctx.deferredImageChunks = [];
-      for (let i = 0; i < chunks.length; i++) {
-        ctx.imageBufferOffset = appendImageChunk(chunks[i], ctx.imageBuffer, ctx.imageBufferOffset);
-        if (ctx.imageBufferOffset >= ctx.imageBuffer.length) {
-          // Deferred chunks alone filled the page (unlikely in practice
-          // — encode is ~100-500ms vs ~1-2s per page on the wire — but
-          // guard for safety). Re-stash the remaining deferred chunks
-          // plus the incoming chunk for the next page, then fall into
-          // the flush-completion branch.
-          for (let j = i + 1; j < chunks.length; j++) {
-            ctx.deferredImageChunks.push(chunks[j]);
-          }
-          ctx.deferredImageChunks.push(packet.payload);
-          return makeFlushTransition(ctx);
-        }
-      }
-    }
-
-    ctx.imageBufferOffset = appendImageChunk(
-      packet.payload,
-      ctx.imageBuffer,
-      ctx.imageBufferOffset,
-    );
-    if (ctx.imageBufferOffset < ctx.imageBuffer.length) {
-      return { next: "IMG_RECEIVING" };
-    }
-    return makeFlushTransition(ctx);
-  }),
-);
-
 /**
- * Build the page-complete transition out of IMG_RECEIVING: snapshot the
- * geometry/buffer for async encode, reset the per-page ctx fields, and
- * route to PAGE_ENCODING_DRAIN (ADF) or POST_STATUS (flatbed) with the
- * flushPage barrier attached. Factored out so the deferred-chunk overflow
- * branch can re-use the same construction.
+ * Page-complete transition out of IMG_RECEIVING: snapshot geometry/buffer
+ * for async encode, reset per-page ctx fields, route to
+ * PAGE_ENCODING_DRAIN (ADF) or POST_STATUS (flatbed). Factored out so the
+ * deferred-chunk overflow branch can reuse the same construction.
  */
-function makeFlushTransition(
-  ctx: EsciCtx,
-):
-  | { next: string; send: SendSpec<EsciCtx> | SendSpec<EsciCtx>[]; flushPage: FlushPage }
-  | { error: Error } {
+function makeFlushTransition(ctx: EsciCtx): TransitionResult<EsciCtx> {
   ctx.pageCount += 1;
   const isBack = ctx.source === "adf-duplex" && ctx.pageCount % 2 === 0;
   if (!ctx.geom) {
@@ -607,7 +549,7 @@ function makeFlushTransition(
   const quality = ctx.jpegQuality;
   ctx.imageBuffer = Buffer.alloc(0);
   ctx.imageBufferOffset = 0;
-  const flush: FlushPage = {
+  const flush: PageFlush = {
     side: isBack ? "back" : "front",
     encode: () => encodeRawGbrToJpeg(rawRgb, widthPx, heightPx, quality),
   };
@@ -621,10 +563,53 @@ function makeFlushTransition(
   };
 }
 
-interface FlushPage {
-  side: "front" | "back";
-  encode: () => Promise<Buffer>;
+/**
+ * Drain ctx.deferredImageChunks into the current page buffer (#71).
+ * Returns "overflowed" when the deferred chunks alone fill the page —
+ * remaining deferred entries plus `incoming` get re-stashed for the
+ * next page, and the caller should emit a flush transition.
+ */
+function drainDeferredIntoBuffer(ctx: EsciCtx, incoming: Buffer): "drained" | "overflowed" {
+  if (ctx.deferredImageChunks.length === 0) return "drained";
+  const chunks = ctx.deferredImageChunks;
+  ctx.deferredImageChunks = [];
+  for (let i = 0; i < chunks.length; i++) {
+    ctx.imageBufferOffset = appendImageChunk(chunks[i], ctx.imageBuffer, ctx.imageBufferOffset);
+    if (ctx.imageBufferOffset >= ctx.imageBuffer.length) {
+      for (let j = i + 1; j < chunks.length; j++) {
+        ctx.deferredImageChunks.push(chunks[j]);
+      }
+      ctx.deferredImageChunks.push(incoming);
+      return "overflowed";
+    }
+  }
+  return "drained";
 }
+
+g.state(
+  "IMG_RECEIVING",
+  decision<EsciCtx>((ctx, packet) => {
+    if (packet.type !== 0xa200) {
+      return {
+        error: new Error(
+          `IMG_RECEIVING: expected IS-0xa200 image chunk, got 0x${packet.type.toString(16).padStart(4, "0")}`,
+        ),
+      };
+    }
+    if (drainDeferredIntoBuffer(ctx, packet.payload) === "overflowed") {
+      return makeFlushTransition(ctx);
+    }
+    ctx.imageBufferOffset = appendImageChunk(
+      packet.payload,
+      ctx.imageBuffer,
+      ctx.imageBufferOffset,
+    );
+    if (ctx.imageBufferOffset < ctx.imageBuffer.length) {
+      return { next: "IMG_RECEIVING" };
+    }
+    return makeFlushTransition(ctx);
+  }),
+);
 
 // =============================================================================
 // PAGE_ENCODING_DRAIN — ADF only; absorbs trailing IS-0xa200 image chunks
@@ -639,9 +624,6 @@ g.state(
   "PAGE_ENCODING_DRAIN",
   decision<EsciCtx>((ctx, packet) => {
     if (packet.type === 0xa200) {
-      // Next page's pixel data, streamed eagerly by the printer. Stash
-      // for replay on the next IMG_RECEIVING entry; self-loop to keep
-      // absorbing further chunks until the eject ACK lands.
       ctx.deferredImageChunks.push(packet.payload);
       return { next: "PAGE_ENCODING_DRAIN" };
     }

--- a/src/esci/graph.ts
+++ b/src/esci/graph.ts
@@ -500,6 +500,14 @@ g.state(
     ctx.geom = geom;
     ctx.imageBuffer = Buffer.alloc(geom.widthPx * geom.heightPx * 3);
     ctx.imageBufferOffset = 0;
+    // Drain proactively here, BEFORE entering IMG_RECEIVING, in case a
+    // slow encode let the printer stash the entire next page during
+    // PAGE_ENCODING_DRAIN. Without this, IMG_RECEIVING would sit on its
+    // deferred queue until the engine timeout (#71). The IMG_RECEIVING
+    // drain prelude stays as a backstop for fragmented arrivals.
+    if (drainDeferredIntoBuffer(ctx, null) === "overflowed") {
+      return makeFlushTransition(ctx);
+    }
     return {
       next: "IMG_RECEIVING",
       send: buildIsPacket(0x2200, buildStreamConfigPayload(reply, ctx.format)),
@@ -566,10 +574,13 @@ function makeFlushTransition(ctx: EsciCtx): TransitionResult<EsciCtx> {
 /**
  * Drain ctx.deferredImageChunks into the current page buffer (#71).
  * Returns "overflowed" when the deferred chunks alone fill the page —
- * remaining deferred entries plus `incoming` get re-stashed for the
- * next page, and the caller should emit a flush transition.
+ * remaining deferred entries (plus `incoming`, when non-null) get
+ * re-stashed for the next page, and the caller should emit a flush
+ * transition. Called from START (no incoming chunk in hand yet — pass
+ * null) so a slow encode that pre-buffered the entire next page
+ * doesn't sit in IMG_RECEIVING until timeout.
  */
-function drainDeferredIntoBuffer(ctx: EsciCtx, incoming: Buffer): "drained" | "overflowed" {
+function drainDeferredIntoBuffer(ctx: EsciCtx, incoming: Buffer | null): "drained" | "overflowed" {
   if (ctx.deferredImageChunks.length === 0) return "drained";
   const chunks = ctx.deferredImageChunks;
   ctx.deferredImageChunks = [];
@@ -579,7 +590,7 @@ function drainDeferredIntoBuffer(ctx: EsciCtx, incoming: Buffer): "drained" | "o
       for (let j = i + 1; j < chunks.length; j++) {
         ctx.deferredImageChunks.push(chunks[j]);
       }
-      ctx.deferredImageChunks.push(incoming);
+      if (incoming !== null) ctx.deferredImageChunks.push(incoming);
       return "overflowed";
     }
   }

--- a/src/esci/scanner.ts
+++ b/src/esci/scanner.ts
@@ -100,6 +100,7 @@ export async function runEsciScan(
       geom: null,
       imageBuffer: Buffer.alloc(0),
       imageBufferOffset: 0,
+      deferredImageChunks: [],
     },
     transportFactory: makeTcpTransportFactory(session, socketFactory),
     outputDir: session.outputDir,


### PR DESCRIPTION
## Summary

Resolves [#71](https://github.com/mtheuma/epson2paperless/issues/71). Regression from v0.4.0's architectural rebuild ([#70](https://github.com/mtheuma/epson2paperless/pull/70)).

Pre-v0.4.0 `scanner-legacy.ts` had an explicit `PAGE_ENCODING` state that absorbed trailing `IS-0xa200` image chunks arriving during the post-page-complete encoding window. That handling was lost when the legacy scanner was collapsed onto the shared `runScanSession` engine: the new graph routed `IMG_RECEIVING` directly to `PAGE_EJECT_WAIT`, whose `0xa000`-only validator rejected anything else. In duplex / multi-page scans the printer eagerly streams the next page's first bytes before our `flushPage` barrier resolves — those bytes landed in `PAGE_EJECT_WAIT` and failed the whole scan.

## Fix (Option A per the issue)

Matches the pre-rebuild design — **stash, not drop**. The trailing chunks in duplex/multi-page mode are the next page's pixel data, not stale tail; dropping would corrupt the duplex back-page.

1. **New `EsciCtx.deferredImageChunks: Buffer[]`** holds chunks captured during the encode window.

2. **New `PAGE_ENCODING_DRAIN` graph state** replaces `PAGE_EJECT_WAIT` as the `IMG_RECEIVING` flush target:
   - on `0xa200`: push payload to `deferredImageChunks`, self-loop
   - on `0xa000` eject ACK: set `inInterPageLoop`, route to `STATUS_1A` (identical to the old `PAGE_EJECT_WAIT` behaviour)
   - other types: error

3. **`IMG_RECEIVING` decision-fn drains `deferredImageChunks`** into the new page's `imageBuffer` before processing each incoming chunk. Empty-queue check is free; after the first drain the queue is empty for the rest of the page. Defensive branch re-stashes for the next page if deferred chunks alone fill the buffer (unlikely — encode ~100-500ms vs ~1-2s of wire time per page — but matches the pre-rebuild guard).

4. **`makeFlushTransition()` extracted** so the normal path and the defensive overflow branch share page-complete construction.

## Test plan

- [x] Replay shield (`src/esci/scanner.test.ts` × 10 WF-3620 fixtures) passes byte-for-byte — captured pcaps don't contain trailing `0xa200` chunks (per the issue's *"fixtures' inter-burst gaps happen to land in IMG_RECEIVING's accumulator window"*), so the new path only fires under real-hardware timing variance.
- [x] 6 new `graph.test.ts` tests:
  - `PAGE_ENCODING_DRAIN: 0xa000 eject ACK sets inInterPageLoop and routes to STATUS_1A` (was the old `PAGE_EJECT_WAIT` test, renamed)
  - `PAGE_ENCODING_DRAIN: trailing 0xa200 chunk is stashed and self-loops`
  - `PAGE_ENCODING_DRAIN: stashes multiple trailing 0xa200 chunks in order`
  - `PAGE_ENCODING_DRAIN: rejects unexpected packet types`
  - `PAGE_ENCODING_DRAIN: rejects 0xa000 with wrong length`
  - `IMG_RECEIVING: drains deferredImageChunks into the new page buffer before processing the incoming chunk`
  - `IMG_RECEIVING: deferred-chunk drain that fills the page re-stashes the incoming chunk for the next page`
- [x] Lint + Prettier clean
- [x] Full suite: 518 passed (was 512, +6 new), no regressions
- [ ] CI green
- [ ] **Hardware smoke (WF-3620 multi-page) deferred** — unit-test layer proves the state machine handles trailing chunks, but the issue's acceptance criterion *"no dropped pages on real hardware"* needs the printer. Validate against the released image when WF-3620 is next available.

## Parallel with PR #78

This PR is fully independent of [#78](https://github.com/mtheuma/epson2paperless/pull/78) (issue #72, raw-socket clean-close). Zero file overlap: #78 touches `src/esci/transport.ts` (new) and the transport-factory site in `src/esci/scanner.ts`; this PR touches `src/esci/graph.ts` and `src/esci/graph.test.ts` plus the `initialCtx` field in `scanner.ts`. The `scanner.ts` diff in this PR is one line and won't conflict with #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)