### PR TITLE
perf(esci/test-support): synthesiseImageStream as a generator

### DIFF
--- a/src/esci/test-support/replay.ts
+++ b/src/esci/test-support/replay.ts
@@ -19,6 +19,12 @@ const FILL_BUFFER = Buffer.alloc(MAX_CHUNK_SIZE, 0xb0);
  * Drive a fixture replay: connect the fake socket, feed all printer→host events in
  * order (with a setImmediate yield before each to let the state machine process the
  * previous reply), then await the session promise.
+ *
+ * Synthesised image streams yield between every packet, not just between events.
+ * Without that, fake.feed() is synchronous (emit → handler → recvChunks.push), the
+ * engine pump's re-entrancy guard short-circuits subsequent void tryDispatch() calls
+ * while the first await is suspended, and the whole stream accumulates in recvChunks
+ * before the pump gets a chance to drain. Per-packet yields keep peak bounded.
  */
 export async function driveFixture(
   fixture: FixtureEvent[],
@@ -34,6 +40,7 @@ export async function driveFixture(
     } else {
       for (const p of synthesiseImageStream(event.totalBytes, event.chunkSize)) {
         fake.feed(p);
+        await new Promise((r) => setImmediate(r));
       }
     }
   }

--- a/src/esci/test-support/replay.ts
+++ b/src/esci/test-support/replay.ts
@@ -49,16 +49,14 @@ export async function driveFixture(
  * that yields a recognisable JPEG when sharp encodes it (useful for
  * eyeballing test failures).
  */
-function synthesiseImageStream(totalBytes: number, chunkSize: number): Buffer[] {
+function* synthesiseImageStream(totalBytes: number, chunkSize: number): Generator<Buffer> {
   if (chunkSize > MAX_CHUNK_SIZE) {
     throw new Error(`synthesiseImageStream: chunkSize ${chunkSize} exceeds MAX_CHUNK_SIZE`);
   }
-  const out: Buffer[] = [];
   let remaining = totalBytes;
   while (remaining > 0) {
     const size = Math.min(chunkSize, remaining);
-    out.push(buildIsPacket(0xa200, FILL_BUFFER.subarray(0, size)));
+    yield buildIsPacket(0xa200, FILL_BUFFER.subarray(0, size));
     remaining -= size;
   }
-  return out;
 }


### PR DESCRIPTION
## Summary

Two-commit perf fix to the legacy ESC/I replay harness:

1. `synthesiseImageStream` converted from an eager `Buffer[]` builder to a `function*` generator (eliminates reference duplication of the synthesised stream).
2. **`driveFixture` now yields `setImmediate` between every `fake.feed()` inside a synthesised image stream.** Without that, `fake.feed()` synchronously pushes into the engine's `recvChunks` queue, and the pump's re-entrancy guard (`if (dispatching) return`) short-circuits subsequent `void tryDispatch()` calls while the first `await dispatchPacket(...)` is suspended — so a synchronous for-loop would fill `recvChunks` with the whole stream before the pump could drain.

The original PR description claimed peak dropped to "one packet (~chunkSize + framing, ≤64 KB)". That was wrong about commit 1 alone — review caught the gap. With commit 2 in place, peak is bounded by per-packet engine drain rate (a few packets at most for sync-resolving state hooks; potentially a small handful while sharp processes a page boundary), not by the total stream length.

Clears the matching bullet under **Deferred technical debt — Performance** in `.reference/next-steps.md`.

The sole caller (`driveFixture` in the same file) already iterates with `for...of`, so no caller change.

## Test plan

- [x] `npx vitest run src/esci/scanner.test.ts src/esci2/scanner.test.ts` — 50/50 replay tests pass on both commits
- [x] `npm test` — 589 passed / 1 skipped (baseline)
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] Replay-suite runtime: 2.68s baseline → 2.71s with both commits (within noise; ~1700 extra setImmediate yields, microsecond cost each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)