### PR TITLE
docs: tighten interoperability framing; drop "clean-room"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,15 @@ npm test                             # full test suite
 - If your PR addresses an open issue, link it in the description.
 - Protocol changes that affect wire bytes need matching updates to the Frida-capture fixtures in `tools/frida-capture/captures/` — the byte-for-byte replay test in `src/scanner.test.ts` will fail otherwise. See `tools/frida-capture/README.md` for the re-capture workflow.
 
+## Provenance
+
+This project re-implements network behavior for interoperability with user-owned hardware. To keep that footing clear, contributions must observe the following:
+
+- **No Epson source, firmware, binaries, or proprietary documentation** in commits, issues, PRs, code comments, or any tracked file. Functional observations described in your own words are fine; verbatim source, identifier names, or comments from vendor code are not.
+- **No NDA-covered material** of any kind.
+- **No tables, blobs, or constants derived from vendor source** unless the same bytes are independently captured from the wire (Frida JSONL, Wireshark pcap) and the capture is the artifact of record.
+- **Provenance notes, where useful, belong in the PR description or commit message**, not in user-facing copy. Internal notes about how a finding was obtained can live under `.reference/` (gitignored) — keep them off the tracked tree.
+
 ## Code of conduct
 
 Be civil. I'm a one-person reviewer doing this in spare time, and clear, kind communication is what makes that sustainable.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Equally valuable: reporting your printer's compatibility so the [Compatible prin
 
 MIT. See [`LICENSE`](LICENSE) for the full text.
 
-**Not affiliated with Seiko Epson Corporation.** This project is an independent, clean-room re-implementation of the network behavior of an Epson "Scan to Computer" workflow, developed by analyzing the wire protocol of a device the author owns. No Epson source code, firmware, or binaries are included or distributed. "EPSON", "EcoTank", "Expression", and "WorkForce" are trademarks of Seiko Epson Corporation, used here descriptively to identify the hardware this software interoperates with.
+**Not affiliated with Seiko Epson Corporation.** This project is an independent interoperability re-implementation of an Epson "Scan to Computer" workflow, based on observed protocol behavior of a device the author owns and limited functional analysis of related software. No Epson source code, firmware, binaries, or source-derived implementation code is included or distributed. "EPSON", "EcoTank", "Expression", and "WorkForce" are trademarks of Seiko Epson Corporation, used here descriptively to identify the hardware this software interoperates with.
 
 ---
 

--- a/src/esci2/dialects/et-2950.ts
+++ b/src/esci2/dialects/et-2950.ts
@@ -5,17 +5,19 @@ import type { Dialect, ParaAxes } from "../dialect.js";
  * Epson ET-2950 (ESC/I-2 over TLS). Flatbed-only hardware — no ADF, no
  * duplex.
  *
- * **Inferred clean-room support — no captured ET-2950 fixture exists.**
+ * **Inferred support — no captured ET-2950 wire fixture exists.**
  * The PARA bytes are reused from `buildParaFlatbedTls()` (the ET-4950
- * family flatbed body) because the ET-2950's diagnostic CAPA tokens match
- * the ET-4950's on every axis that drives PARA: `GMM=UG10UG18`,
- * `CMX=UNITUM08`, `QIT=PREFON  OFF`, `FMT=RAW JPG`. The Epson Scan 2
- * Linux source (see `.reference/research/epson-scan-2-source-findings.md`,
- * read clean-room by a sibling agent) shows that the PARA serialiser is
- * a single token-walking switch — per-printer variation comes purely
- * from which CAPA tokens are advertised and which host-driver setters
- * were called. With ET-2950's CAPA matching ET-4950's, the host driver
- * should produce byte-identical PARA.
+ * family flatbed body) because the ET-2950's diagnostic CAPA tokens
+ * match the ET-4950's on every axis that drives PARA: `GMM=UG10UG18`,
+ * `CMX=UNITUM08`, `QIT=PREFON  OFF`, `FMT=RAW JPG`. A separate
+ * interoperability review of the Epson Scan 2 Linux source/package
+ * (notes under `.reference/`, gitignored) observed that the PARA
+ * serialiser is a single token-walking switch — per-printer variation
+ * comes purely from which CAPA tokens are advertised and which
+ * host-driver setters were called. No Epson code is included here;
+ * this dialect reuses existing captured ET-4950 wire bytes and adds a
+ * fingerprint mapping. With ET-2950's CAPA matching ET-4950's, the host
+ * driver should produce byte-identical PARA.
  *
  * Three acknowledged residual uncertainties (any can fail with a generic
  * `Validation failed in state PARA` rather than a specific `#parFAIL`):


### PR DESCRIPTION
## Summary

Tightens the wording around how this project relates to vendor code. Reviewer on #94 flagged that "clean-room re-implementation" overclaims given the repo openly documents Frida + Ghidra work and the ET-2950 dialect was informed by a review of Epson Scan 2 Linux source. "Interoperability re-implementation" is more accurate and removes the rhetorical hook without changing what the project actually does.

## Changes

- **`README.md`** — disclaimer paragraph rephrased to "independent interoperability re-implementation … no Epson source code, firmware, binaries, or source-derived implementation code is included or distributed".
- **`src/esci2/dialects/et-2950.ts`** — drops both "clean-room" mentions; replaces with "interoperability review of the Epson Scan 2 Linux source/package observed that the PARA serialiser is a single token-walking switch … no Epson code is included here; this dialect reuses existing captured ET-4950 wire bytes and adds a fingerprint mapping".
- **`CONTRIBUTING.md`** — new short "Provenance" section codifying the contributor guardrails: no vendor source/firmware/binaries in tracked files, no NDA material, no source-derived tables unless wire-captured, provenance notes belong in PR bodies / commit messages, not in user-facing copy.

## What's not changed

- `docs/REVERSE-ENGINEERING.md` — already transparent about Frida + Ghidra methodology; no clean-room language to remove.
- `.reference/research/epson-scan-2-source-findings.md` — gitignored, never ships publicly.
- The squash-merge commit for #94 on main keeps its "clean-room PARA inference" subject — git history is append-only. All forward-looking docs and comments use the cleaner framing.

## Test plan

- [x] `npm run lint`, `npm run format:check` clean.
- [x] No source code touched — `npm test` not in scope but should remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)