### PR TITLE
fix(esci2): render bare #XXXLIST CAPA segments as (absent) in diagnostic

### DIFF
--- a/src/esci2/dialect-registry.test.ts
+++ b/src/esci2/dialect-registry.test.ts
@@ -81,6 +81,38 @@ describe("buildDiagnostic", () => {
     expect(diagnostic).toMatch(/CCT list:\s+\(absent\)/); // CCT absence is meaningful, not just blank
   });
 
+  it("renders a bare #CCTLIST (segment present, value empty) as (absent), not blank", () => {
+    // A bare LIST segment followed immediately by another # or end-of-body
+    // parses to an empty string, not null. The diagnostic must still mark
+    // it as (absent) so a maintainer can tell at a glance — the
+    // present-vs-absent distinction drives PARA-variant selection.
+    const info = Buffer.from("#FB AREAd850i0001170#PRDh010PID 9999", "ascii");
+    const capa = Buffer.from("#GMMLISTUG10UG18#CCTLIST#ADFDPLX", "ascii");
+    const diagnostic = buildDiagnostic({
+      capaBody: capa,
+      infoBody: info,
+      transport: "plain",
+      fingerprint: "empty1",
+    });
+    expect(diagnostic).toMatch(/CCT list:\s+\(absent\)/);
+  });
+
+  it("renders a bare #GMMLIST (segment present, value empty) as (absent), not blank", () => {
+    // Same disambiguation must apply consistently across all LIST rows,
+    // not just CCT — the whole point of the diagnostic block is at-a-glance reading.
+    const info = Buffer.from("#FB AREAd850i0001170#PRDh010PID 9999", "ascii");
+    const capa = Buffer.from("#GMMLIST#CMXLISTUNITUM08", "ascii");
+    const diagnostic = buildDiagnostic({
+      capaBody: capa,
+      infoBody: info,
+      transport: "plain",
+      fingerprint: "empty2",
+    });
+    expect(diagnostic).toMatch(/GMM list:\s+\(absent\)/);
+    // Sanity-check: the non-empty CMX value still renders normally.
+    expect(diagnostic).toContain("UNITUM08");
+  });
+
   it("throws an UnsupportedDialectError when explicitly raised", () => {
     expect(() => {
       throw new UnsupportedDialectError("xyz", "diagnostic body");

--- a/src/esci2/dialect-registry.ts
+++ b/src/esci2/dialect-registry.ts
@@ -48,6 +48,11 @@ export function buildDiagnostic(args: {
   const hasAdf = info.segments.some((s) => s.startsWith("#ADF"));
   const hasDuplex = capa.adfDuplex;
   const yn = (v: boolean) => (v ? "Y" : "N");
+  // Treat empty string as absent: a bare `#XXXLIST` (segment present, value
+  // empty) parses to "" rather than null, but for at-a-glance reading the
+  // diagnostic should still mark it as (absent). Matters most for CCT, where
+  // present-vs-absent drives PARA-variant selection.
+  const orAbsent = (s: string | null) => (s && s.length > 0 ? s : "(absent)");
   return [
     `CAPA fingerprint:  ${args.fingerprint}`,
     `PRD:               PID ${info.prdPid ?? "(absent)"}`,
@@ -56,11 +61,11 @@ export function buildDiagnostic(args: {
     `Source caps:       flatbed: ${yn(hasFlatbed)}  ADF: ${yn(hasAdf)}  duplex: ${yn(hasDuplex)}`,
     `Scan area (FB):    ${info.fbArea ?? "(absent)"}`,
     `Scan area (ADF):   ${info.adfArea ?? "(absent)"}`,
-    `GMM list:          ${capa.gmmList ?? "(absent)"}`,
-    `CMX list:          ${capa.cmxList ?? "(absent)"}`,
-    `QIT list:          ${capa.qitList ?? "(absent)"}`,
-    `FMT list:          ${capa.fmtList ?? "(absent)"}`,
-    `CCT list:          ${capa.cctList ?? "(absent)"}`,
+    `GMM list:          ${orAbsent(capa.gmmList)}`,
+    `CMX list:          ${orAbsent(capa.cmxList)}`,
+    `QIT list:          ${orAbsent(capa.qitList)}`,
+    `FMT list:          ${orAbsent(capa.fmtList)}`,
+    `CCT list:          ${orAbsent(capa.cctList)}`,
     `INFO segments:     ${info.segments.length}`,
     `CAPA segments:     ${capa.segments.length}`,
   ].join("\n");


### PR DESCRIPTION
## Summary

A bare `#CCTLIST` (or `#GMMLIST`, etc.) followed by `#` or end-of-buffer parses to an empty string, not null — `textAfterPrefix` slices and trims faithfully. The diagnostic block then rendered a blank line, which the maintainer can't distinguish from a printer that doesn't advertise the capability at all.

Matters most for CCT, where present-vs-absent drives PARA-variant selection (928 vs 920 bytes), and that's what surfaces in the unknown-dialect diagnostic an external reporter would paste back.

Fix: replace `??` with a small `orAbsent` helper on all five LIST rows in `buildDiagnostic`. The parser is unchanged — empty string remains a faithful representation of "segment present, value empty" for other callers.

Flagged in a /code-review pass on [#94](https://github.com/mtheuma/epson2paperless/pull/94); the empty-string gap predates that PR but the new CCT row surfaces it more visibly.

## Test plan

- [x] New test: bare `#CCTLIST` renders as `CCT list:          (absent)` (red-then-green verified)
- [x] New test: bare `#GMMLIST` renders as `(absent)`, and a non-empty neighbor (`#CMXLIST` → `UNITUM08`) still renders normally
- [x] Pre-existing tests for genuinely absent segments and present-with-value still pass
- [x] `npm test` — 602 passed, 1 skipped
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)