### PR TITLE
Add ET-15000 dialect (ESC/I-2 over plain TCP)

### DIFF
--- a/src/esci2/dialects/et-15000.test.ts
+++ b/src/esci2/dialects/et-15000.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { REGISTRY } from "./registry.js";
+import { composePara } from "../para-composer.js";
+import { makeParaSpec } from "./dispatch.js";
+
+const ET15000_FP = "d1d7293e92fa726e006429beacca1255e474de0d66b3559f87176d4e4b3d0e55";
+const entry = REGISTRY.get(ET15000_FP)!;
+
+// The registry entry's static fields are asserted in registry.test.ts alongside
+// the other dialects. This file covers only what's specific to ET-15000's
+// composed PARA. The ET-15000 is an A4 EcoTank (flatbed + ADF simplex, no
+// duplex) on plain TCP, structurally identical to the ET-4800 — so its PARA
+// sizes match the ET-4800's.
+
+describe("ET-15000 composed PARA size", () => {
+  it("flatbed is 936 bytes", () => {
+    expect(composePara(makeParaSpec(entry, "flatbed", "jpg")).length).toBe(936);
+  });
+
+  it("adf-simplex is 944 bytes (+8 for the ADF-only #PAGd000 segment)", () => {
+    expect(composePara(makeParaSpec(entry, "adf-simplex", "jpg")).length).toBe(944);
+  });
+});
+
+describe("ET-15000 action invariance", () => {
+  it("flatbed JPG equals flatbed PDF byte-for-byte", () => {
+    const jpg = composePara(makeParaSpec(entry, "flatbed", "jpg"));
+    const pdf = composePara(makeParaSpec(entry, "flatbed", "pdf"));
+    expect(jpg.equals(pdf)).toBe(true);
+  });
+
+  it("ADF simplex JPG equals ADF simplex PDF byte-for-byte", () => {
+    const jpg = composePara(makeParaSpec(entry, "adf-simplex", "jpg"));
+    const pdf = composePara(makeParaSpec(entry, "adf-simplex", "pdf"));
+    expect(jpg.equals(pdf)).toBe(true);
+  });
+});

