### PR TITLE
docs: note multi-instance needs a distinct MAC per container

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Image: **`ghcr.io/mtheuma/epson2paperless`**. Multi-arch (`linux/amd64`, `linux/
 Notes:
 
 - Uses host networking. The printer's multicast beacon can't reach a bridged container. [Why](docs/PROTOCOL-REFERENCE.md#discovery-and-keepalive-udp-multicast).
-- Running several instances against one printer: each container needs its own MAC address. Use a `macvlan` network, not `ipvlan` or a shared bridge — the printer keys destinations on MAC, so a shared MAC collapses them to a single panel entry.
+- Running several instances against one printer: each container needs its own MAC address. Use a `macvlan` network, not `ipvlan` or a shared bridge.
 - Container runs as UID 1000 (`node`). If your mount has a different owner, `chown` it to match.
 - Docker Desktop on macOS / Windows has caveats around host networking; the primary deployment target is a Linux server.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Image: **`ghcr.io/mtheuma/epson2paperless`**. Multi-arch (`linux/amd64`, `linux/
 Notes:
 
 - Uses host networking. The printer's multicast beacon can't reach a bridged container. [Why](docs/PROTOCOL-REFERENCE.md#discovery-and-keepalive-udp-multicast).
+- Running several instances against one printer: each container needs its own MAC address. Use a `macvlan` network, not `ipvlan` or a shared bridge — the printer keys destinations on MAC, so a shared MAC collapses them to a single panel entry.
 - Container runs as UID 1000 (`node`). If your mount has a different owner, `chown` it to match.
 - Docker Desktop on macOS / Windows has caveats around host networking; the primary deployment target is a Linux server.
 


### PR DESCRIPTION
Adds a brief Docker note that running multiple instances against one printer requires a distinct MAC per container — use `macvlan`, not `ipvlan` or a shared bridge.

Confirmed real-world in issue #105: the reporter ran two containers (distinct `SCAN_DEST_NAME`, distinct IPs) on Unraid IPVLAN and only ever saw one destination on the panel. The printer keys registrations on MAC, so a shared parent MAC collapses both to one entry. Switching to macvlan resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)