### PR TITLE
feat(esci2): infer ET-2950 dialect from ET-4950 family (#92)

### DIFF
--- a/src/esci2/capabilities.test.ts
+++ b/src/esci2/capabilities.test.ts
@@ -24,7 +24,7 @@ describe("parseCapaTokens", () => {
     // we expose them as raw strings after the prefix and let callers do
     // their own slicing for specific values.
     const capa = Buffer.from(
-      "#GMMLISTUG10UG18#CMXLISTUNITUM08#QITLISTPREFON  OFF #FMTLISTRAW JPG ",
+      "#GMMLISTUG10UG18#CMXLISTUNITUM08#QITLISTPREFON  OFF #FMTLISTRAW JPG #CCTLISTCOL MONOPREF",
       "ascii",
     );
     const parsed = parseCapaTokens(capa);
@@ -32,6 +32,7 @@ describe("parseCapaTokens", () => {
     expect(parsed.cmxList).toBe("UNITUM08");
     expect(parsed.qitList).toBe("PREFON  OFF");
     expect(parsed.fmtList).toBe("RAW JPG");
+    expect(parsed.cctList).toBe("COL MONOPREF");
   });
 
   it("detects ADF duplex by presence of #ADFDPLX segment", () => {
@@ -46,6 +47,7 @@ describe("parseCapaTokens", () => {
     const parsed = parseCapaTokens(capa);
     expect(parsed.cmxList).toBeNull();
     expect(parsed.qitList).toBeNull();
+    expect(parsed.cctList).toBeNull();
   });
 });
 

--- a/src/esci2/capabilities.ts
+++ b/src/esci2/capabilities.ts
@@ -41,6 +41,13 @@ export interface CapaTokens {
   qitList: string | null;
   /** Raw text after `#FMTLIST` prefix, e.g. "RAW JPG". Null if absent. */
   fmtList: string | null;
+  /**
+   * Raw text after `#CCTLIST` prefix, e.g. "COL MONOPREF". Null if absent.
+   * Presence/absence drives whether the host driver emits `#CCTCOL ` in
+   * PARA, which changes PARA length by 8 bytes; surface it in diagnostics
+   * so a new printer's report tells us which PARA variant to send.
+   */
+  cctList: string | null;
   /** True if the CAPA body contains a `#ADFDPLX` segment. */
   adfDuplex: boolean;
   /** Raw segments, in encounter order. Includes unrecognised prefixes. */
@@ -89,6 +96,7 @@ export function parseCapaTokens(body: Buffer): CapaTokens {
     cmxList: textAfterPrefix(segments, "#CMXLIST"),
     qitList: textAfterPrefix(segments, "#QITLIST"),
     fmtList: textAfterPrefix(segments, "#FMTLIST"),
+    cctList: textAfterPrefix(segments, "#CCTLIST"),
     adfDuplex: segments.some((s) => s.startsWith("#ADFDPLX")),
     segments,
   };

--- a/src/esci2/dialect-registry.test.ts
+++ b/src/esci2/dialect-registry.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { lookupDialect, DIALECTS, buildDiagnostic } from "./dialect-registry.js";
 import { et4950FamilyDialect } from "./dialects/et-4950-family.js";
 import { et2750Dialect } from "./dialects/et-2750.js";
+import { et2950Dialect } from "./dialects/et-2950.js";
 import { xp7100Dialect } from "./dialects/xp-7100.js";
 import { UnsupportedDialectError } from "./dialect.js";
 import { computeCapaFingerprint } from "./capa-fingerprint.js";
@@ -30,6 +31,11 @@ describe("dialect registry", () => {
     expect(DIALECTS).toContain(xp7100Dialect);
     expect(lookupDialect(xp7100Dialect.capaFingerprint)).toBe(xp7100Dialect);
   });
+
+  it("includes ET-2950 in the registry", () => {
+    expect(DIALECTS).toContain(et2950Dialect);
+    expect(lookupDialect(et2950Dialect.capaFingerprint)).toBe(et2950Dialect);
+  });
 });
 
 describe("buildDiagnostic", () => {
@@ -39,7 +45,7 @@ describe("buildDiagnostic", () => {
       "ascii",
     );
     const capa = Buffer.from(
-      "#GMMLISTUG10UG18#CMXLISTUNITUM08#QITLISTPREFON  OFF #ADFDPLX",
+      "#GMMLISTUG10UG18#CMXLISTUNITUM08#QITLISTPREFON  OFF #CCTLISTCOL MONOPREF#ADFDPLX",
       "ascii",
     );
     const diagnostic = buildDiagnostic({
@@ -57,12 +63,13 @@ describe("buildDiagnostic", () => {
     expect(diagnostic).toContain("d850i0001400"); // ADF scan area
     expect(diagnostic).toContain("UG10UG18");
     expect(diagnostic).toContain("UNITUM08");
+    expect(diagnostic).toContain("COL MONOPREF"); // CCT list surfaced
     expect(diagnostic).toContain("abc123");
   });
 
   it("marks ADF/duplex as N for a flatbed-only printer", () => {
     const info = Buffer.from("#FB AREAd850i0001170#PRDh010PID 112A", "ascii");
-    const capa = Buffer.from("#GMMLISTUG10UG18", "ascii"); // no #ADFDPLX
+    const capa = Buffer.from("#GMMLISTUG10UG18", "ascii"); // no #ADFDPLX, no #CCTLIST
     const diagnostic = buildDiagnostic({
       capaBody: capa,
       infoBody: info,
@@ -71,6 +78,7 @@ describe("buildDiagnostic", () => {
     });
     expect(diagnostic).toMatch(/Source caps:.*flatbed: Y.*ADF: N.*duplex: N/);
     expect(diagnostic).toContain("(absent)"); // for the ADF scan-area row
+    expect(diagnostic).toMatch(/CCT list:\s+\(absent\)/); // CCT absence is meaningful, not just blank
   });
 
   it("throws an UnsupportedDialectError when explicitly raised", () => {

--- a/src/esci2/dialect-registry.ts
+++ b/src/esci2/dialect-registry.ts
@@ -1,6 +1,7 @@
 import { parseCapaTokens, parseInfoTokens } from "./capabilities.js";
 import { et4950FamilyDialect } from "./dialects/et-4950-family.js";
 import { et2750Dialect } from "./dialects/et-2750.js";
+import { et2950Dialect } from "./dialects/et-2950.js";
 import { xp7100Dialect } from "./dialects/xp-7100.js";
 import type { Dialect } from "./dialect.js";
 
@@ -10,7 +11,12 @@ import type { Dialect } from "./dialect.js";
  * the only required code change to support a new model — provided its
  * wire bytes fit one of the existing dialects' shapes.
  */
-export const DIALECTS: readonly Dialect[] = [et4950FamilyDialect, et2750Dialect, xp7100Dialect];
+export const DIALECTS: readonly Dialect[] = [
+  et4950FamilyDialect,
+  et2750Dialect,
+  et2950Dialect,
+  xp7100Dialect,
+];
 
 const BY_FINGERPRINT: ReadonlyMap<string, Dialect> = new Map(
   DIALECTS.map((d) => [d.capaFingerprint, d]),
@@ -54,6 +60,7 @@ export function buildDiagnostic(args: {
     `CMX list:          ${capa.cmxList ?? "(absent)"}`,
     `QIT list:          ${capa.qitList ?? "(absent)"}`,
     `FMT list:          ${capa.fmtList ?? "(absent)"}`,
+    `CCT list:          ${capa.cctList ?? "(absent)"}`,
     `INFO segments:     ${info.segments.length}`,
     `CAPA segments:     ${capa.segments.length}`,
   ].join("\n");

--- a/src/esci2/dialects/et-2950.test.ts
+++ b/src/esci2/dialects/et-2950.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { et2950Dialect } from "./et-2950.js";
+import { buildParaFlatbedTls } from "../commands.js";
+
+// Note on scope: there is no captured ET-2950 fixture. This file is a
+// plumbing/provenance guard, not a printer-byte correctness fixture —
+// unlike `et-2750.test.ts` and `et-4950-family.test.ts`, which anchor
+// to bytes extracted from real-hardware captures. The PARA bytes are
+// inherited from the ET-4950 flatbed builder on the basis of matching
+// CAPA tokens (see the dialect-file comment for the full rationale).
+// First real-hardware report against this dialect is the actual
+// correctness check.
+describe("et2950Dialect", () => {
+  it("has flatbed-only hardware", () => {
+    expect(et2950Dialect.hardware).toEqual({ flatbed: true, adf: false, duplex: false });
+  });
+
+  it("uses fixed-flatbed source detection", () => {
+    expect(et2950Dialect.sourceDetection).toBe("fixed-flatbed");
+  });
+
+  it("uses 3 init-poll iterations (TLS-family default, unverified for this model)", () => {
+    expect(et2950Dialect.initPollIterations).toBe(3);
+  });
+
+  it("flatbed JPG inherits buildParaFlatbedTls() bytes verbatim", () => {
+    const fromDialect = et2950Dialect.buildPara({
+      source: "flatbed",
+      duplex: false,
+      action: "jpg",
+    });
+    expect(fromDialect.equals(buildParaFlatbedTls())).toBe(true);
+  });
+
+  it("flatbed PDF is byte-identical to flatbed JPG (action-invariant on this family)", () => {
+    const jpg = et2950Dialect.buildPara({ source: "flatbed", duplex: false, action: "jpg" });
+    const pdf = et2950Dialect.buildPara({ source: "flatbed", duplex: false, action: "pdf" });
+    expect(jpg.equals(pdf)).toBe(true);
+  });
+
+  it("throws on source=adf (hardware guard)", () => {
+    expect(() => et2950Dialect.buildPara({ source: "adf", duplex: false, action: "jpg" })).toThrow(
+      /adf.*not supported/i,
+    );
+  });
+
+  it("fingerprint matches the one reported in issue #92", () => {
+    expect(et2950Dialect.capaFingerprint).toBe(
+      "b1bf50879666d04c1975d607566790bbdf0bdfa5e2e1e7b27b629e8fa540e8cb",
+    );
+  });
+});

--- a/src/esci2/dialects/et-2950.ts
+++ b/src/esci2/dialects/et-2950.ts
@@ -17,7 +17,7 @@ import type { Dialect, ParaAxes } from "../dialect.js";
  * were called. With ET-2950's CAPA matching ET-4950's, the host driver
  * should produce byte-identical PARA.
  *
- * Two acknowledged residual uncertainties (any can fail with a generic
+ * Three acknowledged residual uncertainties (any can fail with a generic
  * `Validation failed in state PARA` rather than a specific `#parFAIL`):
  *
  *   1. CCT advertisement. The findings doc enumerates a 928-byte form
@@ -28,7 +28,7 @@ import type { Dialect, ParaAxes } from "../dialect.js";
  *   2. `initPollIterations: 3`. The ET-4950 family uses 3, ET-2750 uses
  *      2 (rejects a 3rd poll). ET-2950 firmware is unknown; we pick the
  *      TLS-family value.
- *   3. `#FB AREA d850i0001170` undecoded (the reporter's diagnostic
+ *   3. `#FB AREAd850i0001170` undecoded (the reporter's diagnostic
  *      shape differs from ET-4950's 3-integer form). We inherit
  *      ET-4950's full-A4-at-300-DPI `#ACQ` extents; if the printer's
  *      actual max area is smaller, PARA validation will fail.

--- a/src/esci2/dialects/et-2950.ts
+++ b/src/esci2/dialects/et-2950.ts
@@ -1,0 +1,55 @@
+import { buildParaFlatbedTls } from "../commands.js";
+import type { Dialect, ParaAxes } from "../dialect.js";
+
+/**
+ * Epson ET-2950 (ESC/I-2 over TLS). Flatbed-only hardware — no ADF, no
+ * duplex.
+ *
+ * **Inferred clean-room support — no captured ET-2950 fixture exists.**
+ * The PARA bytes are reused from `buildParaFlatbedTls()` (the ET-4950
+ * family flatbed body) because the ET-2950's diagnostic CAPA tokens match
+ * the ET-4950's on every axis that drives PARA: `GMM=UG10UG18`,
+ * `CMX=UNITUM08`, `QIT=PREFON  OFF`, `FMT=RAW JPG`. The Epson Scan 2
+ * Linux source (see `.reference/research/epson-scan-2-source-findings.md`,
+ * read clean-room by a sibling agent) shows that the PARA serialiser is
+ * a single token-walking switch — per-printer variation comes purely
+ * from which CAPA tokens are advertised and which host-driver setters
+ * were called. With ET-2950's CAPA matching ET-4950's, the host driver
+ * should produce byte-identical PARA.
+ *
+ * Two acknowledged residual uncertainties (any can fail with a generic
+ * `Validation failed in state PARA` rather than a specific `#parFAIL`):
+ *
+ *   1. CCT advertisement. The findings doc enumerates a 928-byte form
+ *      (ET-4950-equivalent, includes `#CCTCOL `) and a 920-byte form
+ *      (without). The reporter's diagnostic predates `#CCTLIST` parsing,
+ *      so we ship the 928-byte form; subsequent reporters will surface
+ *      CCT presence/absence in their diagnostic block.
+ *   2. `initPollIterations: 3`. The ET-4950 family uses 3, ET-2750 uses
+ *      2 (rejects a 3rd poll). ET-2950 firmware is unknown; we pick the
+ *      TLS-family value.
+ *   3. `#FB AREA d850i0001170` undecoded (the reporter's diagnostic
+ *      shape differs from ET-4950's 3-integer form). We inherit
+ *      ET-4950's full-A4-at-300-DPI `#ACQ` extents; if the printer's
+ *      actual max area is smaller, PARA validation will fail.
+ *
+ * Any of these failure modes is non-destructive — the engine aborts and
+ * unlocks via the transport adapter. Issue #92 tracks reporter follow-up.
+ */
+export const et2950Dialect: Dialect = {
+  // From the diagnostic block in issue #92 (the user's printer's CAPA
+  // fingerprint, not derived from any captured fixture).
+  capaFingerprint: "b1bf50879666d04c1975d607566790bbdf0bdfa5e2e1e7b27b629e8fa540e8cb",
+  displayName: "ET-2950 (ESC/I-2 over TLS)",
+  hardware: { flatbed: true, adf: false, duplex: false },
+  sourceDetection: "fixed-flatbed",
+  initPollIterations: 3,
+  buildPara(axes: ParaAxes): Buffer {
+    if (axes.source === "adf") {
+      throw new Error(
+        `et2950Dialect.buildPara: source=adf is not supported (ET-2950 has no ADF hardware)`,
+      );
+    }
+    return buildParaFlatbedTls();
+  },
+};

--- a/src/esci2/graph.test.ts
+++ b/src/esci2/graph.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { esci2Graph, ESCI2_TIMEOUT_MS } from "./graph.js";
+import { esci2Graph, ESCI2_TIMEOUT_MS, applyDialectSourceOverride } from "./graph.js";
 import { IS_HEADER_SIZE, buildPurereadPacket } from "../protocol.js";
 import { et4950FamilyDialect } from "./dialects/et-4950-family.js";
 import { et2750Dialect } from "./dialects/et-2750.js";
@@ -565,6 +565,33 @@ describe("esci2Graph INIT_POLL_STAT source detection", () => {
     const payload = Buffer.from("STATx0000000" + " ".repeat(52), "ascii");
     state.decide(ctx, { type: 0xa000, payload });
     expect(ctx.source).toBe("flatbed");
+  });
+});
+
+describe("applyDialectSourceOverride", () => {
+  // The TLS scanner shell pre-sets ctx.source = "adf" (scanner.ts) because
+  // the dominant TLS path is ADF + flatbed with stat-length detection.
+  // A TLS dialect that uses sourceDetection: "fixed-flatbed" (e.g. the
+  // ET-2950) would otherwise carry "adf" all the way to buildPara, which
+  // throws on flatbed-only hardware. applyDialectSourceOverride pins the
+  // source at the dialect-resolution moment to keep every downstream
+  // stage agreeing on flatbed.
+  it("pins source to flatbed when dialect is fixed-flatbed and ctx pre-set is adf (TLS+flatbed-only)", () => {
+    const ctx = makeCtx({ source: "adf", transport: "tls", dialect: et2750Dialect });
+    applyDialectSourceOverride(ctx, et2750Dialect);
+    expect(ctx.source).toBe("flatbed");
+  });
+
+  it("is a no-op when ctx pre-set already matches (plain-TCP+flatbed-only)", () => {
+    const ctx = makeCtx({ source: "flatbed", transport: "plain", dialect: et2750Dialect });
+    applyDialectSourceOverride(ctx, et2750Dialect);
+    expect(ctx.source).toBe("flatbed");
+  });
+
+  it("leaves source untouched for stat-length dialects so INIT_POLL_STAT can decide per-fixture", () => {
+    const ctx = makeCtx({ source: "adf", transport: "tls", dialect: et4950FamilyDialect });
+    applyDialectSourceOverride(ctx, et4950FamilyDialect);
+    expect(ctx.source).toBe("adf");
   });
 });
 

--- a/src/esci2/graph.test.ts
+++ b/src/esci2/graph.test.ts
@@ -3,6 +3,7 @@ import { esci2Graph, ESCI2_TIMEOUT_MS, applyDialectSourceOverride } from "./grap
 import { IS_HEADER_SIZE, buildPurereadPacket } from "../protocol.js";
 import { et4950FamilyDialect } from "./dialects/et-4950-family.js";
 import { et2750Dialect } from "./dialects/et-2750.js";
+import { et2950Dialect } from "./dialects/et-2950.js";
 
 describe("esci2Graph (smoke)", () => {
   it("builds with the expected initial state and timeout", () => {
@@ -576,9 +577,11 @@ describe("applyDialectSourceOverride", () => {
   // throws on flatbed-only hardware. applyDialectSourceOverride pins the
   // source at the dialect-resolution moment to keep every downstream
   // stage agreeing on flatbed.
-  it("pins source to flatbed when dialect is fixed-flatbed and ctx pre-set is adf (TLS+flatbed-only)", () => {
-    const ctx = makeCtx({ source: "adf", transport: "tls", dialect: et2750Dialect });
-    applyDialectSourceOverride(ctx, et2750Dialect);
+  it("pins source to flatbed when dialect is fixed-flatbed and ctx pre-set is adf (TLS+flatbed-only, ET-2950)", () => {
+    // Exact production scenario for ET-2950: TLS shell pre-sets ctx.source = "adf"
+    // (scanner.ts), dialect resolves to et2950Dialect, override flips source.
+    const ctx = makeCtx({ source: "adf", transport: "tls", dialect: et2950Dialect });
+    applyDialectSourceOverride(ctx, et2950Dialect);
     expect(ctx.source).toBe("flatbed");
   });
 

--- a/src/esci2/graph.ts
+++ b/src/esci2/graph.ts
@@ -66,6 +66,25 @@ export interface Esci2Ctx {
 
 export const ESCI2_TIMEOUT_MS = 30_000;
 export const ESCI2_REPLY_SIZE = 64;
+
+/**
+ * Applies any source-axis overrides implied by a freshly resolved dialect.
+ *
+ * The TLS scanner shell pre-sets ctx.source to "adf" because the dominant
+ * TLS path is ADF + flatbed with `sourceDetection: "stat-length"`, where
+ * INIT_POLL_STAT then flips the source to flatbed if the printer queued
+ * its filler bytes. Dialects with `sourceDetection: "fixed-flatbed"`
+ * deliberately skip that override (see INIT_POLL_STAT), so without
+ * pinning the source here the pre-set "adf" carries all the way through
+ * to buildPara and trips a flatbed-only dialect's ADF guard. ET-2750
+ * doesn't hit this because the plain-TCP shell pre-sets "flatbed" — but
+ * any TLS + flatbed-only dialect (e.g. ET-2950) would.
+ */
+export function applyDialectSourceOverride(ctx: Esci2Ctx, dialect: Dialect): void {
+  if (dialect.sourceDetection === "fixed-flatbed") {
+    ctx.source = "flatbed";
+  }
+}
 const LEGACY_REPLY_SIZE = 1;
 // 5000 zero-length retries gives ~100s of headroom for slow scan starts.
 // XP-7100 flatbed captures show up to 2612 zero-length IMG responses before
@@ -309,6 +328,7 @@ twoPhaseRead(
     // self-documenting. Otherwise the only signal that resolution succeeded
     // is the absence of an UnsupportedDialectError further downstream.
     log.debug("Dialect resolved", { name: dialect.displayName, fingerprint });
+    applyDialectSourceOverride(ctx, dialect);
   },
 );
 


### PR DESCRIPTION
## Summary

- Adds dialect support for the Epson **ET-2950** (TLS, flatbed-only). Closes #92 pending real-hardware verification by the reporter.
- Fixes a latent TLS + `fixed-flatbed` source-handling bug exposed by the new dialect.
- Surfaces `#CCTLIST` in unknown-printer diagnostics so future similar reports include the bit that decides between two PARA-length variants.

## Rationale

A separate interoperability review of the Epson Scan 2 Linux source/package identified a functional behavior of its PARA serializer: it is a single token-walking switch with no per-PRD branches, so per-printer variation comes purely from which CAPA tokens are advertised. The ET-2950's reported CAPA tokens match the ET-4950 family's on every PARA-relevant axis, so `buildParaFlatbedTls()`'s existing captured bytes should be byte-correct here too. This PR does not copy Epson code; it reuses existing captured ET-4950 wire bytes and adds a dialect mapping for the new fingerprint. Internal notes from the review live under `.reference/` (gitignored).

## Acknowledged uncertainties

Each can fail with a generic `Validation failed in state PARA` (not necessarily a literal `#parFAIL`):

1. **CCT advertisement.** Reporter's diagnostic predates `#CCTLIST` parsing. We ship the 928-byte form (with `#CCTCOL `, matching ET-4950); a 920-byte variant exists as a known fallback.
2. **`initPollIterations: 3`** — the TLS-family default. ET-2750 uses 2 (rejects a 3rd poll). ET-2950 firmware is unknown.
3. **`#FB AREA d850i0001170`** — undecoded. Inheriting ET-4950's full-A4-at-300-DPI `#ACQ` extents; if the printer's actual max area is smaller, PARA validation will fail.

All three failure modes are non-destructive — the engine aborts and unlocks via the transport adapter. Reporter follow-up tracked in #92.

## Test plan

- [x] `npm test` — 600 tests passing, including 3 new `applyDialectSourceOverride` cases, 7 new `et2950Dialect` cases, and updated CCT-parsing + diagnostic coverage.
- [x] `npm run lint` clean.
- [x] `npm run format:check` clean.
- [ ] ET-2950 reporter on issue #92 retests with `LOG_LEVEL=debug`, captures full log span from "Dialect resolved" through any failure, plus panel behaviour and (if a file is produced) output dimensions / cropping.

_Note: an earlier revision of this description used "clean-room investigation" wording. Updated to "interoperability review" for accuracy — see #96 for the broader doc cleanup._

🤖 Generated with [Claude Code](https://claude.com/claude-code)