### PR TITLE
docs: drop dev-branch references; correct pre-push hook description

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: test
 
 on:
   push:
-    branches: [dev, main]
+    branches: [main]
   pull_request:
-    branches: [dev, main]
+    branches: [main]
 
 permissions:
   contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,15 +71,15 @@ The ESC/I-2 `PARA` payload is built per-dialect: at INIT1 the graph hashes the p
 
 ## Development workflow
 
-- `main` = deployable. `dev` = integration.
-- Work on `dev` or short-lived branches off `dev`; PR to `main` via `gh pr create --base main --head dev`.
-- CI (`.github/workflows/test.yml`) runs `npm install` and then the same lint + format:check + test trio that the local pre-push hook enforces, on every push to `dev`/`main` and every PR targeting `main`. Uses `npm install` (not `npm ci`) because the lockfile is generated on Windows and lacks Linux-only optional native deps — don't swap to `npm ci` without regenerating the lockfile on Linux.
+- `main` is deployable and protected. There is no long-lived integration branch.
+- Branch off `main`, push, open a PR with `gh pr create --base main --head <branch>`. Merge once CI is green.
+- CI (`.github/workflows/test.yml`) runs `npm install` and then lint + format:check + test, on every push to `main` and every PR targeting `main`. Uses `npm install` (not `npm ci`) because the lockfile is generated on Windows and lacks Linux-only optional native deps — don't swap to `npm ci` without regenerating the lockfile on Linux.
 - A separate `.github/workflows/docker.yml` builds and publishes a multi-arch image to GHCR on pushes to `main` and on `v*` tags. `Dockerfile` + `compose.yaml` at the repo root are the deploy artifacts.
 - Server-side branch protection on `main`: PR required, CI status check required, linear history required.
 
 ### Local pre-push hook
 
-`.githooks/pre-push` blocks `git push origin main` unless `npm run lint`, `npm run format:check`, and `npm test` all pass — mirrors CI's three-step gate so a push that passes here will also pass CI. **Activate once per clone:**
+`.githooks/pre-push` runs `npm run lint` and `npm run format:check` before every push, aborting on failure. Tests are intentionally skipped locally (too slow for every push) — CI runs the full `npm test` on every push and PR. **Activate once per clone:**
 
 ```
 git config core.hooksPath .githooks


### PR DESCRIPTION
## Summary

- `CLAUDE.md` "Development workflow": dropped the long-lived `dev` integration branch. Current flow is feature branch → PR directly to `main`.
- `CLAUDE.md` "Local pre-push hook": corrected to reflect the hook's actual scope (lint + format:check; tests run in CI only, per the hook's own header comment).
- `.github/workflows/test.yml`: dropped `dev` from the `push` and `pull_request` trigger branches. Harmless before (no branch exists, trigger never fired) but misleading documentation.

No functional code changes.

## Test plan

- [x] `npm run format:check` clean
- [x] CI exercises the updated workflow on this PR — `pull_request` trigger filter matches the PR base (`main`), which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)