### PR TITLE
test(esci2): pin IMG_DATA XP-7100 re-echo branch with focused unit cases

### DIFF
--- a/src/esci2/graph.test.ts
+++ b/src/esci2/graph.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { esci2Graph, ESCI2_TIMEOUT_MS } from "./graph.js";
-import { IS_HEADER_SIZE } from "../protocol.js";
+import { IS_HEADER_SIZE, buildPurereadPacket } from "../protocol.js";
 import { et4950FamilyDialect } from "./dialects/et-4950-family.js";
 import { et2750Dialect } from "./dialects/et-2750.js";
 
@@ -673,10 +673,19 @@ describe("esci2Graph T25 — IMG_DATA XP-7100 re-echo branch", () => {
   // focused cases pin the branch so future IMG_DATA refactors fail fast
   // against a unit test instead of via a ~9,800-line fixture mismatch.
 
-  it("64-byte well-formed IMG echo with matching imgChunkSize → re-issues PUREREAD and stays in IMG_DATA", () => {
+  it("64-byte well-formed IMG echo with matching imgChunkSize → re-issues PUREREAD(imgChunkSize) and preserves accumulated chunks", () => {
     const state = esci2Graph.states.IMG_DATA;
     if (state.kind !== "decision") return;
-    const ctx = makeCtx({ imgChunkSize: 0x100000, pageEndKind: "none", imageChunks: [] });
+    // Seed two prior chunks to prove the re-echo branch is non-destructive —
+    // re-echos can fire mid-page after some pixel data has already been
+    // accumulated, so the existing imageChunks must survive untouched.
+    const priorA = Buffer.from([0x11, 0x22, 0x33]);
+    const priorB = Buffer.from([0x44, 0x55]);
+    const ctx = makeCtx({
+      imgChunkSize: 0x100000,
+      pageEndKind: "none",
+      imageChunks: [priorA, priorB],
+    });
     // 64-byte IMG header re-echo: cmd="IMG", length=0x100000 (matches ctx.imgChunkSize).
     // 12-byte header + 52 bytes filler = 64 bytes total (ESCI2_REPLY_SIZE).
     const echo = Buffer.from("IMG x0100000" + " ".repeat(52), "ascii");
@@ -684,9 +693,15 @@ describe("esci2Graph T25 — IMG_DATA XP-7100 re-echo branch", () => {
     const result = state.decide(ctx, { type: 0xa000, payload: echo });
     if ("error" in result) throw result.error;
     expect(result.next).toBe("IMG_DATA");
-    expect(result.send).toBeDefined();
-    // No chunk accumulated — this isn't pixel data, just the echo.
-    expect(ctx.imageChunks).toEqual([]);
+    // Exact bytes: the response must be PUREREAD(imgChunkSize), not just
+    // some non-empty send. Byte-equivalence pins the contract that the
+    // engine re-asks for the *same* chunk size the printer originally
+    // declared, rather than e.g. defaulting to the 64-byte reply size.
+    expect(result.send).toEqual(buildPurereadPacket(0x100000));
+    // Accumulated chunks survive verbatim — the re-echo is not pixel data.
+    expect(ctx.imageChunks).toEqual([priorA, priorB]);
+    expect(ctx.imageChunks[0]).toBe(priorA); // same reference, not a copy
+    expect(ctx.imageChunks[1]).toBe(priorB);
     // No page flush — pixel data hasn't arrived yet.
     expect(result.flushPage).toBeUndefined();
   });

--- a/src/esci2/graph.test.ts
+++ b/src/esci2/graph.test.ts
@@ -660,6 +660,84 @@ describe("esci2Graph T25 — IMG_DATA decision", () => {
   });
 });
 
+describe("esci2Graph T25 — IMG_DATA XP-7100 re-echo branch", () => {
+  // XP-7100 (and possibly other dialects) re-echo the IMG metadata reply in
+  // response to PUREREAD before delivering pixel data. The IMG_DATA state
+  // detects this by checking that the unexpected-length payload is a
+  // well-formed 64-byte IMG header whose declared size matches the chunk
+  // size the engine already stored, and if so re-issues PUREREAD to pull
+  // the real pixel chunk.
+  //
+  // Covered end-to-end by the XP-7100 ADF simplex replay
+  // (tools/pcap-extract/captures/xp-7100/jpg-adf-simplex.jsonl); these
+  // focused cases pin the branch so future IMG_DATA refactors fail fast
+  // against a unit test instead of via a ~9,800-line fixture mismatch.
+
+  it("64-byte well-formed IMG echo with matching imgChunkSize → re-issues PUREREAD and stays in IMG_DATA", () => {
+    const state = esci2Graph.states.IMG_DATA;
+    if (state.kind !== "decision") return;
+    const ctx = makeCtx({ imgChunkSize: 0x100000, pageEndKind: "none", imageChunks: [] });
+    // 64-byte IMG header re-echo: cmd="IMG", length=0x100000 (matches ctx.imgChunkSize).
+    // 12-byte header + 52 bytes filler = 64 bytes total (ESCI2_REPLY_SIZE).
+    const echo = Buffer.from("IMG x0100000" + " ".repeat(52), "ascii");
+    expect(echo.length).toBe(64);
+    const result = state.decide(ctx, { type: 0xa000, payload: echo });
+    if ("error" in result) throw result.error;
+    expect(result.next).toBe("IMG_DATA");
+    expect(result.send).toBeDefined();
+    // No chunk accumulated — this isn't pixel data, just the echo.
+    expect(ctx.imageChunks).toEqual([]);
+    // No page flush — pixel data hasn't arrived yet.
+    expect(result.flushPage).toBeUndefined();
+  });
+
+  it("64-byte well-formed IMG echo with non-matching imgChunkSize → errors", () => {
+    const state = esci2Graph.states.IMG_DATA;
+    if (state.kind !== "decision") return;
+    const ctx = makeCtx({ imgChunkSize: 0x100000, pageEndKind: "none", imageChunks: [] });
+    // Well-formed 64-byte IMG header but length=0x0099999 ≠ ctx.imgChunkSize.
+    // Without the size match we can't be sure this is a benign re-echo;
+    // could equally be a desync, so the safe call is to error out.
+    const echo = Buffer.from("IMG x0099999" + " ".repeat(52), "ascii");
+    expect(echo.length).toBe(64);
+    const result = state.decide(ctx, { type: 0xa000, payload: echo });
+    expect("error" in result).toBe(true);
+  });
+
+  it("64-byte payload that does not parse as an ESC/I-2 reply header → errors", () => {
+    const state = esci2Graph.states.IMG_DATA;
+    if (state.kind !== "decision") return;
+    const ctx = makeCtx({ imgChunkSize: 0x100000, pageEndKind: "none", imageChunks: [] });
+    // 64 zero bytes — byte 4 isn't 'x' → parseEsci2ReplyHeader returns null.
+    const garbage = Buffer.alloc(64, 0x00);
+    const result = state.decide(ctx, { type: 0xa000, payload: garbage });
+    expect("error" in result).toBe(true);
+  });
+
+  it("64-byte well-formed reply with non-IMG cmd → errors", () => {
+    const state = esci2Graph.states.IMG_DATA;
+    if (state.kind !== "decision") return;
+    const ctx = makeCtx({ imgChunkSize: 0x100000, pageEndKind: "none", imageChunks: [] });
+    // Well-formed 64-byte reply header with matching length but cmd="STAT".
+    // The re-echo branch is gated on cmd==="IMG"; any other command falls
+    // through to the error path.
+    const echo = Buffer.from("STATx0100000" + " ".repeat(52), "ascii");
+    expect(echo.length).toBe(64);
+    const result = state.decide(ctx, { type: 0xa000, payload: echo });
+    expect("error" in result).toBe(true);
+  });
+
+  it("non-64-byte short payload that doesn't match imgChunkSize → errors", () => {
+    const state = esci2Graph.states.IMG_DATA;
+    if (state.kind !== "decision") return;
+    const ctx = makeCtx({ imgChunkSize: 100, pageEndKind: "none", imageChunks: [] });
+    // 50 bytes — neither the expected chunk size (100) nor the 64-byte echo
+    // size, so the re-echo branch is skipped and we go straight to error.
+    const result = state.decide(ctx, { type: 0xa000, payload: Buffer.alloc(50) });
+    expect("error" in result).toBe(true);
+  });
+});
+
 describe("esci2Graph T25 — IMG_META zero-length chunk handling", () => {
   it("IMG_META zero-chunk + pageEndKind=last + accumulated → emits flushPage and goes to FIN_AFTER_IMG", async () => {
     const state = esci2Graph.states.IMG_META;


### PR DESCRIPTION
## Summary

- Adds five focused unit cases to `src/esci2/graph.test.ts` pinning the XP-7100 IMG_DATA re-echo branch
- Carried over from PR #82 review (next-steps M1)

## Context

The IMG_DATA decision state ([`src/esci2/graph.ts:802-823`](../blob/main/src/esci2/graph.ts#L802-L823)) handles a quirk where some dialects re-echo the IMG metadata reply in response to PUREREAD before delivering pixel data. Currently that branch is covered only by the XP-7100 ADF simplex end-to-end replay fixture (~9,800 lines), so any future refactor that breaks it surfaces as a fixture mismatch rather than a focused unit test failure.

## Cases added

| Input | Expected |
|---|---|
| 64-byte IMG echo, length matches `ctx.imgChunkSize` | Re-issue PUREREAD, stay in IMG_DATA |
| 64-byte IMG echo, length ≠ `ctx.imgChunkSize` | Error (could be desync, not safe to assume re-echo) |
| 64-byte payload with byte 4 ≠ `'x'` (unparseable header) | Error |
| 64-byte well-formed reply with cmd ≠ `"IMG"` | Error |
| Non-64-byte short payload, length ≠ `ctx.imgChunkSize` | Error |

## Test plan
- [x] `npx vitest run src/esci2/graph.test.ts` — all 93 tests pass (5 new + 88 existing)
- [x] `npm test` — full suite green (586 passed, 1 skipped)
- [x] `npm run lint`
- [x] `npm run format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)