### PR TITLE
test: make scan-session encode-ordering assertion deterministic (#104)

### DIFF
--- a/src/scan-session.test.ts
+++ b/src/scan-session.test.ts
@@ -243,8 +243,13 @@ describe("runScanSession (engine pump)", () => {
     const transport = new FakeTransport();
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "engine-test-"));
 
-    let encodeStartedAt = 0;
-    let sendObservedAt = 0;
+    // Ordering invariant proven deterministically (no wall-clock delta): the
+    // encode promise resolves on a later tick, flipping `encodeResolved`; when
+    // the 0xcafe send is observed we capture that flag. If the engine ever
+    // stopped awaiting the flushPage barrier and sent synchronously, the flag
+    // would still be false at send time and this test would catch it.
+    let encodeResolved = false;
+    let sawSendAfterEncode = false;
     const encodePromise = new Promise<Buffer>((resolve) => {
       setTimeout(() => {
         // Minimal valid JPEG: SOI + EOI
@@ -260,19 +265,20 @@ describe("runScanSession (engine pump)", () => {
           send: Buffer.from([0xca, 0xfe]),
           flushPage: {
             side: "front",
-            encode: () => {
-              encodeStartedAt = Date.now();
-              return encodePromise;
-            },
+            encode: () =>
+              encodePromise.then((b) => {
+                encodeResolved = true;
+                return b;
+              }),
           },
         },
       },
     });
 
-    // Wrap transport.write to record when our send was observed
+    // Wrap transport.write to record encode ordering when our send was observed
     const origWrite = transport.write.bind(transport);
     transport.write = (buf: Buffer) => {
-      if (buf.equals(Buffer.from([0xca, 0xfe]))) sendObservedAt = Date.now();
+      if (buf.equals(Buffer.from([0xca, 0xfe]))) sawSendAfterEncode = encodeResolved;
       return origWrite(buf);
     };
 
@@ -292,7 +298,7 @@ describe("runScanSession (engine pump)", () => {
     const result = await promise;
     expect(result.ok).toBe(true);
     // The send must happen AFTER encode resolved
-    expect(sendObservedAt).toBeGreaterThanOrEqual(encodeStartedAt + 30);
+    expect(sawSendAfterEncode).toBe(true);
 
     fs.rmSync(tempDir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary

Fixes the structurally flaky test `src/scan-session.test.ts > runScanSession (engine pump) > awaits flushPage.encode before sending the next command` (#104).

The test proves a real invariant — the next command (`0xcafe`) is only sent after `flushPage.encode()` resolves — but it checked that invariant via a **wall-clock delta** comparing two clocks with mismatched start points:

- The 30 ms encode timer started at **promise construction**.
- The assertion baseline `encodeStartedAt` was stamped only when `encode()` was actually **invoked**, a few ms later (after `runScanSession` spins up and the `0xa000` packet dispatches).

So the assertion `sendObservedAt >= encodeStartedAt + 30` demanded more elapsed time than could exist, by the scheduling gap between construction and invocation. Under CI load that gap is a few ms → intermittent failure (observed on PR #103, a ~2 ms shortfall).

## Fix

Replace the wall-clock delta with a deterministic ordering flag:

- `encode()` returns `encodePromise.then(b => { encodeResolved = true; return b; })`.
- The `transport.write` wrapper captures `sawSendAfterEncode = encodeResolved` when the `0xcafe` send is observed.
- Assertion becomes `expect(sawSendAfterEncode).toBe(true)`.

The `setTimeout(…, 30)` is kept so the promise resolves on a later tick — this preserves the test's ability to catch a regression where the engine stops awaiting the flushPage barrier and sends synchronously (the flag would be `false` at send time). The 30 ms value no longer affects pass/fail.

Test-only change; no production code touched.

## Verification

- `npm test -- scan-session` → 40 passed
- The specific test looped 5× → passes every time
- `npm run lint` / `npm run format:check` → clean

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)
