### PR TITLE
chore: bump to v0.4.2 + ET-2950 compat row

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ What you get:
 
 ## Compatible printers
 
-| Model                 | Status      | Notes                                                 |
-| --------------------- | ----------- | ----------------------------------------------------- |
-| **ET-3950**           | ✅ Verified |                                                       |
-| **ET-4950 / ET-4956** | ✅ Verified |                                                       |
-| **WF-3620**           | ✅ Verified | Plain TCP scanner, no TLS pinning                     |
-| **ET-2750**           | ✅ Verified | Flatbed-only hardware; ESC/I-2 over plain TCP, no TLS |
-| **XP-7100**           | ✅ Verified |                                                       |
+| Model                 | Status          | Notes                                                 |
+| --------------------- | --------------- | ----------------------------------------------------- |
+| **ET-3950**           | ✅ Verified     |                                                       |
+| **ET-4950 / ET-4956** | ✅ Verified     |                                                       |
+| **WF-3620**           | ✅ Verified     | Plain TCP scanner, no TLS pinning                     |
+| **ET-2750**           | ✅ Verified     | Flatbed-only hardware; ESC/I-2 over plain TCP, no TLS |
+| **ET-2950**           | 🟡 Experimental | Flatbed-only hardware                                 |
+| **XP-7100**           | ✅ Verified     |                                                       |
 
 Compatibility reports are welcome whether your model works or doesn't. [Open an issue](https://github.com/mtheuma/epson2paperless/issues/new?template=compatibility.yml) using the compatibility template.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epson2paperless",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "epson2paperless",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "pdf-lib": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epson2paperless",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Epson Scan to Computer protocol emulator — delivers scans to Paperless-ngx",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Prep for the v0.4.2 tag:

- Bumps `package.json` + `package-lock.json` from 0.4.1 → 0.4.2 (matching the v0.4.1 precedent of bumping inside the release PR; PR #94 missed this).
- Adds the ET-2950 row to the README compatibility table — 🟡 Experimental, flatbed-only hardware.

Bundled changes shipping in v0.4.2 (already merged via #94):
- ET-2950 dialect (#92).
- TLS + `fixed-flatbed` source-handling fix.
- `#CCTLIST` parsed and surfaced in the unsupported-printer diagnostic block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)