### PR TITLE
docs: mark ET-4800 as Verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ What you get:
 | **WF-3620**           | ✅ Verified     | Plain TCP scanner, no TLS pinning                     |
 | **ET-2750**           | ✅ Verified     | Flatbed-only hardware; ESC/I-2 over plain TCP, no TLS |
 | **ET-2950**           | 🟡 Experimental | Flatbed-only hardware                                 |
-| **ET-4800**           | 🟡 Experimental | ADF simplex; ESC/I-2 over plain TCP, no TLS           |
+| **ET-4800**           | ✅ Verified     | ADF simplex; ESC/I-2 over plain TCP, no TLS           |
 | **XP-7100**           | ✅ Verified     |                                                       |
 
 Compatibility reports are welcome whether your model works or doesn't. [Open an issue](https://github.com/mtheuma/epson2paperless/issues/new?template=compatibility.yml) using the compatibility template.


### PR DESCRIPTION
Reporter confirmed all four scan modes (flatbed/ADF, JPG/PDF) work on v0.4.3 in issue #80. Flip the ET-4800 compatibility-table status from 🟡 Experimental to ✅ Verified.

Closes #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)