### PR TITLE
chore(hooks): run lint + format:check on every push, drop tests

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,41 +1,33 @@
 #!/bin/sh
-# pre-push hook: run lint + format:check + test before allowing a push to main.
+# pre-push hook: run lint + format:check before every push.
 #
 # Activate (once per clone):   git config core.hooksPath .githooks
 # Bypass in a one-off case:    git push --no-verify
 #
-# Why only main: feature / integration branches are fair game for
-# in-progress WIP pushes. CI will still run the full gate on every push via
-# .github/workflows/test.yml — this hook is a local backstop for the
-# "oops, I just committed straight to main" case, matching CI's three-step
-# gate (lint + format:check + test) so a push that passes here will also
-# pass CI.
+# Runs on every push (any branch), not just main: server-side branch
+# protection on main means the local hook can't actually gate pushes to
+# main anyway, so this is purely a fast local feedback loop — catching
+# lint/format issues before CI does and saving the ~60s round-trip.
+#
+# Tests are intentionally NOT run here — they're too slow (~6s) to put in
+# every push. CI runs the full three-step gate (lint + format:check + test)
+# via .github/workflows/test.yml on every push and PR.
 
-while read -r local_ref local_sha remote_ref remote_sha; do
-  if [ "$remote_ref" = "refs/heads/main" ]; then
-    echo "[pre-push] Pushing to main — running lint + format:check + tests..."
-    if ! npm run lint; then
-      echo ""
-      echo "[pre-push] Lint failed — push to main aborted."
-      echo "[pre-push] Try:  npm run lint:fix"
-      echo "[pre-push] Or bypass with:  git push --no-verify"
-      exit 1
-    fi
-    if ! npm run format:check; then
-      echo ""
-      echo "[pre-push] Prettier check failed — push to main aborted."
-      echo "[pre-push] Fix with:  npm run format  (then commit)"
-      echo "[pre-push] Or bypass with:  git push --no-verify"
-      exit 1
-    fi
-    if ! npm test; then
-      echo ""
-      echo "[pre-push] Tests failed — push to main aborted."
-      echo "[pre-push] Or bypass with:  git push --no-verify"
-      exit 1
-    fi
-    echo "[pre-push] All checks passed — allowing push."
-  fi
-done
+echo "[pre-push] Running lint + format:check..."
+if ! npm run lint; then
+  echo ""
+  echo "[pre-push] Lint failed — push aborted."
+  echo "[pre-push] Try:  npm run lint:fix"
+  echo "[pre-push] Or bypass with:  git push --no-verify"
+  exit 1
+fi
+if ! npm run format:check; then
+  echo ""
+  echo "[pre-push] Prettier check failed — push aborted."
+  echo "[pre-push] Fix with:  npm run format  (then commit)"
+  echo "[pre-push] Or bypass with:  git push --no-verify"
+  exit 1
+fi
+echo "[pre-push] Lint + format clean — allowing push. (Tests run in CI.)"
 
 exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ npm test                             # 216 tests, ~1s
 
 - Branch off `main`. PR back to `main`.
 - Commit-message style: `type: short summary` — `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`. The body explains the _why_ when it isn't obvious from the diff.
-- The CI gate is `npm run lint`, `npm run format:check`, and `npm test` — all three must pass. Activate the local pre-push hook with `git config core.hooksPath .githooks` to catch issues before pushing.
+- The CI gate is `npm run lint`, `npm run format:check`, and `npm test` — all three must pass. The local pre-push hook (`git config core.hooksPath .githooks`, one-time per clone) runs the first two on every push so you catch lint/format issues before CI does; tests are left to CI to keep the hook fast.
 - If your PR addresses an open issue, link it in the description.
 - Protocol changes that affect wire bytes need matching updates to the Frida-capture fixtures in `tools/frida-capture/captures/` — the byte-for-byte replay test in `src/scanner.test.ts` will fail otherwise. See `tools/frida-capture/README.md` for the re-capture workflow.
 


### PR DESCRIPTION
## Summary

- Pre-push hook now runs on **every push** (any branch), not just main
- Drops `npm test` from the hook — CI keeps the full three-step gate; the hook is just a fast local feedback loop (~3s instead of ~9s)
- Updates `CONTRIBUTING.md` to reflect the hook's new scope vs CI's

## Why

Server-side branch protection on main already enforces PR + CI, so a main-only local hook was theatre — direct pushes to main can't bypass the gate anyway. The change makes the hook useful for the case it was actually missing: catching lint/format issues on feature branches before they fail CI (like the Prettier slip on docs/xp7100-verified that needed a fixup commit).

Self-dogfooded: the push that created this PR ran the new hook (lint + format:check clean).

## Test plan

- [x] Hook fires and passes on the push for this branch
- [x] `npm run lint` clean locally
- [x] `npm run format:check` clean locally
- [ ] CI: lint + format + test pass on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)