### PR TITLE
docs: mark XP-7100 as Verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ What you get:
 | **ET-4950 / ET-4956** | ✅ Verified |                                                                                                                             |
 | **WF-3620**           | ✅ Verified | Plain TCP scanner, no TLS pinning                                                                                           |
 | **ET-2750**           | ✅ Verified | Flatbed-only hardware; ESC/I-2 over plain TCP, no TLS                                                                       |
-| **XP-7100**           | 🟡 Partial  | Replay-verified from [#65](https://github.com/mtheuma/epson2paperless/issues/65) captures; on-hardware confirmation pending |
+| **XP-7100**           | ✅ Verified |                                                                                                                             |
 
 Compatibility reports are welcome whether your model works or doesn't. [Open an issue](https://github.com/mtheuma/epson2paperless/issues/new?template=compatibility.yml) using the compatibility template.
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ What you get:
 
 ## Compatible printers
 
-| Model                 | Status      | Notes                                                                                                                       |
-| --------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------- |
-| **ET-3950**           | ✅ Verified |                                                                                                                             |
-| **ET-4950 / ET-4956** | ✅ Verified |                                                                                                                             |
-| **WF-3620**           | ✅ Verified | Plain TCP scanner, no TLS pinning                                                                                           |
-| **ET-2750**           | ✅ Verified | Flatbed-only hardware; ESC/I-2 over plain TCP, no TLS                                                                       |
-| **XP-7100**           | ✅ Verified |                                                                                                                             |
+| Model                 | Status      | Notes                                                 |
+| --------------------- | ----------- | ----------------------------------------------------- |
+| **ET-3950**           | ✅ Verified |                                                       |
+| **ET-4950 / ET-4956** | ✅ Verified |                                                       |
+| **WF-3620**           | ✅ Verified | Plain TCP scanner, no TLS pinning                     |
+| **ET-2750**           | ✅ Verified | Flatbed-only hardware; ESC/I-2 over plain TCP, no TLS |
+| **XP-7100**           | ✅ Verified |                                                       |
 
 Compatibility reports are welcome whether your model works or doesn't. [Open an issue](https://github.com/mtheuma/epson2paperless/issues/new?template=compatibility.yml) using the compatibility template.
 


### PR DESCRIPTION
## Summary

- Flip XP-7100 compat row from 🟡 Partial → ✅ Verified
- Clear the Notes column (no caveats to record; matches ET-3950 / ET-4950 rows)

@utf8please confirmed v0.4.1 working on real XP-7100 hardware in [#65](https://github.com/mtheuma/epson2paperless/issues/65) — flatbed JPG/PDF, ADF JPG/PDF, and ADF duplex all produced sensible output. The two issues he hit (dark scan lines, ADF jam) were hardware-side, not protocol bugs.

Closes #65.

## Test plan

- [x] README renders correctly (table alignment preserved)
- [ ] CI: lint + format + test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)