### PR TITLE
Add Ko-fi funding link to repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: A0A41CAGWG


### PR DESCRIPTION
## Summary
Adds a GitHub funding configuration file to enable the Ko-fi sponsor button on the repository.

## Changes
- Added `.github/FUNDING.yml` with Ko-fi account identifier (`A0A41CAGWG`)

This enables GitHub's built-in funding link feature, allowing users to easily discover and support the project via Ko-fi.

https://claude.ai/code/session_01KHwViS5ZJr17Vy4PERTvrA