### PR TITLE
chore(esci2): log resolved dialect at DEBUG in INIT1_CAPA

### DIFF
--- a/src/esci2/graph.ts
+++ b/src/esci2/graph.ts
@@ -26,6 +26,9 @@ import type { Dialect } from "./dialect.js";
 import { computeCapaFingerprint } from "./capa-fingerprint.js";
 import { lookupDialect, buildDiagnostic } from "./dialect-registry.js";
 import { UnsupportedDialectError } from "./dialect.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("scanner-esci2");
 
 /**
  * Per-session mutable state threaded through every transition. The engine
@@ -302,6 +305,10 @@ twoPhaseRead(
       return { error: new UnsupportedDialectError(fingerprint, diagnostic) };
     }
     ctx.dialect = dialect;
+    // Surface the dialect that won the CAPA-fingerprint lookup so traces are
+    // self-documenting. Otherwise the only signal that resolution succeeded
+    // is the absence of an UnsupportedDialectError further downstream.
+    log.debug("Dialect resolved", { name: dialect.displayName, fingerprint });
   },
 );
 


### PR DESCRIPTION
## Summary

- Adds a one-line `log.debug("Dialect resolved", { name, fingerprint })` breadcrumb to the INIT1_CAPA callback in `src/esci2/graph.ts` so debug traces show which dialect won the CAPA-fingerprint lookup
- Adds the missing `createLogger("scanner-esci2")` to `src/esci2/graph.ts` (mirrors `scanner-esci` in the legacy path)
- Carried over from PR #82 review (next-steps M3)

## Why

Previously the only signal that dialect resolution succeeded was the *absence* of an `UnsupportedDialectError` downstream. Caught during the v0.4.1 ET-4950 ADF duplex smoke on 2026-05-13 — confirming the dialect was working meant inferring it from the absence of errors instead of seeing it in the trace.

With this line, `LOG_LEVEL=debug` now shows e.g.:

```
[scanner-esci2] DEBUG Dialect resolved name=ET-4950 family fingerprint=...
```

## Test plan
- [x] `npm test` — full suite green (581 passed, 1 skipped; no test count change)
- [x] `npm run lint`
- [x] `npm run format:check`

No new unit test — the log line is a non-functional breadcrumb. Adding a `log.debug` assertion would require mocking the logger module for a one-line side effect; not worth the friction. Verifiable manually with `LOG_LEVEL=debug npm run dev` against any supported printer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)