--- a/src/esci2/dialects/registry.test.ts
+++ b/src/esci2/dialects/registry.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect } from "vitest";
 import { REGISTRY } from "./registry.js";
 
 describe("REGISTRY", () => {
-  it("contains exactly five known fingerprints", () => {
-    expect(REGISTRY.size).toBe(5);
+  it("contains exactly six known fingerprints", () => {
+    expect(REGISTRY.size).toBe(6);
   });
 
   it("includes ET-4950 family entry", () => {
@@ -52,6 +52,19 @@ describe("REGISTRY", () => {
 
   it("includes ET-4800 entry (flatbed + ADF simplex, plain TCP)", () => {
     const e = REGISTRY.get("7870a725ab969136d5eb04387bf01d3cc3168aabb3d11cfaca7d59a4169971c2");
+    expect(e).toBeDefined();
+    expect(e!.sourceDetection).toBe("stat-length");
+    expect(e!.initPollIterations).toBe(3);
+    expect(e!.gmm).toBe("UG18");
+    expect(e!.gammaClass).toEqual({ jpg: "et4800-stock", pdf: "et4800-stock" });
+    expect(e!.cmxClass).toEqual({ jpg: "et4800-um08", pdf: "et4800-um08" });
+    expect(e!.optionalSegments).toEqual({ qit: false, cct: false });
+    expect(e!.fbExtents).toEqual({ x0: 0, y0: 0, w: 2481, h: 3506 });
+    expect(e!.adfExtents).toEqual({ x0: 69, y0: 0, w: 2481, h: 3506 });
+  });
+
+  it("includes ET-15000 entry (flatbed + ADF simplex, plain TCP)", () => {
+    const e = REGISTRY.get("d1d7293e92fa726e006429beacca1255e474de0d66b3559f87176d4e4b3d0e55");
     expect(e).toBeDefined();
     expect(e!.sourceDetection).toBe("stat-length");
     expect(e!.initPollIterations).toBe(3);

--- a/src/esci2/dialects/registry.ts
+++ b/src/esci2/dialects/registry.ts
@@ -84,4 +84,24 @@ export const REGISTRY: ReadonlyMap<string, RegistryEntry> = new Map([
       optionalSegments: { qit: false, cct: false },
     },
   ],
+  [
+    // ET-15000: A3-print / A4-scan EcoTank. Flatbed + ADF simplex (no duplex),
+    // ESC/I-2 over plain TCP. CAPA advertises GMM "UG10UG18" and CMX "UNITUM08"
+    // with QIT/CCT absent — structurally an ET-4800 that additionally lists the
+    // UG10 gamma mode. The gamma/CMX class bytes are reused from the ET-4800
+    // (closest plain-TCP sibling) pending a hardware capture of the ET-15000's
+    // own PARA; live-validated against a real ET-15000 (PID 116E, FW FB 1.01).
+    "d1d7293e92fa726e006429beacca1255e474de0d66b3559f87176d4e4b3d0e55",
+    {
+      displayName: "ET-15000 (ESC/I-2 over plain TCP)",
+      sourceDetection: "stat-length",
+      initPollIterations: 3,
+      fbExtents: { x0: 0, y0: 0, w: 2481, h: 3506 },
+      adfExtents: { x0: 69, y0: 0, w: 2481, h: 3506 },
+      gmm: "UG18",
+      gammaClass: { jpg: "et4800-stock", pdf: "et4800-stock" },
+      cmxClass: { jpg: "et4800-um08", pdf: "et4800-um08" },
+      optionalSegments: { qit: false, cct: false },
+    },
+  ],
 ]);


### PR DESCRIPTION
## Summary

Adds an ESC/I-2 dialect registry entry for the **Epson ET-15000** (PID `116E`, the A3-print / A4-scan EcoTank). Before this, the ET-15000 failed fast with `UnsupportedDialectError` — its CAPA fingerprint wasn't registered.

## What the printer reported

```
CAPA fingerprint:  d1d7293e92fa726e006429beacca1255e474de0d66b3559f87176d4e4b3d0e55
PRD:               PID 116E
Firmware:          FB  1.01
Transport:         esci2-plain
Source caps:       flatbed: Y  ADF: Y  duplex: N
Scan area (FB):    d850i0001400
Scan area (ADF):   d850i0001400
GMM list:          UG10UG18
CMX list:          UNITUM08
QIT list:          (absent)
FMT list:          RAW JPG
CCT list:          (absent)
INFO segments:     15
CAPA segments:     11
```

Structurally this is an **ET-4800**: flatbed + ADF simplex (no duplex), ESC/I-2 over plain TCP, `CMX UNITUM08`, QIT/CCT absent. It differs only in additionally advertising the `UG10` gamma mode (`GMM UG10UG18`) and a distinct segment layout (hence the new fingerprint). The entry mirrors the ET-4800's, and the **gamma/CMX class bytes are reused from the ET-4800** (closest plain-TCP sibling) pending a hardware capture of the ET-15000's own PARA.

This follows the same pattern as the existing **ET-2950** entry (reuses a sibling's LUT, registry + size tests, no committed pcap fixture).

## Live validation

Tested against a real ET-15000 (firmware `FB 1.01`) over the Scan-to-Computer push flow:

- TLS probe rejected → plain-TCP path selected (correct).
- Fingerprint resolves to the new entry; the printer **accepts the composed PARA** and proceeds into image acquisition.
- Flatbed scan returns a clean page: embedded JPEG **2481 × 3506 px (A4 @ 300 dpi)**, matching the registry extents, assembled into a valid PDF v1.7.

```
[scanner-esci2] Dialect resolved { fingerprint: 'd1d7293e…' }
[pdf] embedded page 1/1 (182856 B)
[output] Saved scan to scan_2026-06-02_131330.pdf (183806 bytes)
```

ADF simplex shares the ET-4800 extents but I couldn't get a clean ADF pass on my unit (physical `#errADF PJ` paper-jam); flatbed is confirmed repeatedly. Happy to follow up with an ADF capture, and to provide a pcap/Frida fixture if you'd like one committed.

## Changes

- `src/esci2/dialects/registry.ts` — new ET-15000 entry.
- `src/esci2/dialects/registry.test.ts` — registry count + static-field assertions.
- `src/esci2/dialects/et-15000.test.ts` — composed-PARA size (936 flatbed / 944 ADF simplex) + action invariance, mirroring `et-4800.test.ts`.

`npm run lint`, `npm run format:check`, and `npm test` (653 tests) all pass.