### PR TITLE
Scan-output regression oracle: engine + tooling (Phases 1–2, #27)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 *.bin
 *.raw
+*.baseline.overlay.png
 test-output/
 .claude/
 .reference/

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "scan": "tsx src/one-shot.ts",
     "printer-fingerprint": "tsx tools/printer-fingerprint.ts",
     "test-page:generate": "tsx tools/test-page/generate.ts",
+    "oracle:baseline": "tsx tools/test-oracle/baseline-cli.ts",
     "kill-dev": "node scripts/kill-dev.mjs",
     "test": "vitest run --exclude=.claude/** --exclude=.superpowers/**",
     "test:watch": "vitest",

--- a/src/esci2/scanner.test.ts
+++ b/src/esci2/scanner.test.ts
@@ -74,10 +74,11 @@ function extractScannerParaWrite(fake: FakePlainSocket): Buffer {
   throw new Error("extractScannerParaWrite: PARA header write not found");
 }
 
-// Poll briefly for the async PDF compose chain to drop a .pdf into outputDir.
-// composePdfFromJpegs runs inside a setImmediate hop in doFinalize, so the file
-// appears a few event-loop ticks after the session promise settles. Bounded at
-// 50×10ms; callers assert the .pdf count afterwards, so a miss fails loudly.
+// Defensive poll for the composed .pdf. finalizeSession awaits the PDF compose
+// + write before the session promise settles, so the file is normally already on
+// disk once callers await that promise; this loop only guards against scheduler/
+// filesystem lag. Bounded at 50×10ms; callers assert the .pdf count afterwards,
+// so a miss fails loudly.
 async function waitForPdf(outputDir: string): Promise<void> {
   for (
     let i = 0;

--- a/src/esci2/scanner.test.ts
+++ b/src/esci2/scanner.test.ts
@@ -10,6 +10,7 @@ import { FakeTlsSocket } from "./test-support/fake-tls-socket.js";
 import { FakePlainSocket } from "./test-support/fake-plain-socket.js";
 import { loadFixture, driveFixture } from "./test-support/replay.js";
 import type { FixtureEvent } from "./test-support/replay.js";
+import { readJsonl, trimStatCycles, replayCapture } from "./test-support/frida-replay.js";
 import { REGISTRY } from "./dialects/registry.js";
 import { makeParaSpec } from "./dialects/dispatch.js";
 import { composePara, type ParaSpec } from "./para-composer.js";
@@ -280,159 +281,6 @@ async function drivePastImgTerminator(
   return { fake, sessionPromise, feedEsci2Reply };
 }
 
-export interface CaptureRecord {
-  hook: "startup" | "waiting" | "send" | "recv" | "error" | "async_event";
-  type_hex?: string;
-  payload_hex?: string;
-  payload_size?: number;
-}
-
-/**
- * Trim the driver's variable STAT-cycle count to a fixed `keep`, matching the
- * scanner. The driver runs ~12 STAT heartbeat cycles after two capability-
- * discovery cycles; our scanner runs 3. Each STAT cycle is exactly 9 capture
- * records (3 sends + 6 recvs: envelope header + body per send). We keep the
- * first `keep` driver STAT cycles, drop the rest, and resume at FS X.
- *
- * Pre-STAT sends: LOCK (1) + cycle 1 (6) + cycle 2 (8) = 15 sends. The STAT
- * loop begins at the 16th send → sendIndices[15].
- */
-export function trimStatCycles(records: CaptureRecord[], keep: number): CaptureRecord[] {
-  const sendIndices = records.map((r, i) => (r.hook === "send" ? i : -1)).filter((i) => i !== -1);
-  if (sendIndices.length < 16) {
-    throw new Error(`trimStatCycles: capture has only ${sendIndices.length} sends, expected ≥ 16`);
-  }
-  const statLoopStart = sendIndices[15];
-  const fsXRecord = records.findIndex((r) => r.hook === "send" && r.payload_hex?.endsWith("1c58"));
-  if (fsXRecord === -1) {
-    throw new Error("trimStatCycles: no FS X send found (payload ending 1c58)");
-  }
-  // Detect cycle size by measuring from the first STAT-cycle send (sendIndices[15])
-  // to the second STAT-cycle send (sendIndices[16 + sendsPerCycle - 1]).
-  // Each cycle starts with a FS Y send; count total records until the next FS Y
-  // send to determine recordsPerStatCycle. FS Y payload ends in "1c59".
-  const fsYPayload = records[statLoopStart].payload_hex ?? "";
-  const nextCycleStart = records.findIndex(
-    (r, i) => i > statLoopStart && r.hook === "send" && (r.payload_hex ?? "") === fsYPayload,
-  );
-  if (nextCycleStart === -1) {
-    throw new Error(
-      "trimStatCycles: could not detect STAT cycle boundary (no second FS Y matching first)",
-    );
-  }
-  const recordsPerStatCycle = nextCycleStart - statLoopStart;
-  const trimmedStatEnd = statLoopStart + keep * recordsPerStatCycle;
-  return [...records.slice(0, trimmedStatEnd), ...records.slice(fsXRecord)];
-}
-
-describe("trimStatCycles", () => {
-  it("keeps LOCK + cycles 1+2, trims the STAT loop, and resumes at FS X", () => {
-    // Build a minimal capture: 15 pre-STAT sends (LOCK + 6 cycle-1 + 8 cycle-2),
-    // 5 STAT cycles (45 records), then an FS X send, then a post-FS-X send.
-    const pre = Array.from({ length: 15 }, (_, i) => ({
-      hook: "send" as const,
-      payload_hex: `aa${i.toString(16).padStart(2, "0")}`,
-    }));
-    const oneStatCycle: CaptureRecord[] = [
-      { hook: "send", payload_hex: "bb01" },
-      { hook: "recv" },
-      { hook: "recv" },
-      { hook: "send", payload_hex: "bb02" },
-      { hook: "recv" },
-      { hook: "recv" },
-      { hook: "send", payload_hex: "bb03" },
-      { hook: "recv" },
-      { hook: "recv" },
-    ];
-    const statLoop = Array.from({ length: 5 }, () => oneStatCycle).flat();
-    const fsX: CaptureRecord = {
-      hook: "send",
-      payload_hex: "49532000000c0000000a000000000002000000011c58",
-    };
-    const post: CaptureRecord = { hook: "send", payload_hex: "ffff" };
-    const all: CaptureRecord[] = [...pre, ...statLoop, fsX, post];
-
-    const trimmed = trimStatCycles(all, 3);
-
-    // 15 pre + (3 × 9) STAT + 2 post (FS X + post) = 44 records
-    expect(trimmed.length).toBe(15 + 27 + 2);
-    expect(trimmed[15 + 27].payload_hex).toBe(fsX.payload_hex);
-    expect(trimmed[15 + 27 + 1].payload_hex).toBe("ffff");
-  });
-
-  it("throws if capture has fewer than 16 sends", () => {
-    const tooShort: CaptureRecord[] = Array.from({ length: 10 }, () => ({
-      hook: "send",
-      payload_hex: "aa",
-    }));
-    expect(() => trimStatCycles(tooShort, 3)).toThrow(/expected ≥ 16/);
-  });
-
-  it("throws if no FS X send is present", () => {
-    const noFsX: CaptureRecord[] = Array.from({ length: 20 }, () => ({
-      hook: "send",
-      payload_hex: "aa",
-    }));
-    expect(() => trimStatCycles(noFsX, 3)).toThrow(/no FS X send/);
-  });
-});
-
-function readJsonl(filePath: string): CaptureRecord[] {
-  return readFileSync(filePath, "utf8")
-    .trim()
-    .split("\n")
-    .map((line) => JSON.parse(line) as CaptureRecord);
-}
-
-/**
- * Drive the scanner through a (pre-trimmed) captured session.
- * Feeds every `recv` record as bytes, asserts every `send` record matches
- * the scanner's nth write. Returns after the records are exhausted.
- */
-async function replayCapture(
-  records: CaptureRecord[],
-  outputDir: string,
-  duplex: boolean,
-  action: "jpg" | "pdf",
-): Promise<{
-  totalDriverSends: number;
-  scannerWrites: Buffer[];
-  sessionPromise: Promise<void>;
-}> {
-  const filtered = records.filter((r) => r.hook === "send" || r.hook === "recv");
-  const fake = new FakeTlsSocket();
-
-  const sessionPromise = runEsci2Scan(
-    { printerIp: "192.0.2.58", port: 1865, destId: 0x02, outputDir, tempDir: "", duplex, action },
-    fake.asFactory(),
-  );
-  fake.simulateConnect();
-
-  let expectedSendIdx = 0;
-  for (const rec of filtered) {
-    if (rec.hook === "recv") {
-      fake.feed(Buffer.from(rec.payload_hex ?? "", "hex"));
-      await waitImmediate();
-    } else {
-      // Wait for the scanner to produce this write — handles the engine's
-      // async flushPage barrier (multi-microtask: await encode → file I/O →
-      // unpause → write staged send) without hard-coding tick counts.
-      await fake.waitForWriteCount(expectedSendIdx + 1);
-      const actual = fake.writes[expectedSendIdx].toString("hex");
-      const expected = rec.payload_hex ?? "";
-      expect(actual, `send #${expectedSendIdx} (driver type=${rec.type_hex})`).toBe(expected);
-      expectedSendIdx++;
-    }
-  }
-
-  // Let the DONE-path finalization task run to completion.
-  await waitImmediate();
-  await waitImmediate();
-
-  const totalDriverSends = filtered.filter((r) => r.hook === "send").length;
-  return { totalDriverSends, scannerWrites: fake.writes, sessionPromise };
-}
-
 describe("scanner replay — full Windows-driver session", () => {
   // True if a JPEG buffer contains an EXIF APP1 (FF E1) marker within the
   // first ~1 KB. Good enough for these assertions — if we're injecting
@@ -495,7 +343,17 @@ describe("scanner replay — full Windows-driver session", () => {
       const raw = readJsonl(fixturePath);
       const trimmed = trimStatCycles(raw, 3);
       const result = await replayCapture(trimmed, outputDir, duplex, action);
-      expect(result.scannerWrites.length).toBe(result.totalDriverSends);
+      // Byte-for-byte shield: every scanner write must equal the captured
+      // driver `send` bytes, in order. Lifted out of replayCapture (which is
+      // expect-free for reuse) and re-asserted here.
+      const sends = trimmed.filter((r) => r.hook === "send");
+      expect(result.scannerWrites.length).toBe(sends.length);
+      for (let i = 0; i < sends.length; i++) {
+        expect(
+          result.scannerWrites[i].toString("hex"),
+          `send #${i} (type=${sends[i].type_hex})`,
+        ).toBe(sends[i].payload_hex ?? "");
+      }
       await expect(result.sessionPromise).resolves.toBeUndefined();
 
       const files = readdirSync(outputDir).sort();
@@ -564,7 +422,17 @@ describe("scanner replay — full Windows-driver session", () => {
       const raw = readJsonl(fixturePath);
       const trimmed = trimStatCycles(raw, 3);
       const result = await replayCapture(trimmed, outputDir, duplex, "pdf");
-      expect(result.scannerWrites.length).toBe(result.totalDriverSends);
+      // Byte-for-byte shield: every scanner write must equal the captured
+      // driver `send` bytes, in order. Lifted out of replayCapture (which is
+      // expect-free for reuse) and re-asserted here.
+      const sends = trimmed.filter((r) => r.hook === "send");
+      expect(result.scannerWrites.length).toBe(sends.length);
+      for (let i = 0; i < sends.length; i++) {
+        expect(
+          result.scannerWrites[i].toString("hex"),
+          `send #${i} (type=${sends[i].type_hex})`,
+        ).toBe(sends[i].payload_hex ?? "");
+      }
       await expect(result.sessionPromise).resolves.toBeUndefined();
 
       await waitForPdf(outputDir);

--- a/src/esci2/test-support/frida-replay.test.ts
+++ b/src/esci2/test-support/frida-replay.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { trimStatCycles } from "./frida-replay.js";
+import type { CaptureRecord } from "./frida-replay.js";
+
+describe("trimStatCycles", () => {
+  it("keeps LOCK + cycles 1+2, trims the STAT loop, and resumes at FS X", () => {
+    // Build a minimal capture: 15 pre-STAT sends (LOCK + 6 cycle-1 + 8 cycle-2),
+    // 5 STAT cycles (45 records), then an FS X send, then a post-FS-X send.
+    const pre = Array.from({ length: 15 }, (_, i) => ({
+      hook: "send" as const,
+      payload_hex: `aa${i.toString(16).padStart(2, "0")}`,
+    }));
+    const oneStatCycle: CaptureRecord[] = [
+      { hook: "send", payload_hex: "bb01" },
+      { hook: "recv" },
+      { hook: "recv" },
+      { hook: "send", payload_hex: "bb02" },
+      { hook: "recv" },
+      { hook: "recv" },
+      { hook: "send", payload_hex: "bb03" },
+      { hook: "recv" },
+      { hook: "recv" },
+    ];
+    const statLoop = Array.from({ length: 5 }, () => oneStatCycle).flat();
+    const fsX: CaptureRecord = {
+      hook: "send",
+      payload_hex: "49532000000c0000000a000000000002000000011c58",
+    };
+    const post: CaptureRecord = { hook: "send", payload_hex: "ffff" };
+    const all: CaptureRecord[] = [...pre, ...statLoop, fsX, post];
+
+    const trimmed = trimStatCycles(all, 3);
+
+    // 15 pre + (3 × 9) STAT + 2 post (FS X + post) = 44 records
+    expect(trimmed.length).toBe(15 + 27 + 2);
+    expect(trimmed[15 + 27].payload_hex).toBe(fsX.payload_hex);
+    expect(trimmed[15 + 27 + 1].payload_hex).toBe("ffff");
+  });
+
+  it("throws if capture has fewer than 16 sends", () => {
+    const tooShort: CaptureRecord[] = Array.from({ length: 10 }, () => ({
+      hook: "send",
+      payload_hex: "aa",
+    }));
+    expect(() => trimStatCycles(tooShort, 3)).toThrow(/expected ≥ 16/);
+  });
+
+  it("throws if no FS X send is present", () => {
+    const noFsX: CaptureRecord[] = Array.from({ length: 20 }, () => ({
+      hook: "send",
+      payload_hex: "aa",
+    }));
+    expect(() => trimStatCycles(noFsX, 3)).toThrow(/no FS X send/);
+  });
+});

--- a/src/esci2/test-support/frida-replay.ts
+++ b/src/esci2/test-support/frida-replay.ts
@@ -55,7 +55,26 @@ export function trimStatCycles(records: CaptureRecord[], keep: number): CaptureR
   }
   const recordsPerStatCycle = nextCycleStart - statLoopStart;
   const trimmedStatEnd = statLoopStart + keep * recordsPerStatCycle;
+  if (trimmedStatEnd > fsXRecord) {
+    // keep is larger than the capture actually has; the two slices would overlap
+    // and duplicate FS X plus the whole image phase. Fail clearly instead.
+    throw new Error(
+      `trimStatCycles: keep=${keep} exceeds the capture's STAT cycle count ` +
+        `(trimmed end ${trimmedStatEnd} would overlap FS X at ${fsXRecord})`,
+    );
+  }
   return [...records.slice(0, trimmedStatEnd), ...records.slice(fsXRecord)];
+}
+
+/** Default replay connection params. The captured ET-4950 session is host-only
+ *  (a FakeTlsSocket), so these are placeholders, but the baseline records them
+ *  and a baseline can override them via ReplayOptions. */
+export const REPLAY_PRINTER_IP = "192.0.2.58";
+export const REPLAY_DEST_ID = 0x02;
+
+export interface ReplayOptions {
+  printerIp?: string;
+  destId?: number;
 }
 
 export interface ReplayResult {
@@ -77,12 +96,21 @@ export async function replayCapture(
   outputDir: string,
   duplex: boolean,
   action: "jpg" | "pdf",
+  opts: ReplayOptions = {},
 ): Promise<ReplayResult> {
   const filtered = records.filter((r) => r.hook === "send" || r.hook === "recv");
   const fake = new FakeTlsSocket();
 
   const sessionPromise = runEsci2Scan(
-    { printerIp: "192.0.2.58", port: 1865, destId: 0x02, outputDir, tempDir: "", duplex, action },
+    {
+      printerIp: opts.printerIp ?? REPLAY_PRINTER_IP,
+      port: 1865,
+      destId: opts.destId ?? REPLAY_DEST_ID,
+      outputDir,
+      tempDir: "",
+      duplex,
+      action,
+    },
     fake.asFactory(),
   );
   fake.simulateConnect();

--- a/src/esci2/test-support/frida-replay.ts
+++ b/src/esci2/test-support/frida-replay.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from "node:fs";
+import { runEsci2Scan } from "../scanner.js";
+import { FakeTlsSocket } from "./fake-tls-socket.js";
+
+function waitImmediate(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+export interface CaptureRecord {
+  hook: "startup" | "waiting" | "send" | "recv" | "error" | "async_event";
+  type_hex?: string;
+  payload_hex?: string;
+  payload_size?: number;
+}
+
+export function readJsonl(filePath: string): CaptureRecord[] {
+  return readFileSync(filePath, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as CaptureRecord);
+}
+
+/**
+ * Trim the driver's variable STAT-cycle count to a fixed `keep`, matching the
+ * scanner. The driver runs ~12 STAT heartbeat cycles after two capability-
+ * discovery cycles; our scanner runs 3. Each STAT cycle is exactly 9 capture
+ * records (3 sends + 6 recvs: envelope header + body per send). We keep the
+ * first `keep` driver STAT cycles, drop the rest, and resume at FS X.
+ *
+ * Pre-STAT sends: LOCK (1) + cycle 1 (6) + cycle 2 (8) = 15 sends. The STAT
+ * loop begins at the 16th send → sendIndices[15].
+ */
+export function trimStatCycles(records: CaptureRecord[], keep: number): CaptureRecord[] {
+  const sendIndices = records.map((r, i) => (r.hook === "send" ? i : -1)).filter((i) => i !== -1);
+  if (sendIndices.length < 16) {
+    throw new Error(`trimStatCycles: capture has only ${sendIndices.length} sends, expected ≥ 16`);
+  }
+  const statLoopStart = sendIndices[15];
+  const fsXRecord = records.findIndex((r) => r.hook === "send" && r.payload_hex?.endsWith("1c58"));
+  if (fsXRecord === -1) {
+    throw new Error("trimStatCycles: no FS X send found (payload ending 1c58)");
+  }
+  // Detect cycle size by measuring from the first STAT-cycle send (sendIndices[15])
+  // to the second STAT-cycle send (sendIndices[16 + sendsPerCycle - 1]).
+  // Each cycle starts with a FS Y send; count total records until the next FS Y
+  // send to determine recordsPerStatCycle. FS Y payload ends in "1c59".
+  const fsYPayload = records[statLoopStart].payload_hex ?? "";
+  const nextCycleStart = records.findIndex(
+    (r, i) => i > statLoopStart && r.hook === "send" && (r.payload_hex ?? "") === fsYPayload,
+  );
+  if (nextCycleStart === -1) {
+    throw new Error(
+      "trimStatCycles: could not detect STAT cycle boundary (no second FS Y matching first)",
+    );
+  }
+  const recordsPerStatCycle = nextCycleStart - statLoopStart;
+  const trimmedStatEnd = statLoopStart + keep * recordsPerStatCycle;
+  return [...records.slice(0, trimmedStatEnd), ...records.slice(fsXRecord)];
+}
+
+export interface ReplayResult {
+  totalDriverSends: number;
+  scannerWrites: Buffer[];
+  sessionPromise: Promise<void>;
+}
+
+/**
+ * Drive the scanner through a (pre-trimmed) captured session.
+ * Feeds every `recv` record as bytes and waits for the scanner's matching nth
+ * write. Returns after the records are exhausted. Byte-for-byte assertion of
+ * each scanner write against the captured `send` bytes is the caller's job —
+ * this helper deliberately contains no `expect` calls so it can be reused
+ * outside Vitest (e.g. a dev replay CLI).
+ */
+export async function replayCapture(
+  records: CaptureRecord[],
+  outputDir: string,
+  duplex: boolean,
+  action: "jpg" | "pdf",
+): Promise<ReplayResult> {
+  const filtered = records.filter((r) => r.hook === "send" || r.hook === "recv");
+  const fake = new FakeTlsSocket();
+
+  const sessionPromise = runEsci2Scan(
+    { printerIp: "192.0.2.58", port: 1865, destId: 0x02, outputDir, tempDir: "", duplex, action },
+    fake.asFactory(),
+  );
+  fake.simulateConnect();
+
+  let expectedSendIdx = 0;
+  for (const rec of filtered) {
+    if (rec.hook === "recv") {
+      fake.feed(Buffer.from(rec.payload_hex ?? "", "hex"));
+      await waitImmediate();
+    } else {
+      // Wait for the scanner to produce this write — handles the engine's
+      // async flushPage barrier (multi-microtask: await encode → file I/O →
+      // unpause → write staged send) without hard-coding tick counts.
+      await fake.waitForWriteCount(expectedSendIdx + 1);
+      expectedSendIdx++;
+    }
+  }
+
+  // Let the DONE-path finalization task run to completion.
+  await waitImmediate();
+  await waitImmediate();
+
+  const totalDriverSends = filtered.filter((r) => r.hook === "send").length;
+  return { totalDriverSends, scannerWrites: fake.writes, sessionPromise };
+}

--- a/src/exif.test.ts
+++ b/src/exif.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { setJpegOrientation } from "./exif.js";
+import sharp from "sharp";
+import { setJpegOrientation, readJpegOrientation } from "./exif.js";
 
 describe("setJpegOrientation", () => {
   // A minimal valid JPEG prefix for tests: SOI + 3 arbitrary bytes.
@@ -73,5 +74,26 @@ describe("setJpegOrientation", () => {
     const result = setJpegOrientation(minimalJpeg, 3);
     // Bytes 2-3 of the output are the APP1 segment length (big-endian, excludes marker).
     expect(result.readUInt16BE(4)).toBe(0x0022);
+  });
+});
+
+describe("readJpegOrientation", () => {
+  it("reads back an orientation written by setJpegOrientation", async () => {
+    const jpeg = await sharp({
+      create: { width: 4, height: 4, channels: 3, background: { r: 1, g: 2, b: 3 } },
+    })
+      .jpeg()
+      .toBuffer();
+    const tagged = setJpegOrientation(jpeg, 3);
+    expect(readJpegOrientation(tagged)).toBe(3);
+  });
+
+  it("returns undefined for a JFIF-only JPEG with no EXIF", async () => {
+    const jpeg = await sharp({
+      create: { width: 4, height: 4, channels: 3, background: { r: 1, g: 2, b: 3 } },
+    })
+      .jpeg()
+      .toBuffer();
+    expect(readJpegOrientation(jpeg)).toBeUndefined();
   });
 });

--- a/src/exif.test.ts
+++ b/src/exif.test.ts
@@ -125,4 +125,18 @@ describe("readJpegOrientation", () => {
     expect(() => readJpegOrientation(buf)).not.toThrow();
     expect(readJpegOrientation(buf)).toBeUndefined();
   });
+
+  it("skips a non-Exif APP1 (XMP) and still finds a following Exif APP1", () => {
+    // The 36-byte Exif APP1 (Orientation=3) that setJpegOrientation emits.
+    const exifApp1 = setJpegOrientation(Buffer.from([0xff, 0xd8]), 3).subarray(2, 38);
+    // A leading XMP APP1 (also marker 0xE1) that must be skipped, not bailed on.
+    const xmpBody = Buffer.from("http://ns.adobe.com/xap/1.0/\0<x:xmpmeta/>", "ascii");
+    const xmpLen = 2 + xmpBody.length; // segment length includes its 2 length bytes
+    const xmpApp1 = Buffer.concat([
+      Buffer.from([0xff, 0xe1, (xmpLen >> 8) & 0xff, xmpLen & 0xff]),
+      xmpBody,
+    ]);
+    const buf = Buffer.concat([Buffer.from([0xff, 0xd8]), xmpApp1, exifApp1]);
+    expect(readJpegOrientation(buf)).toBe(3);
+  });
 });

--- a/src/exif.test.ts
+++ b/src/exif.test.ts
@@ -96,4 +96,33 @@ describe("readJpegOrientation", () => {
       .toBuffer();
     expect(readJpegOrientation(jpeg)).toBeUndefined();
   });
+
+  it("returns undefined (does not throw) on a corrupt EXIF IFD offset", () => {
+    // Valid SOI + APP1 + "Exif\0\0" + TIFF header, but the IFD0 offset points
+    // far past the buffer. The parser must bounds-check, not RangeError.
+    const buf = Buffer.from([
+      0xff,
+      0xd8, // SOI
+      0xff,
+      0xe1, // APP1
+      0x00,
+      0x10, // nominal segment length
+      0x45,
+      0x78,
+      0x69,
+      0x66,
+      0x00,
+      0x00, // "Exif\0\0"
+      0x49,
+      0x49,
+      0x2a,
+      0x00, // TIFF header (little-endian)
+      0xff,
+      0xff,
+      0xff,
+      0xff, // IFD0 offset pointing past the buffer
+    ]);
+    expect(() => readJpegOrientation(buf)).not.toThrow();
+    expect(readJpegOrientation(buf)).toBeUndefined();
+  });
 });

--- a/src/exif.ts
+++ b/src/exif.ts
@@ -60,3 +60,40 @@ export function setJpegOrientation(jpeg: Buffer, orientation: ExifOrientation): 
   jpeg.copy(out, 2 + app1.length, 2);
   return out;
 }
+
+/**
+ * Reads the EXIF Orientation tag from a JPEG, or undefined if there's no
+ * APP1/EXIF segment or no Orientation tag. Minimal TIFF parser — handles the
+ * single-IFD layout that setJpegOrientation and camera firmware produce.
+ */
+export function readJpegOrientation(jpeg: Buffer): ExifOrientation | undefined {
+  let off = 2; // skip SOI
+  while (off + 4 <= jpeg.length) {
+    if (jpeg[off] !== 0xff) break;
+    const marker = jpeg[off + 1];
+    const segLen = jpeg.readUInt16BE(off + 2);
+    if (marker === 0xe1) {
+      // APP1 — expect "Exif\0\0" then TIFF header.
+      const base = off + 4;
+      if (jpeg.toString("ascii", base, base + 4) === "Exif") {
+        const tiff = base + 6;
+        const le = jpeg.toString("ascii", tiff, tiff + 2) === "II";
+        const u16 = (p: number) => (le ? jpeg.readUInt16LE(p) : jpeg.readUInt16BE(p));
+        const u32 = (p: number) => (le ? jpeg.readUInt32LE(p) : jpeg.readUInt32BE(p));
+        const ifd0 = tiff + u32(tiff + 4);
+        const count = u16(ifd0);
+        for (let i = 0; i < count; i++) {
+          const entry = ifd0 + 2 + i * 12;
+          if (u16(entry) === 0x0112) {
+            const v = u16(entry + 8);
+            if (v === 1 || v === 3 || v === 6 || v === 8) return v;
+          }
+        }
+      }
+      return undefined;
+    }
+    if (marker === 0xda) break; // start of scan — no more metadata
+    off += 2 + segLen;
+  }
+  return undefined;
+}

--- a/src/exif.ts
+++ b/src/exif.ts
@@ -73,10 +73,11 @@ export function readJpegOrientation(jpeg: Buffer): ExifOrientation | undefined {
     const marker = jpeg[off + 1];
     const segLen = jpeg.readUInt16BE(off + 2);
     if (marker === 0xe1) {
-      // APP1 — expect "Exif\0\0" then TIFF header. Every read below is
-      // bounds-checked against jpeg.length so a truncated or corrupt EXIF
-      // returns undefined (per this function's contract) rather than throwing
-      // a RangeError on an out-of-range buffer offset.
+      // APP1 — only an "Exif\0\0" APP1 carries the Orientation tag. Other APP1
+      // segments (e.g. an XMP APP1 written before the Exif one) are skipped so
+      // they don't hide a later Exif segment. Every read below is bounds-checked
+      // against jpeg.length so a truncated or corrupt EXIF returns undefined
+      // (per this function's contract) rather than throwing a RangeError.
       const base = off + 4;
       const tiff = base + 6;
       if (tiff + 8 <= jpeg.length && jpeg.toString("ascii", base, base + 4) === "Exif") {
@@ -95,8 +96,9 @@ export function readJpegOrientation(jpeg: Buffer): ExifOrientation | undefined {
             }
           }
         }
+        return undefined; // Exif APP1 parsed; no usable Orientation tag.
       }
-      return undefined;
+      // Non-Exif APP1 — fall through to skip it and keep scanning.
     }
     if (marker === 0xda) break; // start of scan — no more metadata
     off += 2 + segLen;

--- a/src/exif.ts
+++ b/src/exif.ts
@@ -101,6 +101,7 @@ export function readJpegOrientation(jpeg: Buffer): ExifOrientation | undefined {
       // Non-Exif APP1 — fall through to skip it and keep scanning.
     }
     if (marker === 0xda) break; // start of scan — no more metadata
+    if (segLen < 2) break; // malformed segment length (min is 2) — can't safely advance
     off += 2 + segLen;
   }
   return undefined;

--- a/src/exif.ts
+++ b/src/exif.ts
@@ -73,20 +73,26 @@ export function readJpegOrientation(jpeg: Buffer): ExifOrientation | undefined {
     const marker = jpeg[off + 1];
     const segLen = jpeg.readUInt16BE(off + 2);
     if (marker === 0xe1) {
-      // APP1 — expect "Exif\0\0" then TIFF header.
+      // APP1 — expect "Exif\0\0" then TIFF header. Every read below is
+      // bounds-checked against jpeg.length so a truncated or corrupt EXIF
+      // returns undefined (per this function's contract) rather than throwing
+      // a RangeError on an out-of-range buffer offset.
       const base = off + 4;
-      if (jpeg.toString("ascii", base, base + 4) === "Exif") {
-        const tiff = base + 6;
+      const tiff = base + 6;
+      if (tiff + 8 <= jpeg.length && jpeg.toString("ascii", base, base + 4) === "Exif") {
         const le = jpeg.toString("ascii", tiff, tiff + 2) === "II";
         const u16 = (p: number) => (le ? jpeg.readUInt16LE(p) : jpeg.readUInt16BE(p));
         const u32 = (p: number) => (le ? jpeg.readUInt32LE(p) : jpeg.readUInt32BE(p));
         const ifd0 = tiff + u32(tiff + 4);
-        const count = u16(ifd0);
-        for (let i = 0; i < count; i++) {
-          const entry = ifd0 + 2 + i * 12;
-          if (u16(entry) === 0x0112) {
-            const v = u16(entry + 8);
-            if (v === 1 || v === 3 || v === 6 || v === 8) return v;
+        if (ifd0 + 2 <= jpeg.length) {
+          const count = u16(ifd0);
+          for (let i = 0; i < count; i++) {
+            const entry = ifd0 + 2 + i * 12;
+            if (entry + 12 > jpeg.length) break; // entry runs past the buffer
+            if (u16(entry) === 0x0112) {
+              const v = u16(entry + 8);
+              if (v === 1 || v === 3 || v === 6 || v === 8) return v;
+            }
           }
         }
       }

--- a/src/test-oracle/baseline.test.ts
+++ b/src/test-oracle/baseline.test.ts
@@ -20,6 +20,7 @@ const sample: Baseline = {
   swatches: [{ label: "FF0000", rgb: [200, 30, 25] }],
   greySpreads: [{ label: "C0C0C0", spread: 4 }],
   stripeVarianceMax: 12,
+  expectedPageCount: 1,
   expectedBackPages: [],
   tolerances: { swatchDeltaE: 4, crosshairPx: 6, greySpread: 10, stripeVariance: 25 },
 };

--- a/src/test-oracle/baseline.test.ts
+++ b/src/test-oracle/baseline.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { BaselineSchema, loadBaseline, saveBaseline, type Baseline } from "./baseline.js";
+
+const sample: Baseline = {
+  approvedAt: "2026-06-05",
+  note: "ET-4956 flatbed reference",
+  replay: {
+    fixturePath: "tools/frida-capture/captures/x.jsonl",
+    source: "flatbed",
+    duplex: false,
+    trimStatCycles: 3,
+    printerIp: "192.0.2.58",
+    destId: 2,
+  },
+  page: { width: 1191, height: 1684 },
+  crosshairResidualPx: 1.2,
+  swatches: [{ label: "FF0000", rgb: [200, 30, 25] }],
+  greySpreads: [{ label: "C0C0C0", spread: 4 }],
+  stripeVarianceMax: 12,
+  expectedBackPages: [],
+  tolerances: { swatchDeltaE: 4, crosshairPx: 6, greySpread: 10, stripeVariance: 25 },
+};
+
+describe("baseline", () => {
+  it("accepts a well-formed baseline", () => {
+    expect(() => BaselineSchema.parse(sample)).not.toThrow();
+  });
+
+  it("rejects a baseline missing the replay block", () => {
+    const bad = { ...sample } as Record<string, unknown>;
+    delete bad.replay;
+    expect(() => BaselineSchema.parse(bad)).toThrow();
+  });
+
+  it("round-trips through save/load", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "baseline-test-"));
+    try {
+      const p = path.join(dir, "x.baseline.json");
+      saveBaseline(p, sample);
+      expect(loadBaseline(p)).toEqual(sample);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/test-oracle/baseline.ts
+++ b/src/test-oracle/baseline.ts
@@ -1,0 +1,39 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { z } from "zod";
+
+export const BaselineSchema = z.object({
+  approvedAt: z.string(),
+  note: z.string().optional(),
+  replay: z.object({
+    fixturePath: z.string(),
+    source: z.enum(["flatbed", "adf-simplex", "adf-duplex"]),
+    duplex: z.boolean(),
+    trimStatCycles: z.number().int().nonnegative(),
+    printerIp: z.string(),
+    destId: z.number().int(),
+  }),
+  page: z.object({ width: z.number().int(), height: z.number().int() }),
+  crosshairResidualPx: z.number(),
+  swatches: z.array(
+    z.object({ label: z.string(), rgb: z.tuple([z.number(), z.number(), z.number()]) }),
+  ),
+  greySpreads: z.array(z.object({ label: z.string(), spread: z.number() })),
+  stripeVarianceMax: z.number(),
+  expectedBackPages: z.array(z.number().int()),
+  tolerances: z.object({
+    swatchDeltaE: z.number(),
+    crosshairPx: z.number(),
+    greySpread: z.number(),
+    stripeVariance: z.number(),
+  }),
+});
+
+export type Baseline = z.infer<typeof BaselineSchema>;
+
+export function loadBaseline(filePath: string): Baseline {
+  return BaselineSchema.parse(JSON.parse(readFileSync(filePath, "utf8")));
+}
+
+export function saveBaseline(filePath: string, baseline: Baseline): void {
+  writeFileSync(filePath, JSON.stringify(BaselineSchema.parse(baseline), null, 2) + "\n");
+}

--- a/src/test-oracle/baseline.ts
+++ b/src/test-oracle/baseline.ts
@@ -19,6 +19,8 @@ export const BaselineSchema = z.object({
   ),
   greySpreads: z.array(z.object({ label: z.string(), spread: z.number() })),
   stripeVarianceMax: z.number(),
+  /** Total pages the fixture is expected to produce — pins dropped/extra-page regressions. */
+  expectedPageCount: z.number().int().positive(),
   expectedBackPages: z.array(z.number().int()),
   tolerances: z.object({
     swatchDeltaE: z.number(),

--- a/src/test-oracle/color.test.ts
+++ b/src/test-oracle/color.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { deltaE, channelSpread } from "./color.js";
+
+describe("color", () => {
+  it("returns ~0 deltaE for identical colours", () => {
+    expect(deltaE({ r: 100, g: 120, b: 140 }, { r: 100, g: 120, b: 140 })).toBeLessThan(0.001);
+  });
+
+  it("returns a larger deltaE for distinct colours", () => {
+    expect(deltaE({ r: 255, g: 0, b: 0 }, { r: 0, g: 255, b: 0 })).toBeGreaterThan(50);
+  });
+
+  it("computes channel spread", () => {
+    expect(channelSpread({ r: 100, g: 110, b: 90 })).toBe(20);
+  });
+});

--- a/src/test-oracle/color.ts
+++ b/src/test-oracle/color.ts
@@ -1,0 +1,32 @@
+import type { Rgb } from "./types.js";
+
+export function channelSpread(c: Rgb): number {
+  return Math.max(c.r, c.g, c.b) - Math.min(c.r, c.g, c.b);
+}
+
+function srgbToLinear(v: number): number {
+  const c = v / 255;
+  return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
+function rgbToLab(c: Rgb): [number, number, number] {
+  const r = srgbToLinear(c.r);
+  const g = srgbToLinear(c.g);
+  const b = srgbToLinear(c.b);
+  // sRGB → XYZ (D65)
+  const x = (r * 0.4124 + g * 0.3576 + b * 0.1805) / 0.95047;
+  const y = r * 0.2126 + g * 0.7152 + b * 0.0722;
+  const z = (r * 0.0193 + g * 0.1192 + b * 0.9505) / 1.08883;
+  const f = (t: number) => (t > 0.008856 ? Math.cbrt(t) : 7.787 * t + 16 / 116);
+  const fx = f(x),
+    fy = f(y),
+    fz = f(z);
+  return [116 * fy - 16, 500 * (fx - fy), 200 * (fy - fz)];
+}
+
+/** CIE76 colour distance in CIELAB. Sufficient for baseline regression. */
+export function deltaE(a: Rgb, b: Rgb): number {
+  const [l1, a1, b1] = rgbToLab(a);
+  const [l2, a2, b2] = rgbToLab(b);
+  return Math.sqrt((l1 - l2) ** 2 + (a1 - a2) ** 2 + (b1 - b2) ** 2);
+}

--- a/src/test-oracle/crosshairs.test.ts
+++ b/src/test-oracle/crosshairs.test.ts
@@ -13,10 +13,14 @@ describe("detectCrosshairs", () => {
     }
   });
 
-  it("ignores a saturated coloured marker next to the TL crosshair", () => {
+  it("ignores a dark-but-single-channel-bright marker next to the TL crosshair", () => {
+    // {0,0,150} has an average channel value of 50 (< NEAR_BLACK 60), so a naive
+    // average/luminance-based filter WOULD count it and bias the TL centroid. The
+    // all-channel filter correctly excludes it because b=150 is not < 60, so this
+    // test passes only because the implementation uses the all-channel filter.
     const { raster, expectedCrosshairsPx } = buildTestPageRaster({
       scale: 2,
-      marker: { r: 255, g: 0, b: 0 },
+      marker: { r: 0, g: 0, b: 150 },
     });
     const found = detectCrosshairs(raster);
     expect(Math.abs(found[0].x - expectedCrosshairsPx[0].x)).toBeLessThan(3);

--- a/src/test-oracle/crosshairs.test.ts
+++ b/src/test-oracle/crosshairs.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { detectCrosshairs } from "./crosshairs.js";
+import { buildTestPageRaster } from "./test-support/raster-draw.js";
+
+describe("detectCrosshairs", () => {
+  it("finds all 4 crosshair centres near their expected positions", () => {
+    const { raster, expectedCrosshairsPx } = buildTestPageRaster({ scale: 2 });
+    const found = detectCrosshairs(raster);
+    expect(found).toHaveLength(4);
+    for (let i = 0; i < 4; i++) {
+      expect(Math.abs(found[i].x - expectedCrosshairsPx[i].x)).toBeLessThan(3);
+      expect(Math.abs(found[i].y - expectedCrosshairsPx[i].y)).toBeLessThan(3);
+    }
+  });
+
+  it("ignores a saturated coloured marker next to the TL crosshair", () => {
+    const { raster, expectedCrosshairsPx } = buildTestPageRaster({
+      scale: 2,
+      marker: { r: 255, g: 0, b: 0 },
+    });
+    const found = detectCrosshairs(raster);
+    expect(Math.abs(found[0].x - expectedCrosshairsPx[0].x)).toBeLessThan(3);
+    expect(Math.abs(found[0].y - expectedCrosshairsPx[0].y)).toBeLessThan(3);
+  });
+});

--- a/src/test-oracle/crosshairs.ts
+++ b/src/test-oracle/crosshairs.ts
@@ -1,0 +1,46 @@
+import type { Point, Raster } from "./types.js";
+import { LAYOUT, crosshairPoints } from "../../tools/test-page/layout.js";
+
+const NEAR_BLACK = 60; // all channels must be below this to count as crosshair ink
+const WINDOW_FRACTION = 0.18; // search window edge length as a fraction of the page
+
+/**
+ * Detect the 4 registration crosshairs, returned in layout order [TL,TR,BL,BR]
+ * as pixel centroids. For each crosshair we search a window centred on its
+ * EXPECTED pixel position (derived from the layout's corner fractions × image
+ * size — coarse is fine, the page is near-aligned) and take the centroid of
+ * NEAR-BLACK-IN-ALL-CHANNELS pixels. The all-channel threshold is what keeps
+ * the saturated red "F" / blue "B" markers (which sit near the TL crosshair)
+ * from biasing the centroid — they're bright in one channel.
+ */
+export function detectCrosshairs(r: Raster): Point[] {
+  const half = Math.round((Math.min(r.width, r.height) * WINDOW_FRACTION) / 2);
+  return crosshairPoints.map((cp) => {
+    const fx = cp.x / LAYOUT.pageWidth;
+    const fy = 1 - cp.y / LAYOUT.pageHeight;
+    const cx = Math.round(fx * r.width);
+    const cy = Math.round(fy * r.height);
+    const x0 = Math.max(0, cx - half);
+    const y0 = Math.max(0, cy - half);
+    const x1 = Math.min(r.width, cx + half);
+    const y1 = Math.min(r.height, cy + half);
+
+    let sx = 0;
+    let sy = 0;
+    let n = 0;
+    for (let y = y0; y < y1; y++) {
+      for (let x = x0; x < x1; x++) {
+        const i = (y * r.width + x) * r.channels;
+        if (r.data[i] < NEAR_BLACK && r.data[i + 1] < NEAR_BLACK && r.data[i + 2] < NEAR_BLACK) {
+          sx += x;
+          sy += y;
+          n++;
+        }
+      }
+    }
+    if (n === 0) {
+      throw new Error(`detectCrosshairs: no near-black pixels in window around (${cx},${cy})`);
+    }
+    return { x: sx / n, y: sy / n };
+  });
+}

--- a/src/test-oracle/crosshairs.ts
+++ b/src/test-oracle/crosshairs.ts
@@ -12,6 +12,17 @@ const WINDOW_FRACTION = 0.18; // search window edge length as a fraction of the 
  * NEAR-BLACK-IN-ALL-CHANNELS pixels. The all-channel threshold is what keeps
  * the saturated red "F" / blue "B" markers (which sit near the TL crosshair)
  * from biasing the centroid — they're bright in one channel.
+ *
+ * Real-scan assumptions (observations for when this runs on actual scans, not
+ * the synthetic test page):
+ * - The NEAR_BLACK=60 cut is a hard threshold tuned for near-black ink;
+ *   anti-aliased / soft crosshair edges on a real scan get dropped, which
+ *   narrows but does not bias the (symmetric) centroid.
+ * - The window sizing assumes a roughly page-shaped (A4) input; on a near-square
+ *   crop the four windows approach each other.
+ * - Each window is assumed to contain no other near-black content besides the
+ *   crosshair (true for the compatibility page, whose corners are otherwise
+ *   empty); stray dark content inside a window would bias the centroid.
  */
 export function detectCrosshairs(r: Raster): Point[] {
   const half = Math.round((Math.min(r.width, r.height) * WINDOW_FRACTION) / 2);

--- a/src/test-oracle/decode.test.ts
+++ b/src/test-oracle/decode.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import sharp from "sharp";
+import { decodeToRaster } from "./decode.js";
+import { setJpegOrientation } from "../exif.js";
+
+async function solidJpeg(w: number, h: number, c: { r: number; g: number; b: number }) {
+  return sharp({ create: { width: w, height: h, channels: 3, background: c } })
+    .jpeg({ quality: 100 })
+    .toBuffer();
+}
+
+describe("decodeToRaster", () => {
+  it("decodes a JPEG to a 3-channel raster of the right size", async () => {
+    const jpeg = await solidJpeg(16, 8, { r: 200, g: 100, b: 50 });
+    const r = await decodeToRaster(jpeg);
+    expect(r.width).toBe(16);
+    expect(r.height).toBe(8);
+    expect(r.channels).toBe(3);
+    const i = (4 * 16 + 8) * 3;
+    expect(r.data[i]).toBeGreaterThan(190);
+    expect(r.data[i]).toBeLessThan(210);
+  });
+
+  it("applies EXIF orientation when asked (180° swaps top/bottom rows)", async () => {
+    const top = await sharp({
+      create: { width: 8, height: 4, channels: 3, background: { r: 255, g: 0, b: 0 } },
+    })
+      .png()
+      .toBuffer();
+    const bottom = await sharp({
+      create: { width: 8, height: 4, channels: 3, background: { r: 0, g: 0, b: 255 } },
+    })
+      .png()
+      .toBuffer();
+    const composed = await sharp({
+      create: { width: 8, height: 8, channels: 3, background: { r: 0, g: 0, b: 0 } },
+    })
+      .composite([
+        { input: top, top: 0, left: 0 },
+        { input: bottom, top: 4, left: 0 },
+      ])
+      .jpeg({ quality: 100 })
+      .toBuffer();
+    const tagged = setJpegOrientation(composed, 3);
+
+    const off = await decodeToRaster(tagged, { applyOrientation: false });
+    const on = await decodeToRaster(tagged, { applyOrientation: true });
+    const topPx = (r: typeof off) => r.data[(1 * 8 + 4) * 3];
+    expect(topPx(off)).toBeGreaterThan(200);
+    expect(topPx(on)).toBeLessThan(60);
+  });
+});

--- a/src/test-oracle/decode.ts
+++ b/src/test-oracle/decode.ts
@@ -1,0 +1,18 @@
+import sharp from "sharp";
+import type { Raster } from "./types.js";
+
+export interface DecodeOpts {
+  /** Bake EXIF orientation into pixels via sharp.rotate() (default false). */
+  applyOrientation?: boolean;
+}
+
+/**
+ * Decode a JPEG buffer to a tightly-packed RGB raster (top-left origin).
+ * Never accepts PDF — sharp/libvips cannot rasterize PDF in this build.
+ */
+export async function decodeToRaster(jpeg: Buffer, opts: DecodeOpts = {}): Promise<Raster> {
+  let pipeline = sharp(jpeg);
+  if (opts.applyOrientation) pipeline = pipeline.rotate(); // auto-orient from EXIF
+  const { data, info } = await pipeline.removeAlpha().raw().toBuffer({ resolveWithObject: true });
+  return { data, width: info.width, height: info.height, channels: info.channels };
+}

--- a/src/test-oracle/metrics.test.ts
+++ b/src/test-oracle/metrics.test.ts
@@ -23,4 +23,10 @@ describe("metrics", () => {
     }
     expect(perRowVariance(r, { x: 0, y: 0, w: 20, h: 20 })).toBeGreaterThan(1000);
   });
+
+  it("throws on an empty region (consistent with meanRgb, not silent NaN)", () => {
+    const r = blankRaster(20, 20);
+    expect(() => perRowVariance(r, { x: 5, y: 5, w: 0, h: 0 })).toThrow(/empty region/);
+    expect(() => meanRgb(r, { x: 5, y: 5, w: 0, h: 0 })).toThrow(/empty region/);
+  });
 });

--- a/src/test-oracle/metrics.test.ts
+++ b/src/test-oracle/metrics.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { meanRgb, perRowVariance } from "./metrics.js";
+import { blankRaster, fillRect } from "./test-support/raster-draw.js";
+
+describe("metrics", () => {
+  it("computes the mean RGB of a region", () => {
+    const r = blankRaster(20, 20);
+    fillRect(r, { x: 5, y: 5, w: 10, h: 10 }, { r: 40, g: 80, b: 120 });
+    expect(meanRgb(r, { x: 5, y: 5, w: 10, h: 10 })).toEqual({ r: 40, g: 80, b: 120 });
+  });
+
+  it("reports ~0 row variance for a flat fill", () => {
+    const r = blankRaster(20, 20);
+    fillRect(r, { x: 0, y: 0, w: 20, h: 20 }, { r: 128, g: 128, b: 128 });
+    expect(perRowVariance(r, { x: 0, y: 0, w: 20, h: 20 })).toBeLessThan(0.001);
+  });
+
+  it("reports high row variance for horizontal banding", () => {
+    const r = blankRaster(20, 20);
+    for (let y = 0; y < 20; y++) {
+      const v = y % 2 === 0 ? 0 : 255;
+      fillRect(r, { x: 0, y, w: 20, h: 1 }, { r: v, g: v, b: v });
+    }
+    expect(perRowVariance(r, { x: 0, y: 0, w: 20, h: 20 })).toBeGreaterThan(1000);
+  });
+});

--- a/src/test-oracle/metrics.ts
+++ b/src/test-oracle/metrics.ts
@@ -1,0 +1,47 @@
+import type { Raster, Rect, Rgb } from "./types.js";
+
+function clampRect(r: Raster, rect: Rect): { x0: number; y0: number; x1: number; y1: number } {
+  return {
+    x0: Math.max(0, Math.round(rect.x)),
+    y0: Math.max(0, Math.round(rect.y)),
+    x1: Math.min(r.width, Math.round(rect.x + rect.w)),
+    y1: Math.min(r.height, Math.round(rect.y + rect.h)),
+  };
+}
+
+export function meanRgb(r: Raster, rect: Rect): Rgb {
+  const { x0, y0, x1, y1 } = clampRect(r, rect);
+  let sr = 0,
+    sg = 0,
+    sb = 0,
+    n = 0;
+  for (let y = y0; y < y1; y++) {
+    for (let x = x0; x < x1; x++) {
+      const i = (y * r.width + x) * r.channels;
+      sr += r.data[i];
+      sg += r.data[i + 1];
+      sb += r.data[i + 2];
+      n++;
+    }
+  }
+  if (n === 0) throw new Error("meanRgb: empty region");
+  return { r: sr / n, g: sg / n, b: sb / n };
+}
+
+/** Variance across per-row luma means — high under horizontal banding. */
+export function perRowVariance(r: Raster, rect: Rect): number {
+  const { x0, y0, x1, y1 } = clampRect(r, rect);
+  const rowMeans: number[] = [];
+  for (let y = y0; y < y1; y++) {
+    let s = 0,
+      n = 0;
+    for (let x = x0; x < x1; x++) {
+      const i = (y * r.width + x) * r.channels;
+      s += (r.data[i] + r.data[i + 1] + r.data[i + 2]) / 3;
+      n++;
+    }
+    if (n > 0) rowMeans.push(s / n);
+  }
+  const mean = rowMeans.reduce((a, b) => a + b, 0) / rowMeans.length;
+  return rowMeans.reduce((a, b) => a + (b - mean) ** 2, 0) / rowMeans.length;
+}

--- a/src/test-oracle/metrics.ts
+++ b/src/test-oracle/metrics.ts
@@ -42,6 +42,7 @@ export function perRowVariance(r: Raster, rect: Rect): number {
     }
     if (n > 0) rowMeans.push(s / n);
   }
+  if (rowMeans.length === 0) throw new Error("perRowVariance: empty region");
   const mean = rowMeans.reduce((a, b) => a + b, 0) / rowMeans.length;
   return rowMeans.reduce((a, b) => a + (b - mean) ** 2, 0) / rowMeans.length;
 }

--- a/src/test-oracle/oracle.test.ts
+++ b/src/test-oracle/oracle.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { measure, assertAgainst } from "./oracle.js";
+import { buildTestPageRaster } from "./test-support/raster-draw.js";
+import type { Baseline } from "./baseline.js";
+
+function baselineFrom(raster: ReturnType<typeof buildTestPageRaster>["raster"]): Baseline {
+  const m = measure(raster);
+  return {
+    approvedAt: "2026-06-05",
+    replay: {
+      fixturePath: "x",
+      source: "flatbed",
+      duplex: false,
+      trimStatCycles: 3,
+      printerIp: "192.0.2.58",
+      destId: 2,
+    },
+    page: { width: raster.width, height: raster.height },
+    crosshairResidualPx: m.crosshairResidualPx,
+    swatches: m.swatches,
+    greySpreads: m.greySpreads,
+    stripeVarianceMax: m.stripeVarianceMax,
+    expectedBackPages: [],
+    tolerances: {
+      swatchDeltaE: 4,
+      crosshairPx: 6,
+      greySpread: 12,
+      stripeVariance: m.stripeVarianceMax + 20,
+    },
+  };
+}
+
+describe("oracle", () => {
+  it("passes a synthetic page against a baseline measured from itself", () => {
+    const { raster } = buildTestPageRaster({ scale: 2 });
+    const baseline = baselineFrom(raster);
+    const report = assertAgainst(raster, baseline);
+    expect(report.pass).toBe(true);
+  });
+
+  it("fails when a swatch colour is shifted beyond tolerance", () => {
+    const { raster: good } = buildTestPageRaster({ scale: 2 });
+    const baseline = baselineFrom(good);
+    const colors = baseline.swatches.map((s) => ({ r: s.rgb[0], g: s.rgb[1], b: s.rgb[2] }));
+    colors[0] = { r: 0, g: 255, b: 0 }; // red → green
+    const { raster: bad } = buildTestPageRaster({ scale: 2, swatchColors: colors });
+    const report = assertAgainst(bad, baseline);
+    expect(report.pass).toBe(false);
+    expect(report.checks.find((c) => c.name === "swatch:FF0000")?.pass).toBe(false);
+  });
+
+  it("fails when output dimensions don't match the baseline page size", () => {
+    const { raster } = buildTestPageRaster({ scale: 2 });
+    const baseline = baselineFrom(raster); // page size recorded at scale 2
+    const { raster: scaled } = buildTestPageRaster({ scale: 3 });
+    const report = assertAgainst(scaled, baseline);
+    expect(report.pass).toBe(false);
+    expect(report.checks.find((c) => c.name === "geometry:page-size")?.pass).toBe(false);
+  });
+});

--- a/src/test-oracle/oracle.test.ts
+++ b/src/test-oracle/oracle.test.ts
@@ -39,6 +39,19 @@ describe("oracle", () => {
     expect(report.pass).toBe(true);
   });
 
+  it("accepts a uniformly shifted page (translation invariance is by design, not a false pass)", () => {
+    // Same page, same size, but all content + registration crosshairs translated
+    // together. The crosshair-fit transform absorbs the offset, so sampling
+    // follows the page and every check still passes. This documents the intended
+    // scan-positioning robustness — it is NOT a missed regression. Non-affine
+    // distortion (skew/stride) raises the residual and is caught separately.
+    const { raster } = buildTestPageRaster({ scale: 2 });
+    const baseline = baselineFrom(raster);
+    const { raster: shifted } = buildTestPageRaster({ scale: 2, shiftPx: { dx: 20, dy: 20 } });
+    const report = assertAgainst(shifted, baseline);
+    expect(report.pass, JSON.stringify(report.checks, null, 2)).toBe(true);
+  });
+
   it("fails when a swatch colour is shifted beyond tolerance", () => {
     const { raster: good } = buildTestPageRaster({ scale: 2 });
     const baseline = baselineFrom(good);

--- a/src/test-oracle/oracle.test.ts
+++ b/src/test-oracle/oracle.test.ts
@@ -20,6 +20,7 @@ function baselineFrom(raster: ReturnType<typeof buildTestPageRaster>["raster"]):
     swatches: m.swatches,
     greySpreads: m.greySpreads,
     stripeVarianceMax: m.stripeVarianceMax,
+    expectedPageCount: 1,
     expectedBackPages: [],
     tolerances: {
       swatchDeltaE: 4,

--- a/src/test-oracle/oracle.ts
+++ b/src/test-oracle/oracle.ts
@@ -105,15 +105,33 @@ export function measure(raster: Raster): Measurement {
 
 /** Run all checks against a committed baseline. */
 export function assertAgainst(raster: Raster, baseline: Baseline): OracleReport {
-  const m = measure(raster);
   const checks: CheckResult[] = [];
 
+  // Page-size first: it needs only the raster dimensions and stays meaningful
+  // even when measurement can't run.
   checks.push({
     name: "geometry:page-size",
     pass: raster.width === baseline.page.width && raster.height === baseline.page.height,
     measured: null,
     detail: `${raster.width}x${raster.height} vs baseline ${baseline.page.width}x${baseline.page.height}`,
   });
+
+  // measure() throws on a badly degenerate raster (no detectable crosshairs, an
+  // off-image sample region) — exactly the input class page-size flags. Turn that
+  // into a failed check so the oracle always returns a readable report instead of
+  // a raw stack trace.
+  let m: Measurement;
+  try {
+    m = measure(raster);
+  } catch (err) {
+    checks.push({
+      name: "measure",
+      pass: false,
+      measured: null,
+      detail: err instanceof Error ? err.message : String(err),
+    });
+    return { pass: false, crosshairResidualPx: NaN, checks };
+  }
 
   checks.push({
     name: "geometry:crosshair-residual",

--- a/src/test-oracle/oracle.ts
+++ b/src/test-oracle/oracle.ts
@@ -1,0 +1,131 @@
+import type { CheckResult, OracleReport, Raster, Rgb } from "./types.js";
+import type { Baseline } from "./baseline.js";
+import { detectCrosshairs } from "./crosshairs.js";
+import { fitTransform, mapRect, residualPx } from "./transform.js";
+import { meanRgb, perRowVariance } from "./metrics.js";
+import { deltaE, channelSpread } from "./color.js";
+import {
+  crosshairPoints,
+  swatchRect,
+  greySwatchIndices,
+  ruleLineBand,
+  SWATCHES,
+} from "../../tools/test-page/layout.js";
+
+/** Shrink a rect inward by `inset` px on every side to avoid edge bleed. */
+function inset(rect: { x: number; y: number; w: number; h: number }, by: number) {
+  return { x: rect.x + by, y: rect.y + by, w: rect.w - 2 * by, h: rect.h - 2 * by };
+}
+
+export interface Measurement {
+  crosshairResidualPx: number;
+  swatches: { label: string; rgb: [number, number, number] }[];
+  greySpreads: { label: string; spread: number }[];
+  stripeVarianceMax: number;
+}
+
+/** Sample all metrics from a raster (no baseline) — used to bake baselines. */
+export function measure(raster: Raster): Measurement {
+  const pxCrosshairs = detectCrosshairs(raster);
+  const t = fitTransform(crosshairPoints, pxCrosshairs);
+  const crosshairResidualPx = residualPx(crosshairPoints, pxCrosshairs, t);
+
+  const swatches = SWATCHES.map((s, i) => {
+    const m = meanRgb(raster, inset(mapRect(t, swatchRect(i)), 6));
+    return {
+      label: s.label,
+      rgb: [round(m.r), round(m.g), round(m.b)] as [number, number, number],
+    };
+  });
+
+  const greySpreads = greySwatchIndices.map((i) => {
+    const m = meanRgb(raster, inset(mapRect(t, swatchRect(i)), 6));
+    return { label: SWATCHES[i].label, spread: round(channelSpread(m)) };
+  });
+
+  const stripeVarianceMax = Math.max(
+    ...greySwatchIndices.map((i) => perRowVariance(raster, inset(mapRect(t, swatchRect(i)), 6))),
+    perRowVariance(raster, inset(mapRect(t, ruleLineBand), 2)),
+  );
+
+  return {
+    crosshairResidualPx: round2(crosshairResidualPx),
+    swatches,
+    greySpreads,
+    stripeVarianceMax: round2(stripeVarianceMax),
+  };
+}
+
+/** Run all checks against a committed baseline. */
+export function assertAgainst(raster: Raster, baseline: Baseline): OracleReport {
+  const m = measure(raster);
+  const checks: CheckResult[] = [];
+
+  checks.push({
+    name: "geometry:page-size",
+    pass: raster.width === baseline.page.width && raster.height === baseline.page.height,
+    measured: raster.width,
+    baseline: baseline.page.width,
+    detail: `${raster.width}x${raster.height} vs baseline ${baseline.page.width}x${baseline.page.height}`,
+  });
+
+  checks.push({
+    name: "geometry:crosshair-residual",
+    pass: m.crosshairResidualPx <= baseline.tolerances.crosshairPx,
+    measured: m.crosshairResidualPx,
+    tolerance: baseline.tolerances.crosshairPx,
+  });
+
+  for (const bs of baseline.swatches) {
+    const got = m.swatches.find((s) => s.label === bs.label);
+    if (!got) {
+      checks.push({
+        name: `swatch:${bs.label}`,
+        pass: false,
+        measured: NaN,
+        detail: "missing in measurement",
+      });
+      continue;
+    }
+    const d = deltaE(rgb(got.rgb), rgb(bs.rgb));
+    checks.push({
+      name: `swatch:${bs.label}`,
+      pass: d <= baseline.tolerances.swatchDeltaE,
+      measured: round2(d),
+      tolerance: baseline.tolerances.swatchDeltaE,
+    });
+  }
+
+  for (const bg of baseline.greySpreads) {
+    const got = m.greySpreads.find((g) => g.label === bg.label);
+    checks.push({
+      name: `grey:${bg.label}`,
+      pass: !!got && got.spread <= baseline.tolerances.greySpread,
+      measured: got?.spread ?? NaN,
+      tolerance: baseline.tolerances.greySpread,
+    });
+  }
+
+  checks.push({
+    name: "stripe:max-row-variance",
+    pass: m.stripeVarianceMax <= baseline.tolerances.stripeVariance,
+    measured: m.stripeVarianceMax,
+    tolerance: baseline.tolerances.stripeVariance,
+  });
+
+  return {
+    pass: checks.every((c) => c.pass),
+    crosshairResidualPx: m.crosshairResidualPx,
+    checks,
+  };
+}
+
+function rgb(t: [number, number, number]): Rgb {
+  return { r: t[0], g: t[1], b: t[2] };
+}
+function round(n: number): number {
+  return Math.round(n);
+}
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/src/test-oracle/oracle.ts
+++ b/src/test-oracle/oracle.ts
@@ -26,7 +26,17 @@ export interface Geometry {
   crosshairResidualPx: number;
 }
 
-/** Detect the crosshairs and fit the point→pixel transform for a raster. */
+/**
+ * Detect the crosshairs and fit the point→pixel transform for a raster.
+ *
+ * The fit makes all downstream sampling translation- and scale-invariant by
+ * design: a page that lands shifted or scaled on the bed/ADF is followed via
+ * its registration marks, so a *uniform* placement shift intentionally passes
+ * every check (it is benign scan positioning, not a regression — see the
+ * "accepts a uniformly shifted page" test). What the geometry checks catch is
+ * *non-affine* distortion: skew and stride drift raise the crosshair residual
+ * (the fit cannot absorb them), and a wrong output size fails geometry:page-size.
+ */
 function fitRaster(raster: Raster): Geometry {
   const pxCrosshairs = detectCrosshairs(raster);
   const transform = fitTransform(crosshairPoints, pxCrosshairs);

--- a/src/test-oracle/oracle.ts
+++ b/src/test-oracle/oracle.ts
@@ -1,4 +1,4 @@
-import type { CheckResult, OracleReport, Raster, Rgb } from "./types.js";
+import type { CheckResult, OracleReport, Point, Raster, Rect, Rgb, Transform } from "./types.js";
 import type { Baseline } from "./baseline.js";
 import { detectCrosshairs } from "./crosshairs.js";
 import { fitTransform, mapRect, residualPx } from "./transform.js";
@@ -12,9 +12,35 @@ import {
   SWATCHES,
 } from "../../tools/test-page/layout.js";
 
-/** Shrink a rect inward by `inset` px on every side to avoid edge bleed. */
-function inset(rect: { x: number; y: number; w: number; h: number }, by: number) {
+/** Inset applied to each swatch's mapped rect before sampling, to avoid edge bleed. */
+const SWATCH_INSET_PX = 6;
+
+/** Shrink a rect inward by `by` px on every side. */
+function inset(rect: Rect, by: number): Rect {
   return { x: rect.x + by, y: rect.y + by, w: rect.w - 2 * by, h: rect.h - 2 * by };
+}
+
+export interface Geometry {
+  transform: Transform;
+  pxCrosshairs: Point[];
+  crosshairResidualPx: number;
+}
+
+/** Detect the crosshairs and fit the point→pixel transform for a raster. */
+function fitRaster(raster: Raster): Geometry {
+  const pxCrosshairs = detectCrosshairs(raster);
+  const transform = fitTransform(crosshairPoints, pxCrosshairs);
+  return {
+    transform,
+    pxCrosshairs,
+    crosshairResidualPx: round2(residualPx(crosshairPoints, pxCrosshairs, transform)),
+  };
+}
+
+/** The inset pixel sample box for each of the 12 swatches under a transform.
+ *  Exported so the baseline CLI's overlay draws the exact regions sampled. */
+export function swatchSampleBoxes(t: Transform): Rect[] {
+  return SWATCHES.map((_, i) => inset(mapRect(t, swatchRect(i)), SWATCH_INSET_PX));
 }
 
 export interface Measurement {
@@ -24,38 +50,47 @@ export interface Measurement {
   stripeVarianceMax: number;
 }
 
-/** Sample all metrics from a raster (no baseline) — used to bake baselines. */
-export function measure(raster: Raster): Measurement {
-  const pxCrosshairs = detectCrosshairs(raster);
-  const t = fitTransform(crosshairPoints, pxCrosshairs);
-  const crosshairResidualPx = residualPx(crosshairPoints, pxCrosshairs, t);
+/** Sample all metrics from a raster AND return the fitted geometry, so callers
+ *  (e.g. the baseline CLI) can draw an overlay of the exact sampled regions
+ *  without re-detecting the crosshairs. */
+export function measureWithGeometry(raster: Raster): {
+  measurement: Measurement;
+  geometry: Geometry;
+} {
+  const geometry = fitRaster(raster);
+  const boxes = swatchSampleBoxes(geometry.transform);
+  // One mean per swatch; grey spreads reuse those means rather than re-scanning.
+  const means = boxes.map((b) => meanRgb(raster, b));
 
-  const swatchSample = (i: number) => inset(mapRect(t, swatchRect(i)), 6);
+  const swatches = SWATCHES.map((s, i) => ({
+    label: s.label,
+    rgb: [round(means[i].r), round(means[i].g), round(means[i].b)] as [number, number, number],
+  }));
 
-  const swatches = SWATCHES.map((s, i) => {
-    const m = meanRgb(raster, swatchSample(i));
-    return {
-      label: s.label,
-      rgb: [round(m.r), round(m.g), round(m.b)] as [number, number, number],
-    };
-  });
-
-  const greySpreads = greySwatchIndices.map((i) => {
-    const m = meanRgb(raster, swatchSample(i));
-    return { label: SWATCHES[i].label, spread: round(channelSpread(m)) };
-  });
+  const greySpreads = greySwatchIndices.map((i) => ({
+    label: SWATCHES[i].label,
+    spread: round(channelSpread(means[i])),
+  }));
 
   const stripeVarianceMax = Math.max(
-    ...greySwatchIndices.map((i) => perRowVariance(raster, swatchSample(i))),
-    perRowVariance(raster, inset(mapRect(t, ruleLineBand), 2)),
+    ...greySwatchIndices.map((i) => perRowVariance(raster, boxes[i])),
+    perRowVariance(raster, inset(mapRect(geometry.transform, ruleLineBand), 2)),
   );
 
   return {
-    crosshairResidualPx: round2(crosshairResidualPx),
-    swatches,
-    greySpreads,
-    stripeVarianceMax: round2(stripeVarianceMax),
+    measurement: {
+      crosshairResidualPx: geometry.crosshairResidualPx,
+      swatches,
+      greySpreads,
+      stripeVarianceMax: round2(stripeVarianceMax),
+    },
+    geometry,
   };
+}
+
+/** Sample all metrics from a raster (no baseline) — used to bake baselines. */
+export function measure(raster: Raster): Measurement {
+  return measureWithGeometry(raster).measurement;
 }
 
 /** Run all checks against a committed baseline. */

--- a/src/test-oracle/oracle.ts
+++ b/src/test-oracle/oracle.ts
@@ -30,8 +30,10 @@ export function measure(raster: Raster): Measurement {
   const t = fitTransform(crosshairPoints, pxCrosshairs);
   const crosshairResidualPx = residualPx(crosshairPoints, pxCrosshairs, t);
 
+  const swatchSample = (i: number) => inset(mapRect(t, swatchRect(i)), 6);
+
   const swatches = SWATCHES.map((s, i) => {
-    const m = meanRgb(raster, inset(mapRect(t, swatchRect(i)), 6));
+    const m = meanRgb(raster, swatchSample(i));
     return {
       label: s.label,
       rgb: [round(m.r), round(m.g), round(m.b)] as [number, number, number],
@@ -39,12 +41,12 @@ export function measure(raster: Raster): Measurement {
   });
 
   const greySpreads = greySwatchIndices.map((i) => {
-    const m = meanRgb(raster, inset(mapRect(t, swatchRect(i)), 6));
+    const m = meanRgb(raster, swatchSample(i));
     return { label: SWATCHES[i].label, spread: round(channelSpread(m)) };
   });
 
   const stripeVarianceMax = Math.max(
-    ...greySwatchIndices.map((i) => perRowVariance(raster, inset(mapRect(t, swatchRect(i)), 6))),
+    ...greySwatchIndices.map((i) => perRowVariance(raster, swatchSample(i))),
     perRowVariance(raster, inset(mapRect(t, ruleLineBand), 2)),
   );
 
@@ -64,8 +66,7 @@ export function assertAgainst(raster: Raster, baseline: Baseline): OracleReport 
   checks.push({
     name: "geometry:page-size",
     pass: raster.width === baseline.page.width && raster.height === baseline.page.height,
-    measured: raster.width,
-    baseline: baseline.page.width,
+    measured: null,
     detail: `${raster.width}x${raster.height} vs baseline ${baseline.page.width}x${baseline.page.height}`,
   });
 
@@ -82,7 +83,7 @@ export function assertAgainst(raster: Raster, baseline: Baseline): OracleReport 
       checks.push({
         name: `swatch:${bs.label}`,
         pass: false,
-        measured: NaN,
+        measured: null,
         detail: "missing in measurement",
       });
       continue;
@@ -101,7 +102,7 @@ export function assertAgainst(raster: Raster, baseline: Baseline): OracleReport 
     checks.push({
       name: `grey:${bg.label}`,
       pass: !!got && got.spread <= baseline.tolerances.greySpread,
-      measured: got?.spread ?? NaN,
+      measured: got?.spread ?? null,
       tolerance: baseline.tolerances.greySpread,
     });
   }

--- a/src/test-oracle/oracle.ts
+++ b/src/test-oracle/oracle.ts
@@ -8,7 +8,6 @@ import {
   crosshairPoints,
   swatchRect,
   greySwatchIndices,
-  ruleLineBand,
   SWATCHES,
 } from "../../tools/test-page/layout.js";
 
@@ -82,9 +81,13 @@ export function measureWithGeometry(raster: Raster): {
     spread: round(channelSpread(means[i])),
   }));
 
+  // Stripe/smear: per-row variance inside the flat grey swatches only (banding
+  // and planar-vs-interleaved layout bugs raise it). The intentionally
+  // high-variance rule-line band is deliberately NOT folded in — doing so let it
+  // set a loose ceiling that masked swatch banding; page skew is already covered
+  // by the crosshair-fit residual.
   const stripeVarianceMax = Math.max(
     ...greySwatchIndices.map((i) => perRowVariance(raster, boxes[i])),
-    perRowVariance(raster, inset(mapRect(geometry.transform, ruleLineBand), 2)),
   );
 
   return {

--- a/src/test-oracle/regression.test.ts
+++ b/src/test-oracle/regression.test.ts
@@ -63,13 +63,20 @@ describe("scan-output oracle regression", () => {
       const report = assertAgainst(raster, baseline);
       expect(report.pass, JSON.stringify(report.checks, null, 2)).toBe(true);
 
-      // Per-page EXIF orientation: back pages carry Orientation=3, front pages
-      // carry NO tag. Asserting the complement catches an over-tagging regression
-      // (every page stamped) that the pixel checks can't see.
+      // Per-page EXIF orientation: a page is a back page iff its orientation is 3
+      // (the ADF U-turn flip). Back pages MUST read 3; front pages MUST NOT be 3.
+      // We assert front pages `!== 3` rather than `=== undefined` to stay symmetric
+      // with the bake's back-page rule (readJpegOrientation === 3): a printer that
+      // stamps a benign front-page tag (e.g. Orientation=1) should not false-fail
+      // a correct capture, while an over-tagging regression (front stamped 3) and
+      // an under-tagging one (back missing 3) are both still caught.
       for (let p = 1; p <= files.length; p++) {
         const orient = readJpegOrientation(readFileSync(path.join(outputDir, files[p - 1])));
-        const expectedOrient = baseline.expectedBackPages.includes(p) ? 3 : undefined;
-        expect(orient, `JPG page ${p} EXIF orientation`).toBe(expectedOrient);
+        if (baseline.expectedBackPages.includes(p)) {
+          expect(orient, `JPG back page ${p} EXIF orientation`).toBe(3);
+        } else {
+          expect(orient, `JPG front page ${p} EXIF orientation`).not.toBe(3);
+        }
       }
 
       // PDF replay for EVERY baseline (not just duplex): page count + per-page

--- a/src/test-oracle/regression.test.ts
+++ b/src/test-oracle/regression.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, mkdtempSync, rmSync, existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PDFDocument } from "pdf-lib";
+import { loadBaseline } from "./baseline.js";
+import { decodeToRaster } from "./decode.js";
+import { assertAgainst } from "./oracle.js";
+import { readJsonl, trimStatCycles, replayCapture } from "../esci2/test-support/frida-replay.js";
+import { readJpegOrientation } from "../exif.js";
+
+// Discover committed baselines under the Frida capture dir.
+function findBaselines(): string[] {
+  const root = "tools/frida-capture/captures";
+  if (!existsSync(root)) return [];
+  return readdirSync(root)
+    .filter((f) => f.endsWith(".baseline.json"))
+    .map((f) => path.join(root, f));
+}
+
+const baselines = findBaselines();
+
+describe("scan-output oracle regression", () => {
+  if (baselines.length === 0) {
+    it.skip("no committed baselines yet — capture an ET-4956 compatibility scan (Phase 0/3)", () => {});
+    return;
+  }
+
+  it.each(baselines)("matches baseline %s", async (baselinePath) => {
+    const baseline = loadBaseline(baselinePath);
+    const outputDir = mkdtempSync(path.join(os.tmpdir(), "oracle-reg-"));
+    try {
+      const records = trimStatCycles(readJsonl(baseline.replay.fixturePath), baseline.replay.trimStatCycles);
+
+      // JPG sampling replay.
+      const jpg = await replayCapture(records, outputDir, baseline.replay.duplex, "jpg");
+      await jpg.sessionPromise;
+      const files = readdirSync(outputDir).filter((f) => f.endsWith(".jpg")).sort();
+      const raster = await decodeToRaster(readFileSync(path.join(outputDir, files[0])));
+      const report = assertAgainst(raster, baseline);
+      expect(report.pass, JSON.stringify(report.checks, null, 2)).toBe(true);
+
+      // Duplex: back pages carry EXIF Orientation=3 (JPG) and /Rotate=180 (PDF);
+      // front pages carry neither. Driven by baseline.expectedBackPages.
+      if (baseline.replay.duplex) {
+        for (const p of baseline.expectedBackPages) {
+          const orient = readJpegOrientation(readFileSync(path.join(outputDir, files[p - 1])));
+          expect(orient, `JPG back page ${p}`).toBe(3);
+        }
+
+        const pdfDir = mkdtempSync(path.join(os.tmpdir(), "oracle-reg-pdf-"));
+        try {
+          const pdf = await replayCapture(records, pdfDir, true, "pdf");
+          await pdf.sessionPromise;
+          const pdfFile = readdirSync(pdfDir).find((f) => f.endsWith(".pdf"))!;
+          const doc = await PDFDocument.load(readFileSync(path.join(pdfDir, pdfFile)));
+          expect(doc.getPageCount(), "PDF page count").toBe(files.length);
+          for (let i = 0; i < doc.getPageCount(); i++) {
+            const expected = baseline.expectedBackPages.includes(i + 1) ? 180 : 0;
+            expect(doc.getPage(i).getRotation().angle, `PDF page ${i + 1}`).toBe(expected);
+          }
+        } finally {
+          rmSync(pdfDir, { recursive: true, force: true });
+        }
+      }
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/test-oracle/regression.test.ts
+++ b/src/test-oracle/regression.test.ts
@@ -41,6 +41,11 @@ describe("scan-output oracle regression", () => {
       const files = readdirSync(outputDir)
         .filter((f) => f.endsWith(".jpg"))
         .sort();
+      // Guard before indexing so a dropped-page regression fails with a clear
+      // message rather than an opaque path.join(dir, undefined) TypeError.
+      expect(files.length, `expected at least one JPG page, got ${files.length}`).toBeGreaterThan(
+        0,
+      );
       const raster = await decodeToRaster(readFileSync(path.join(outputDir, files[0])));
       const report = assertAgainst(raster, baseline);
       expect(report.pass, JSON.stringify(report.checks, null, 2)).toBe(true);
@@ -49,6 +54,10 @@ describe("scan-output oracle regression", () => {
       // front pages carry neither. Driven by baseline.expectedBackPages.
       if (baseline.replay.duplex) {
         for (const p of baseline.expectedBackPages) {
+          expect(
+            files.length,
+            `baseline expects back page ${p} but only ${files.length} page(s) were produced`,
+          ).toBeGreaterThanOrEqual(p);
           const orient = readJpegOrientation(readFileSync(path.join(outputDir, files[p - 1])));
           expect(orient, `JPG back page ${p}`).toBe(3);
         }
@@ -57,8 +66,9 @@ describe("scan-output oracle regression", () => {
         try {
           const pdf = await replayCapture(records, pdfDir, true, "pdf");
           await pdf.sessionPromise;
-          const pdfFile = readdirSync(pdfDir).find((f) => f.endsWith(".pdf"))!;
-          const doc = await PDFDocument.load(readFileSync(path.join(pdfDir, pdfFile)));
+          const pdfFile = readdirSync(pdfDir).find((f) => f.endsWith(".pdf"));
+          expect(pdfFile, "expected a composed PDF in the PDF replay output").toBeDefined();
+          const doc = await PDFDocument.load(readFileSync(path.join(pdfDir, pdfFile!)));
           expect(doc.getPageCount(), "PDF page count").toBe(files.length);
           for (let i = 0; i < doc.getPageCount(); i++) {
             const expected = baseline.expectedBackPages.includes(i + 1) ? 180 : 0;

--- a/src/test-oracle/regression.test.ts
+++ b/src/test-oracle/regression.test.ts
@@ -41,10 +41,11 @@ describe("scan-output oracle regression", () => {
       const files = readdirSync(outputDir)
         .filter((f) => f.endsWith(".jpg"))
         .sort();
-      // Guard before indexing so a dropped-page regression fails with a clear
-      // message rather than an opaque path.join(dir, undefined) TypeError.
-      expect(files.length, `expected at least one JPG page, got ${files.length}`).toBeGreaterThan(
-        0,
+      // Pin the absolute page count so a dropped/extra-page regression (the
+      // PR #79 class) fails here rather than slipping through the page-0-only
+      // pixel sampling below.
+      expect(files.length, `expected ${baseline.expectedPageCount} JPG page(s)`).toBe(
+        baseline.expectedPageCount,
       );
       const raster = await decodeToRaster(readFileSync(path.join(outputDir, files[0])));
       const report = assertAgainst(raster, baseline);
@@ -69,7 +70,7 @@ describe("scan-output oracle regression", () => {
           const pdfFile = readdirSync(pdfDir).find((f) => f.endsWith(".pdf"));
           expect(pdfFile, "expected a composed PDF in the PDF replay output").toBeDefined();
           const doc = await PDFDocument.load(readFileSync(path.join(pdfDir, pdfFile!)));
-          expect(doc.getPageCount(), "PDF page count").toBe(files.length);
+          expect(doc.getPageCount(), "PDF page count").toBe(baseline.expectedPageCount);
           for (let i = 0; i < doc.getPageCount(); i++) {
             const expected = baseline.expectedBackPages.includes(i + 1) ? 180 : 0;
             expect(doc.getPage(i).getRotation().angle, `PDF page ${i + 1}`).toBe(expected);

--- a/src/test-oracle/regression.test.ts
+++ b/src/test-oracle/regression.test.ts
@@ -9,11 +9,13 @@ import { assertAgainst } from "./oracle.js";
 import { readJsonl, trimStatCycles, replayCapture } from "../esci2/test-support/frida-replay.js";
 import { readJpegOrientation } from "../exif.js";
 
-// Discover committed baselines under the Frida capture dir.
+// Discover committed baselines anywhere under the Frida capture dir (recursive,
+// so a baseline committed in a per-model subfolder is still picked up).
 function findBaselines(): string[] {
   const root = "tools/frida-capture/captures";
   if (!existsSync(root)) return [];
-  return readdirSync(root)
+  return readdirSync(root, { recursive: true })
+    .map((f) => f.toString())
     .filter((f) => f.endsWith(".baseline.json"))
     .map((f) => path.join(root, f));
 }
@@ -28,6 +30,10 @@ describe("scan-output oracle regression", () => {
 
   it.each(baselines)("matches baseline %s", async (baselinePath) => {
     const baseline = loadBaseline(baselinePath);
+    const replayOpts = {
+      printerIp: baseline.replay.printerIp,
+      destId: baseline.replay.destId,
+    };
     const outputDir = mkdtempSync(path.join(os.tmpdir(), "oracle-reg-"));
     try {
       const records = trimStatCycles(
@@ -36,7 +42,13 @@ describe("scan-output oracle regression", () => {
       );
 
       // JPG sampling replay.
-      const jpg = await replayCapture(records, outputDir, baseline.replay.duplex, "jpg");
+      const jpg = await replayCapture(
+        records,
+        outputDir,
+        baseline.replay.duplex,
+        "jpg",
+        replayOpts,
+      );
       await jpg.sessionPromise;
       const files = readdirSync(outputDir)
         .filter((f) => f.endsWith(".jpg"))
@@ -51,33 +63,33 @@ describe("scan-output oracle regression", () => {
       const report = assertAgainst(raster, baseline);
       expect(report.pass, JSON.stringify(report.checks, null, 2)).toBe(true);
 
-      // Duplex: back pages carry EXIF Orientation=3 (JPG) and /Rotate=180 (PDF);
-      // front pages carry neither. Driven by baseline.expectedBackPages.
-      if (baseline.replay.duplex) {
-        for (const p of baseline.expectedBackPages) {
-          expect(
-            files.length,
-            `baseline expects back page ${p} but only ${files.length} page(s) were produced`,
-          ).toBeGreaterThanOrEqual(p);
-          const orient = readJpegOrientation(readFileSync(path.join(outputDir, files[p - 1])));
-          expect(orient, `JPG back page ${p}`).toBe(3);
-        }
+      // Per-page EXIF orientation: back pages carry Orientation=3, front pages
+      // carry NO tag. Asserting the complement catches an over-tagging regression
+      // (every page stamped) that the pixel checks can't see.
+      for (let p = 1; p <= files.length; p++) {
+        const orient = readJpegOrientation(readFileSync(path.join(outputDir, files[p - 1])));
+        const expectedOrient = baseline.expectedBackPages.includes(p) ? 3 : undefined;
+        expect(orient, `JPG page ${p} EXIF orientation`).toBe(expectedOrient);
+      }
 
-        const pdfDir = mkdtempSync(path.join(os.tmpdir(), "oracle-reg-pdf-"));
-        try {
-          const pdf = await replayCapture(records, pdfDir, true, "pdf");
-          await pdf.sessionPromise;
-          const pdfFile = readdirSync(pdfDir).find((f) => f.endsWith(".pdf"));
-          expect(pdfFile, "expected a composed PDF in the PDF replay output").toBeDefined();
-          const doc = await PDFDocument.load(readFileSync(path.join(pdfDir, pdfFile!)));
-          expect(doc.getPageCount(), "PDF page count").toBe(baseline.expectedPageCount);
-          for (let i = 0; i < doc.getPageCount(); i++) {
-            const expected = baseline.expectedBackPages.includes(i + 1) ? 180 : 0;
-            expect(doc.getPage(i).getRotation().angle, `PDF page ${i + 1}`).toBe(expected);
-          }
-        } finally {
-          rmSync(pdfDir, { recursive: true, force: true });
+      // PDF replay for EVERY baseline (not just duplex): page count + per-page
+      // /Rotate (back pages 180, front pages 0). This exercises the PDF compose
+      // path for flatbed/simplex baselines too, where a dropped page or a
+      // compose fallback would otherwise go unchecked.
+      const pdfDir = mkdtempSync(path.join(os.tmpdir(), "oracle-reg-pdf-"));
+      try {
+        const pdf = await replayCapture(records, pdfDir, baseline.replay.duplex, "pdf", replayOpts);
+        await pdf.sessionPromise;
+        const pdfFile = readdirSync(pdfDir).find((f) => f.endsWith(".pdf"));
+        expect(pdfFile, "expected a composed PDF in the PDF replay output").toBeDefined();
+        const doc = await PDFDocument.load(readFileSync(path.join(pdfDir, pdfFile!)));
+        expect(doc.getPageCount(), "PDF page count").toBe(baseline.expectedPageCount);
+        for (let i = 0; i < doc.getPageCount(); i++) {
+          const expectedRotation = baseline.expectedBackPages.includes(i + 1) ? 180 : 0;
+          expect(doc.getPage(i).getRotation().angle, `PDF page ${i + 1}`).toBe(expectedRotation);
         }
+      } finally {
+        rmSync(pdfDir, { recursive: true, force: true });
       }
     } finally {
       rmSync(outputDir, { recursive: true, force: true });

--- a/src/test-oracle/regression.test.ts
+++ b/src/test-oracle/regression.test.ts
@@ -30,12 +30,17 @@ describe("scan-output oracle regression", () => {
     const baseline = loadBaseline(baselinePath);
     const outputDir = mkdtempSync(path.join(os.tmpdir(), "oracle-reg-"));
     try {
-      const records = trimStatCycles(readJsonl(baseline.replay.fixturePath), baseline.replay.trimStatCycles);
+      const records = trimStatCycles(
+        readJsonl(baseline.replay.fixturePath),
+        baseline.replay.trimStatCycles,
+      );
 
       // JPG sampling replay.
       const jpg = await replayCapture(records, outputDir, baseline.replay.duplex, "jpg");
       await jpg.sessionPromise;
-      const files = readdirSync(outputDir).filter((f) => f.endsWith(".jpg")).sort();
+      const files = readdirSync(outputDir)
+        .filter((f) => f.endsWith(".jpg"))
+        .sort();
       const raster = await decodeToRaster(readFileSync(path.join(outputDir, files[0])));
       const report = assertAgainst(raster, baseline);
       expect(report.pass, JSON.stringify(report.checks, null, 2)).toBe(true);

--- a/src/test-oracle/regression.test.ts
+++ b/src/test-oracle/regression.test.ts
@@ -59,6 +59,11 @@ describe("scan-output oracle regression", () => {
       expect(files.length, `expected ${baseline.expectedPageCount} JPG page(s)`).toBe(
         baseline.expectedPageCount,
       );
+      // Pixel metrics are asserted on the FRONT page only (files[0]) — that's
+      // where the swatch grid lives. Later pages are covered by the page-count
+      // pin above, the per-page EXIF orientation loop below, and the PDF /Rotate
+      // checks; per-page colour is a documented follow-up (multi-front-sheet /
+      // WF-3620 path).
       const raster = await decodeToRaster(readFileSync(path.join(outputDir, files[0])));
       const report = assertAgainst(raster, baseline);
       expect(report.pass, JSON.stringify(report.checks, null, 2)).toBe(true);

--- a/src/test-oracle/test-support/raster-draw.test.ts
+++ b/src/test-oracle/test-support/raster-draw.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { blankRaster, fillRect, getPixel, buildTestPageRaster } from "./raster-draw.js";
+
+describe("raster-draw", () => {
+  it("creates a white raster of the requested size", () => {
+    const r = blankRaster(4, 3);
+    expect(r.width).toBe(4);
+    expect(r.height).toBe(3);
+    expect(r.channels).toBe(3);
+    expect(getPixel(r, 0, 0)).toEqual({ r: 255, g: 255, b: 255 });
+  });
+
+  it("fills a rectangle with a colour", () => {
+    const r = blankRaster(10, 10);
+    fillRect(r, { x: 2, y: 2, w: 3, h: 3 }, { r: 10, g: 20, b: 30 });
+    expect(getPixel(r, 3, 3)).toEqual({ r: 10, g: 20, b: 30 });
+    expect(getPixel(r, 0, 0)).toEqual({ r: 255, g: 255, b: 255 });
+  });
+
+  it("builds a synthetic test page with black corner crosshairs", () => {
+    const { raster } = buildTestPageRaster({ scale: 2 });
+    let foundBlack = false;
+    for (let y = 0; y < 120 && !foundBlack; y++) {
+      for (let x = 0; x < 120 && !foundBlack; x++) {
+        const p = getPixel(raster, x, y);
+        if (p.r < 40 && p.g < 40 && p.b < 40) foundBlack = true;
+      }
+    }
+    expect(foundBlack).toBe(true);
+  });
+});

--- a/src/test-oracle/test-support/raster-draw.ts
+++ b/src/test-oracle/test-support/raster-draw.ts
@@ -1,0 +1,95 @@
+import type { Raster, Rect, Rgb } from "../types.js";
+import {
+  LAYOUT,
+  SWATCHES,
+  swatchRect,
+  crosshairPoints,
+  markerRegion,
+} from "../../../tools/test-page/layout.js";
+
+export function blankRaster(width: number, height: number): Raster {
+  const data = Buffer.alloc(width * height * 3, 255); // white
+  return { data, width, height, channels: 3 };
+}
+
+export function getPixel(r: Raster, x: number, y: number): Rgb {
+  const i = (y * r.width + x) * r.channels;
+  return { r: r.data[i], g: r.data[i + 1], b: r.data[i + 2] };
+}
+
+export function fillRect(r: Raster, rect: Rect, c: Rgb): void {
+  const x0 = Math.max(0, Math.round(rect.x));
+  const y0 = Math.max(0, Math.round(rect.y));
+  const x1 = Math.min(r.width, Math.round(rect.x + rect.w));
+  const y1 = Math.min(r.height, Math.round(rect.y + rect.h));
+  for (let y = y0; y < y1; y++) {
+    for (let x = x0; x < x1; x++) {
+      const i = (y * r.width + x) * r.channels;
+      r.data[i] = c.r;
+      r.data[i + 1] = c.g;
+      r.data[i + 2] = c.b;
+    }
+  }
+}
+
+export interface BuildPageOpts {
+  scale?: number; // pixels per PDF point
+  swatchColors?: Rgb[]; // override the 12 swatch fills (defaults to declared hex)
+  marker?: Rgb; // colour of the asymmetric corner marker (default red "F")
+}
+
+/**
+ * Render the layout into a raster (top-left origin), converting PDF point
+ * space (bottom-left) via px = pt*scale for x and (pageHeight - pt)*scale for y.
+ * Returns the raster plus the expected pixel-space crosshair centres so tests
+ * can assert detection without re-deriving the conversion.
+ */
+export function buildTestPageRaster(opts: BuildPageOpts = {}): {
+  raster: Raster;
+  expectedCrosshairsPx: { x: number; y: number }[];
+} {
+  const scale = opts.scale ?? 2;
+  const width = Math.round(LAYOUT.pageWidth * scale);
+  const height = Math.round(LAYOUT.pageHeight * scale);
+  const raster = blankRaster(width, height);
+
+  const toPx = (x: number) => x * scale;
+  const toPy = (y: number) => (LAYOUT.pageHeight - y) * scale;
+  const ptRectToPx = (pr: { x: number; y: number; w: number; h: number }): Rect => {
+    const top = toPy(pr.y + pr.h);
+    const left = toPx(pr.x);
+    return { x: left, y: top, w: pr.w * scale, h: pr.h * scale };
+  };
+
+  // Swatches.
+  for (let i = 0; i < SWATCHES.length; i++) {
+    const c = opts.swatchColors?.[i] ?? {
+      r: SWATCHES[i].r,
+      g: SWATCHES[i].g,
+      b: SWATCHES[i].b,
+    };
+    fillRect(raster, ptRectToPx(swatchRect(i)), c);
+  }
+
+  // Crosshairs: a small black plus at each corner.
+  const arm = Math.round(12 * scale);
+  const thick = Math.max(1, Math.round(1 * scale));
+  const expectedCrosshairsPx = crosshairPoints.map((p) => ({ x: toPx(p.x), y: toPy(p.y) }));
+  for (const cp of expectedCrosshairsPx) {
+    fillRect(
+      raster,
+      { x: cp.x - arm, y: cp.y - thick, w: 2 * arm, h: 2 * thick },
+      { r: 0, g: 0, b: 0 },
+    );
+    fillRect(
+      raster,
+      { x: cp.x - thick, y: cp.y - arm, w: 2 * thick, h: 2 * arm },
+      { r: 0, g: 0, b: 0 },
+    );
+  }
+
+  // Asymmetric marker near the TL crosshair (default saturated red, like "F").
+  fillRect(raster, ptRectToPx(markerRegion), opts.marker ?? { r: 255, g: 0, b: 0 });
+
+  return { raster, expectedCrosshairsPx };
+}

--- a/src/test-oracle/test-support/raster-draw.ts
+++ b/src/test-oracle/test-support/raster-draw.ts
@@ -36,6 +36,7 @@ export interface BuildPageOpts {
   scale?: number; // pixels per PDF point
   swatchColors?: Rgb[]; // override the 12 swatch fills (defaults to declared hex)
   marker?: Rgb; // colour of the asymmetric corner marker (default red "F")
+  shiftPx?: { dx: number; dy: number }; // uniformly translate all drawn content (exercises translation invariance)
 }
 
 /**
@@ -49,12 +50,17 @@ export function buildTestPageRaster(opts: BuildPageOpts = {}): {
   expectedCrosshairsPx: { x: number; y: number }[];
 } {
   const scale = opts.scale ?? 2;
+  const dx = opts.shiftPx?.dx ?? 0;
+  const dy = opts.shiftPx?.dy ?? 0;
   const width = Math.round(LAYOUT.pageWidth * scale);
   const height = Math.round(LAYOUT.pageHeight * scale);
   const raster = blankRaster(width, height);
 
-  const toPx = (x: number) => x * scale;
-  const toPy = (y: number) => (LAYOUT.pageHeight - y) * scale;
+  // The page size is unchanged; shiftPx translates all content (swatches,
+  // crosshairs, marker) together within the same raster, so detection still
+  // finds the marks at their shifted positions.
+  const toPx = (x: number) => x * scale + dx;
+  const toPy = (y: number) => (LAYOUT.pageHeight - y) * scale + dy;
   const ptRectToPx = (pr: { x: number; y: number; w: number; h: number }): Rect => {
     const top = toPy(pr.y + pr.h);
     const left = toPx(pr.x);

--- a/src/test-oracle/transform.test.ts
+++ b/src/test-oracle/transform.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { fitTransform, mapRect, residualPx } from "./transform.js";
+import { crosshairPoints, swatchRect } from "../../tools/test-page/layout.js";
+import { buildTestPageRaster } from "./test-support/raster-draw.js";
+
+describe("transform", () => {
+  it("fits a scale+translate with a negative y-scale (PDF up vs raster down)", () => {
+    const { expectedCrosshairsPx } = buildTestPageRaster({ scale: 2 });
+    const t = fitTransform(crosshairPoints, expectedCrosshairsPx);
+    expect(t.sx).toBeCloseTo(2, 1);
+    expect(t.sy).toBeCloseTo(-2, 1);
+    expect(residualPx(crosshairPoints, expectedCrosshairsPx, t)).toBeLessThan(0.5);
+  });
+
+  it("maps a swatch's point-rect into the expected pixel box", () => {
+    const { expectedCrosshairsPx } = buildTestPageRaster({ scale: 2 });
+    const t = fitTransform(crosshairPoints, expectedCrosshairsPx);
+    const px = mapRect(t, swatchRect(0));
+    expect(px.w).toBeCloseTo(120 * 2, 0);
+    expect(px.h).toBeCloseTo(70 * 2, 0);
+    expect(px.x).toBeGreaterThan(0);
+    expect(px.y).toBeGreaterThan(0);
+  });
+
+  it("residualPx is large when one crosshair is displaced (the fit can't absorb it)", () => {
+    const { expectedCrosshairsPx } = buildTestPageRaster({ scale: 2 });
+    const perturbed = expectedCrosshairsPx.map((p, i) =>
+      i === 0 ? { x: p.x + 25, y: p.y - 25 } : p,
+    );
+    const t = fitTransform(crosshairPoints, perturbed);
+    expect(residualPx(crosshairPoints, perturbed, t)).toBeGreaterThan(10);
+  });
+});

--- a/src/test-oracle/transform.ts
+++ b/src/test-oracle/transform.ts
@@ -1,0 +1,45 @@
+import type { Point, Rect, Transform } from "./types.js";
+
+/** 1-D least squares: out ≈ scale*in + offset. */
+function fitAxis(pairs: { in: number; out: number }[]): { scale: number; offset: number } {
+  const n = pairs.length;
+  const sx = pairs.reduce((a, p) => a + p.in, 0);
+  const sy = pairs.reduce((a, p) => a + p.out, 0);
+  const sxx = pairs.reduce((a, p) => a + p.in * p.in, 0);
+  const sxy = pairs.reduce((a, p) => a + p.in * p.out, 0);
+  const denom = n * sxx - sx * sx;
+  const scale = (n * sxy - sx * sy) / denom;
+  const offset = (sy - scale * sx) / n;
+  return { scale, offset };
+}
+
+/** Fit pt→px from corresponding crosshair points (same order in both arrays). */
+export function fitTransform(ptPoints: Point[], pxPoints: Point[]): Transform {
+  const xAxis = fitAxis(ptPoints.map((p, i) => ({ in: p.x, out: pxPoints[i].x })));
+  const yAxis = fitAxis(ptPoints.map((p, i) => ({ in: p.y, out: pxPoints[i].y })));
+  return { sx: xAxis.scale, ox: xAxis.offset, sy: yAxis.scale, oy: yAxis.offset };
+}
+
+function apply(t: Transform, p: Point): Point {
+  return { x: t.sx * p.x + t.ox, y: t.sy * p.y + t.oy };
+}
+
+/** Max per-crosshair Euclidean residual between measured and predicted. */
+export function residualPx(ptPoints: Point[], pxPoints: Point[], t: Transform): number {
+  let max = 0;
+  for (let i = 0; i < ptPoints.length; i++) {
+    const pred = apply(t, ptPoints[i]);
+    const d = Math.hypot(pred.x - pxPoints[i].x, pred.y - pxPoints[i].y);
+    if (d > max) max = d;
+  }
+  return max;
+}
+
+/** Map a PDF-point rect (bottom-left origin) to a pixel rect (top-left). */
+export function mapRect(t: Transform, ptRect: Rect): Rect {
+  const c1 = apply(t, { x: ptRect.x, y: ptRect.y });
+  const c2 = apply(t, { x: ptRect.x + ptRect.w, y: ptRect.y + ptRect.h });
+  const x = Math.min(c1.x, c2.x);
+  const y = Math.min(c1.y, c2.y);
+  return { x, y, w: Math.abs(c2.x - c1.x), h: Math.abs(c2.y - c1.y) };
+}

--- a/src/test-oracle/types.ts
+++ b/src/test-oracle/types.ts
@@ -1,0 +1,50 @@
+/** Decoded image: tightly-packed pixels, row-major, top-left origin. */
+export interface Raster {
+  data: Buffer;
+  width: number;
+  height: number;
+  channels: number; // 3 (RGB) for our JPEG decodes
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/** Axis-aligned rectangle. Units depend on context (points or pixels). */
+export interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/** Independent per-axis scale+offset: px = scale*pt + offset. sy is negative
+ *  (PDF y-up vs raster y-down). */
+export interface Transform {
+  sx: number;
+  ox: number;
+  sy: number;
+  oy: number;
+}
+
+export interface CheckResult {
+  name: string;
+  pass: boolean;
+  measured: number;
+  baseline?: number;
+  tolerance?: number;
+  detail?: string;
+}
+
+export interface OracleReport {
+  pass: boolean;
+  crosshairResidualPx: number;
+  checks: CheckResult[];
+}

--- a/src/test-oracle/types.ts
+++ b/src/test-oracle/types.ts
@@ -37,7 +37,8 @@ export interface Transform {
 export interface CheckResult {
   name: string;
   pass: boolean;
-  measured: number;
+  /** The check's measured value, or null when the check isn't a single numeric comparison (e.g. page-size, or a missing region). */
+  measured: number | null;
   baseline?: number;
   tolerance?: number;
   detail?: string;

--- a/tools/test-oracle/baseline-cli.test.ts
+++ b/tools/test-oracle/baseline-cli.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import sharp from "sharp";
+import { buildBaselineFromOutputDir } from "./baseline-cli.js";
+import { buildTestPageRaster } from "../../src/test-oracle/test-support/raster-draw.js";
+
+describe("buildBaselineFromOutputDir", () => {
+  it("measures the lone JPG in an output dir and produces a baseline + overlay", async () => {
+    const { raster } = buildTestPageRaster({ scale: 2 });
+    const jpeg = await sharp(raster.data, {
+      raw: { width: raster.width, height: raster.height, channels: 3 },
+    })
+      .jpeg({ quality: 100 })
+      .toBuffer();
+    const dir = mkdtempSync(path.join(os.tmpdir(), "oracle-cli-"));
+    try {
+      writeFileSync(path.join(dir, "scan_2026-06-05_000000.jpg"), jpeg);
+      const { baseline, overlayPng } = await buildBaselineFromOutputDir(dir, {
+        fixturePath: "x.jsonl",
+        source: "flatbed",
+        duplex: false,
+        trimStatCycles: 3,
+        printerIp: "192.0.2.58",
+        destId: 2,
+        approvedAt: "2026-06-05",
+      });
+      expect(baseline.swatches).toHaveLength(12);
+      expect(baseline.swatches.find((s) => s.label === "FF0000")?.rgb[0]).toBeGreaterThan(200);
+      expect((await sharp(overlayPng).metadata()).format).toBe("png");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tools/test-oracle/baseline-cli.test.ts
+++ b/tools/test-oracle/baseline-cli.test.ts
@@ -28,6 +28,7 @@ describe("buildBaselineFromOutputDir", () => {
       });
       expect(baseline.swatches).toHaveLength(12);
       expect(baseline.swatches.find((s) => s.label === "FF0000")?.rgb[0]).toBeGreaterThan(200);
+      expect(baseline.expectedPageCount).toBe(1);
       expect((await sharp(overlayPng).metadata()).format).toBe("png");
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -55,6 +56,7 @@ describe("buildBaselineFromOutputDir", () => {
         approvedAt: "2026-06-05",
       });
       expect(baseline.expectedBackPages).toEqual([2]);
+      expect(baseline.expectedPageCount).toBe(2);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tools/test-oracle/baseline-cli.test.ts
+++ b/tools/test-oracle/baseline-cli.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import sharp from "sharp";
 import { buildBaselineFromOutputDir } from "./baseline-cli.js";
 import { buildTestPageRaster } from "../../src/test-oracle/test-support/raster-draw.js";
+import { setJpegOrientation } from "../../src/exif.js";
 
 describe("buildBaselineFromOutputDir", () => {
   it("measures the lone JPG in an output dir and produces a baseline + overlay", async () => {
@@ -29,13 +30,14 @@ describe("buildBaselineFromOutputDir", () => {
       expect(baseline.swatches).toHaveLength(12);
       expect(baseline.swatches.find((s) => s.label === "FF0000")?.rgb[0]).toBeGreaterThan(200);
       expect(baseline.expectedPageCount).toBe(1);
+      expect(baseline.expectedBackPages).toEqual([]);
       expect((await sharp(overlayPng).metadata()).format).toBe("png");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it("derives expectedBackPages (even pages) for a duplex baseline", async () => {
+  it("derives expectedBackPages from the replay output's EXIF orientation", async () => {
     const { raster } = buildTestPageRaster({ scale: 2 });
     const jpeg = await sharp(raster.data, {
       raw: { width: raster.width, height: raster.height, channels: 3 },
@@ -44,8 +46,10 @@ describe("buildBaselineFromOutputDir", () => {
       .toBuffer();
     const dir = mkdtempSync(path.join(os.tmpdir(), "oracle-cli-dup-"));
     try {
+      // Front page: no EXIF. Back page: tagged Orientation=3, as the scanner
+      // does for duplex back sides — that tag is what the CLI reads.
       writeFileSync(path.join(dir, "scan_2026-06-05_000000_01.jpg"), jpeg);
-      writeFileSync(path.join(dir, "scan_2026-06-05_000000_02.jpg"), jpeg);
+      writeFileSync(path.join(dir, "scan_2026-06-05_000000_02.jpg"), setJpegOrientation(jpeg, 3));
       const { baseline } = await buildBaselineFromOutputDir(dir, {
         fixturePath: "x.jsonl",
         source: "adf-duplex",

--- a/tools/test-oracle/baseline-cli.test.ts
+++ b/tools/test-oracle/baseline-cli.test.ts
@@ -33,4 +33,30 @@ describe("buildBaselineFromOutputDir", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("derives expectedBackPages (even pages) for a duplex baseline", async () => {
+    const { raster } = buildTestPageRaster({ scale: 2 });
+    const jpeg = await sharp(raster.data, {
+      raw: { width: raster.width, height: raster.height, channels: 3 },
+    })
+      .jpeg({ quality: 100 })
+      .toBuffer();
+    const dir = mkdtempSync(path.join(os.tmpdir(), "oracle-cli-dup-"));
+    try {
+      writeFileSync(path.join(dir, "scan_2026-06-05_000000_01.jpg"), jpeg);
+      writeFileSync(path.join(dir, "scan_2026-06-05_000000_02.jpg"), jpeg);
+      const { baseline } = await buildBaselineFromOutputDir(dir, {
+        fixturePath: "x.jsonl",
+        source: "adf-duplex",
+        duplex: true,
+        trimStatCycles: 3,
+        printerIp: "192.0.2.58",
+        destId: 2,
+        approvedAt: "2026-06-05",
+      });
+      expect(baseline.expectedBackPages).toEqual([2]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tools/test-oracle/baseline-cli.ts
+++ b/tools/test-oracle/baseline-cli.ts
@@ -2,8 +2,10 @@ import { readdirSync, readFileSync, writeFileSync, mkdtempSync, rmSync } from "n
 import path from "node:path";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
 import { decodeToRaster } from "../../src/test-oracle/decode.js";
 import { measureWithGeometry, swatchSampleBoxes } from "../../src/test-oracle/oracle.js";
+import { readJpegOrientation } from "../../src/exif.js";
 import { SWATCHES } from "../test-page/layout.js";
 import { saveBaseline, type Baseline } from "../../src/test-oracle/baseline.js";
 import { renderOverlay } from "./overlay.js";
@@ -11,7 +13,15 @@ import {
   readJsonl,
   trimStatCycles,
   replayCapture,
+  REPLAY_PRINTER_IP,
+  REPLAY_DEST_ID,
 } from "../../src/esci2/test-support/frida-replay.js";
+
+const VALID_SOURCES: BaselineMeta["source"][] = ["flatbed", "adf-simplex", "adf-duplex"];
+const USAGE =
+  "usage: npm run oracle:baseline -- <fixture.jsonl> [--source flatbed|adf-simplex|adf-duplex] [--trim-stat-cycles N]";
+/** The dir regression.test.ts scans for committed baselines. */
+const DISCOVERY_ROOT = path.join("tools", "frida-capture", "captures");
 
 export interface BaselineMeta {
   fixturePath: string;
@@ -33,11 +43,19 @@ export async function buildBaselineFromOutputDir(
     .filter((f) => f.endsWith(".jpg"))
     .sort();
   if (jpgs.length === 0) throw new Error(`no .jpg in ${outputDir}`);
-  const jpeg = readFileSync(path.join(outputDir, jpgs[0]));
+  const pageBuffers = jpgs.map((f) => readFileSync(path.join(outputDir, f)));
+  const jpeg = pageBuffers[0];
   const raster = await decodeToRaster(jpeg);
   // Single fit: the geometry that produced the measurement also drives the
   // overlay, so the overlay boxes are exactly the regions the baseline sampled.
   const { measurement: m, geometry } = measureWithGeometry(raster);
+
+  // Record the back pages from the replay OUTPUT — the pages the scanner
+  // actually tagged with EXIF Orientation=3 — rather than assuming an even-page
+  // parity rule, so the baseline matches whatever the replay produces.
+  const expectedBackPages = pageBuffers
+    .map((buf, i) => (readJpegOrientation(buf) === 3 ? i + 1 : 0))
+    .filter((p) => p > 0);
 
   const baseline: Baseline = {
     approvedAt: meta.approvedAt,
@@ -56,7 +74,7 @@ export async function buildBaselineFromOutputDir(
     greySpreads: m.greySpreads,
     stripeVarianceMax: m.stripeVarianceMax,
     expectedPageCount: jpgs.length,
-    expectedBackPages: deriveBackPages(meta.duplex, jpgs.length),
+    expectedBackPages,
     tolerances: {
       swatchDeltaE: 5,
       crosshairPx: Math.max(3, Math.ceil(m.crosshairResidualPx) + 2),
@@ -76,44 +94,64 @@ export async function buildBaselineFromOutputDir(
   return { baseline, overlayPng };
 }
 
-/** In a duplex scan the back side of each sheet is the even-numbered page. */
-function deriveBackPages(duplex: boolean, pageCount: number): number[] {
-  if (!duplex) return [];
-  const pages: number[] = [];
-  for (let p = 2; p <= pageCount; p += 2) pages.push(p);
-  return pages;
-}
-
 async function main(): Promise<void> {
-  const fixturePath = process.argv[2];
+  // parseArgs rejects unknown flags and a flag whose value is missing (e.g.
+  // `--trim-stat-cycles` as the last token), so those fail clearly rather than
+  // silently defaulting; the outer catch prints the message.
+  const { values, positionals } = parseArgs({
+    allowPositionals: true,
+    options: {
+      source: { type: "string", default: "flatbed" },
+      "trim-stat-cycles": { type: "string", default: "3" },
+    },
+  });
+
+  const fixturePath = positionals[0];
   if (!fixturePath) {
+    console.error(USAGE);
+    process.exit(1);
+  }
+  // Refuse a path that doesn't end in .jsonl: the output paths are derived by
+  // replacing the .jsonl suffix, so a non-matching path would make the baseline
+  // / overlay paths equal the fixture path and overwrite the capture itself.
+  if (!fixturePath.endsWith(".jsonl")) {
+    console.error(`fixture must be a .jsonl file (got: ${fixturePath})`);
+    process.exit(1);
+  }
+
+  const source = values.source ?? "flatbed";
+  if (!VALID_SOURCES.includes(source as BaselineMeta["source"])) {
+    console.error(`--source must be one of: ${VALID_SOURCES.join(" | ")} (got: ${source})`);
+    process.exit(1);
+  }
+  const duplex = source === "adf-duplex";
+
+  const trimStr = values["trim-stat-cycles"] ?? "3";
+  const trim = Number(trimStr);
+  if (trimStr.trim() === "" || !Number.isInteger(trim) || trim < 0) {
     console.error(
-      "usage: npm run oracle:baseline -- <fixture.jsonl> [--source flatbed|adf-simplex|adf-duplex] [--trim-stat-cycles N]",
+      `--trim-stat-cycles must be a non-negative integer (got: ${JSON.stringify(trimStr)})`,
     );
     process.exit(1);
   }
-  const sourceArg = argValue("--source") ?? "flatbed";
-  const duplex = sourceArg === "adf-duplex";
-  const trimArg = argValue("--trim-stat-cycles");
-  const trim = trimArg !== undefined ? Number(trimArg) : 3;
-  if (!Number.isInteger(trim) || trim < 0) {
-    console.error(`--trim-stat-cycles must be a non-negative integer, got: ${trimArg}`);
-    process.exit(1);
-  }
+
   const outputDir = mkdtempSync(path.join(os.tmpdir(), "oracle-baseline-"));
   try {
     const records = readJsonl(fixturePath);
     const trimmed = trimStatCycles(records, trim);
-    const { sessionPromise } = await replayCapture(trimmed, outputDir, duplex, "jpg");
+    const { sessionPromise } = await replayCapture(trimmed, outputDir, duplex, "jpg", {
+      printerIp: REPLAY_PRINTER_IP,
+      destId: REPLAY_DEST_ID,
+    });
     await sessionPromise;
 
     const { baseline, overlayPng } = await buildBaselineFromOutputDir(outputDir, {
       fixturePath,
-      source: sourceArg as BaselineMeta["source"],
+      source: source as BaselineMeta["source"],
       duplex,
       trimStatCycles: trim,
-      printerIp: "192.0.2.58",
-      destId: 0x02,
+      printerIp: REPLAY_PRINTER_IP,
+      destId: REPLAY_DEST_ID,
       approvedAt: new Date().toISOString().slice(0, 10),
     });
     const baselinePath = fixturePath.replace(/\.jsonl$/, ".baseline.json");
@@ -122,6 +160,12 @@ async function main(): Promise<void> {
     writeFileSync(overlayPath, overlayPng);
     console.log(`Wrote ${baselinePath}`);
     console.log(`Wrote ${overlayPath} (gitignored — eyeball this, then commit the .json)`);
+    if (!path.resolve(baselinePath).startsWith(path.resolve(DISCOVERY_ROOT) + path.sep)) {
+      console.warn(
+        `WARNING: ${baselinePath} is outside ${DISCOVERY_ROOT}; the regression suite ` +
+          `only discovers baselines under that directory and will NOT run this one.`,
+      );
+    }
     console.table(
       baseline.swatches.map((s) => ({ swatch: s.label, R: s.rgb[0], G: s.rgb[1], B: s.rgb[2] })),
     );
@@ -129,11 +173,6 @@ async function main(): Promise<void> {
   } finally {
     rmSync(outputDir, { recursive: true, force: true });
   }
-}
-
-function argValue(flag: string): string | undefined {
-  const i = process.argv.indexOf(flag);
-  return i >= 0 ? process.argv[i + 1] : undefined;
 }
 
 const __filename = fileURLToPath(import.meta.url);

--- a/tools/test-oracle/baseline-cli.ts
+++ b/tools/test-oracle/baseline-cli.ts
@@ -126,14 +126,16 @@ async function main(): Promise<void> {
   }
   const duplex = source === "adf-duplex";
 
-  const trimStr = values["trim-stat-cycles"] ?? "3";
-  const trim = Number(trimStr);
-  if (trimStr.trim() === "" || !Number.isInteger(trim) || trim < 0) {
+  const trimStr = (values["trim-stat-cycles"] ?? "3").trim();
+  // Decimal digits only: Number() would otherwise silently accept hex (0x3) and
+  // exponent (1e1) forms that Number.isInteger passes.
+  if (!/^\d+$/.test(trimStr)) {
     console.error(
-      `--trim-stat-cycles must be a non-negative integer (got: ${JSON.stringify(trimStr)})`,
+      `--trim-stat-cycles must be a non-negative integer (got: ${JSON.stringify(values["trim-stat-cycles"])})`,
     );
     process.exit(1);
   }
+  const trim = Number(trimStr);
 
   const outputDir = mkdtempSync(path.join(os.tmpdir(), "oracle-baseline-"));
   try {

--- a/tools/test-oracle/baseline-cli.ts
+++ b/tools/test-oracle/baseline-cli.ts
@@ -55,6 +55,7 @@ export async function buildBaselineFromOutputDir(
     swatches: m.swatches,
     greySpreads: m.greySpreads,
     stripeVarianceMax: m.stripeVarianceMax,
+    expectedPageCount: jpgs.length,
     expectedBackPages: deriveBackPages(meta.duplex, jpgs.length),
     tolerances: {
       swatchDeltaE: 5,

--- a/tools/test-oracle/baseline-cli.ts
+++ b/tools/test-oracle/baseline-cli.ts
@@ -44,6 +44,13 @@ export async function buildBaselineFromOutputDir(
     .sort();
   if (jpgs.length === 0) throw new Error(`no .jpg in ${outputDir}`);
   const pageBuffers = jpgs.map((f) => readFileSync(path.join(outputDir, f)));
+  // Pixel metrics (swatch colour, grey neutrality, stripe variance, crosshair
+  // geometry) are sampled from the FRONT page only — page 1 is where the
+  // compatibility PDF's swatch grid lives. Later pages (e.g. a duplex back side,
+  // which carries text rather than the grid) are covered by expectedPageCount and
+  // per-page EXIF orientation, not pixel metrics. Full per-page colour checks are
+  // a follow-up gated on a multi-front-sheet fixture / the WF-3620 host-decode
+  // path, where per-page pixel bugs are actually reachable.
   const jpeg = pageBuffers[0];
   const raster = await decodeToRaster(jpeg);
   // Single fit: the geometry that produced the measurement also drives the

--- a/tools/test-oracle/baseline-cli.ts
+++ b/tools/test-oracle/baseline-cli.ts
@@ -1,0 +1,129 @@
+import { readdirSync, readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+import { decodeToRaster } from "../../src/test-oracle/decode.js";
+import { measure } from "../../src/test-oracle/oracle.js";
+import { detectCrosshairs } from "../../src/test-oracle/crosshairs.js";
+import { fitTransform, mapRect } from "../../src/test-oracle/transform.js";
+import { crosshairPoints, swatchRect, SWATCHES } from "../test-page/layout.js";
+import { saveBaseline, type Baseline } from "../../src/test-oracle/baseline.js";
+import { renderOverlay } from "./overlay.js";
+import {
+  readJsonl,
+  trimStatCycles,
+  replayCapture,
+} from "../../src/esci2/test-support/frida-replay.js";
+
+export interface BaselineMeta {
+  fixturePath: string;
+  source: "flatbed" | "adf-simplex" | "adf-duplex";
+  duplex: boolean;
+  trimStatCycles: number;
+  printerIp: string;
+  destId: number;
+  approvedAt: string;
+  note?: string;
+}
+
+/** Sample the lone JPG in `outputDir`, returning a baseline + overlay PNG. */
+export async function buildBaselineFromOutputDir(
+  outputDir: string,
+  meta: BaselineMeta,
+): Promise<{ baseline: Baseline; overlayPng: Buffer }> {
+  const jpgs = readdirSync(outputDir)
+    .filter((f) => f.endsWith(".jpg"))
+    .sort();
+  if (jpgs.length === 0) throw new Error(`no .jpg in ${outputDir}`);
+  const jpeg = readFileSync(path.join(outputDir, jpgs[0]));
+  const raster = await decodeToRaster(jpeg);
+  const m = measure(raster);
+
+  const baseline: Baseline = {
+    approvedAt: meta.approvedAt,
+    note: meta.note,
+    replay: {
+      fixturePath: meta.fixturePath,
+      source: meta.source,
+      duplex: meta.duplex,
+      trimStatCycles: meta.trimStatCycles,
+      printerIp: meta.printerIp,
+      destId: meta.destId,
+    },
+    page: { width: raster.width, height: raster.height },
+    crosshairResidualPx: m.crosshairResidualPx,
+    swatches: m.swatches,
+    greySpreads: m.greySpreads,
+    stripeVarianceMax: m.stripeVarianceMax,
+    expectedBackPages: [],
+    tolerances: {
+      swatchDeltaE: 5,
+      crosshairPx: Math.max(3, Math.ceil(m.crosshairResidualPx) + 2),
+      greySpread: Math.max(8, Math.ceil(Math.max(...m.greySpreads.map((g) => g.spread))) + 4),
+      stripeVariance: Math.ceil(m.stripeVarianceMax) + 30,
+    },
+  };
+
+  const pxCrosshairs = detectCrosshairs(raster);
+  const t = fitTransform(crosshairPoints, pxCrosshairs);
+  const boxes = SWATCHES.map((s, i) => {
+    const r = mapRect(t, swatchRect(i));
+    return { x: r.x, y: r.y, w: r.w, h: r.h, label: s.label };
+  });
+  const overlayPng = await renderOverlay(jpeg, { crosshairs: pxCrosshairs, boxes });
+  return { baseline, overlayPng };
+}
+
+async function main(): Promise<void> {
+  const fixturePath = process.argv[2];
+  if (!fixturePath) {
+    console.error(
+      "usage: npm run oracle:baseline -- <fixture.jsonl> [--source flatbed|adf-simplex|adf-duplex]",
+    );
+    process.exit(1);
+  }
+  const sourceArg = argValue("--source") ?? "flatbed";
+  const duplex = sourceArg === "adf-duplex";
+  const outputDir = mkdtempSync(path.join(os.tmpdir(), "oracle-baseline-"));
+  try {
+    const records = readJsonl(fixturePath);
+    const trimmed = trimStatCycles(records, 3);
+    const { sessionPromise } = await replayCapture(trimmed, outputDir, duplex, "jpg");
+    await sessionPromise;
+
+    const { baseline, overlayPng } = await buildBaselineFromOutputDir(outputDir, {
+      fixturePath,
+      source: sourceArg as BaselineMeta["source"],
+      duplex,
+      trimStatCycles: 3,
+      printerIp: "192.0.2.58",
+      destId: 0x02,
+      approvedAt: new Date().toISOString().slice(0, 10),
+    });
+    const baselinePath = fixturePath.replace(/\.jsonl$/, ".baseline.json");
+    const overlayPath = fixturePath.replace(/\.jsonl$/, ".baseline.overlay.png");
+    saveBaseline(baselinePath, baseline);
+    writeFileSync(overlayPath, overlayPng);
+    console.log(`Wrote ${baselinePath}`);
+    console.log(`Wrote ${overlayPath} (gitignored — eyeball this, then commit the .json)`);
+    console.table(
+      baseline.swatches.map((s) => ({ swatch: s.label, R: s.rgb[0], G: s.rgb[1], B: s.rgb[2] })),
+    );
+    console.log(`crosshair residual: ${baseline.crosshairResidualPx}px`);
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true });
+  }
+}
+
+function argValue(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+const __filename = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename)) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tools/test-oracle/baseline-cli.ts
+++ b/tools/test-oracle/baseline-cli.ts
@@ -3,10 +3,8 @@ import path from "node:path";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
 import { decodeToRaster } from "../../src/test-oracle/decode.js";
-import { measure } from "../../src/test-oracle/oracle.js";
-import { detectCrosshairs } from "../../src/test-oracle/crosshairs.js";
-import { fitTransform, mapRect } from "../../src/test-oracle/transform.js";
-import { crosshairPoints, swatchRect, SWATCHES } from "../test-page/layout.js";
+import { measureWithGeometry, swatchSampleBoxes } from "../../src/test-oracle/oracle.js";
+import { SWATCHES } from "../test-page/layout.js";
 import { saveBaseline, type Baseline } from "../../src/test-oracle/baseline.js";
 import { renderOverlay } from "./overlay.js";
 import {
@@ -37,7 +35,9 @@ export async function buildBaselineFromOutputDir(
   if (jpgs.length === 0) throw new Error(`no .jpg in ${outputDir}`);
   const jpeg = readFileSync(path.join(outputDir, jpgs[0]));
   const raster = await decodeToRaster(jpeg);
-  const m = measure(raster);
+  // Single fit: the geometry that produced the measurement also drives the
+  // overlay, so the overlay boxes are exactly the regions the baseline sampled.
+  const { measurement: m, geometry } = measureWithGeometry(raster);
 
   const baseline: Baseline = {
     approvedAt: meta.approvedAt,
@@ -55,7 +55,7 @@ export async function buildBaselineFromOutputDir(
     swatches: m.swatches,
     greySpreads: m.greySpreads,
     stripeVarianceMax: m.stripeVarianceMax,
-    expectedBackPages: [],
+    expectedBackPages: deriveBackPages(meta.duplex, jpgs.length),
     tolerances: {
       swatchDeltaE: 5,
       crosshairPx: Math.max(3, Math.ceil(m.crosshairResidualPx) + 2),
@@ -64,30 +64,45 @@ export async function buildBaselineFromOutputDir(
     },
   };
 
-  const pxCrosshairs = detectCrosshairs(raster);
-  const t = fitTransform(crosshairPoints, pxCrosshairs);
-  const boxes = SWATCHES.map((s, i) => {
-    const r = mapRect(t, swatchRect(i));
-    return { x: r.x, y: r.y, w: r.w, h: r.h, label: s.label };
-  });
-  const overlayPng = await renderOverlay(jpeg, { crosshairs: pxCrosshairs, boxes });
+  const boxes = swatchSampleBoxes(geometry.transform).map((r, i) => ({
+    x: r.x,
+    y: r.y,
+    w: r.w,
+    h: r.h,
+    label: SWATCHES[i].label,
+  }));
+  const overlayPng = await renderOverlay(jpeg, { crosshairs: geometry.pxCrosshairs, boxes });
   return { baseline, overlayPng };
+}
+
+/** In a duplex scan the back side of each sheet is the even-numbered page. */
+function deriveBackPages(duplex: boolean, pageCount: number): number[] {
+  if (!duplex) return [];
+  const pages: number[] = [];
+  for (let p = 2; p <= pageCount; p += 2) pages.push(p);
+  return pages;
 }
 
 async function main(): Promise<void> {
   const fixturePath = process.argv[2];
   if (!fixturePath) {
     console.error(
-      "usage: npm run oracle:baseline -- <fixture.jsonl> [--source flatbed|adf-simplex|adf-duplex]",
+      "usage: npm run oracle:baseline -- <fixture.jsonl> [--source flatbed|adf-simplex|adf-duplex] [--trim-stat-cycles N]",
     );
     process.exit(1);
   }
   const sourceArg = argValue("--source") ?? "flatbed";
   const duplex = sourceArg === "adf-duplex";
+  const trimArg = argValue("--trim-stat-cycles");
+  const trim = trimArg !== undefined ? Number(trimArg) : 3;
+  if (!Number.isInteger(trim) || trim < 0) {
+    console.error(`--trim-stat-cycles must be a non-negative integer, got: ${trimArg}`);
+    process.exit(1);
+  }
   const outputDir = mkdtempSync(path.join(os.tmpdir(), "oracle-baseline-"));
   try {
     const records = readJsonl(fixturePath);
-    const trimmed = trimStatCycles(records, 3);
+    const trimmed = trimStatCycles(records, trim);
     const { sessionPromise } = await replayCapture(trimmed, outputDir, duplex, "jpg");
     await sessionPromise;
 
@@ -95,7 +110,7 @@ async function main(): Promise<void> {
       fixturePath,
       source: sourceArg as BaselineMeta["source"],
       duplex,
-      trimStatCycles: 3,
+      trimStatCycles: trim,
       printerIp: "192.0.2.58",
       destId: 0x02,
       approvedAt: new Date().toISOString().slice(0, 10),

--- a/tools/test-oracle/overlay.test.ts
+++ b/tools/test-oracle/overlay.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import sharp from "sharp";
+import { renderOverlay } from "./overlay.js";
+
+describe("renderOverlay", () => {
+  it("draws sample boxes + crosshair marks over a base JPEG and returns a PNG", async () => {
+    const base = await sharp({
+      create: { width: 200, height: 280, channels: 3, background: { r: 255, g: 255, b: 255 } },
+    })
+      .jpeg()
+      .toBuffer();
+    const png = await renderOverlay(base, {
+      crosshairs: [
+        { x: 10, y: 10 },
+        { x: 190, y: 10 },
+        { x: 10, y: 270 },
+        { x: 190, y: 270 },
+      ],
+      boxes: [{ x: 50, y: 50, w: 40, h: 30, label: "FF0000" }],
+    });
+    const meta = await sharp(png).metadata();
+    expect(meta.format).toBe("png");
+    expect(meta.width).toBe(200);
+    expect(meta.height).toBe(280);
+  });
+});

--- a/tools/test-oracle/overlay.ts
+++ b/tools/test-oracle/overlay.ts
@@ -1,0 +1,39 @@
+import sharp from "sharp";
+
+export interface OverlayBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  label: string;
+}
+
+export interface OverlayOpts {
+  crosshairs: { x: number; y: number }[];
+  boxes: OverlayBox[];
+}
+
+/** Composite an SVG of sample boxes + detected crosshairs over a base image. */
+export async function renderOverlay(baseImage: Buffer, opts: OverlayOpts): Promise<Buffer> {
+  const meta = await sharp(baseImage).metadata();
+  const width = meta.width ?? 0;
+  const height = meta.height ?? 0;
+  const boxes = opts.boxes
+    .map(
+      (b) =>
+        `<rect x="${b.x}" y="${b.y}" width="${b.w}" height="${b.h}" fill="none" stroke="#00FF00" stroke-width="2"/>` +
+        `<text x="${b.x}" y="${b.y - 2}" font-size="12" fill="#00AA00">${b.label}</text>`,
+    )
+    .join("");
+  const marks = opts.crosshairs
+    .map(
+      (c) =>
+        `<circle cx="${c.x}" cy="${c.y}" r="6" fill="none" stroke="#FF00FF" stroke-width="2"/>`,
+    )
+    .join("");
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">${boxes}${marks}</svg>`;
+  return sharp(baseImage)
+    .composite([{ input: Buffer.from(svg) }])
+    .png()
+    .toBuffer();
+}

--- a/tools/test-page/generate.ts
+++ b/tools/test-page/generate.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { PDFDocument, PDFPage, PDFFont, StandardFonts, rgb } from "pdf-lib";
-import { LAYOUT, SWATCHES, swatchRect } from "./layout.js";
+import { LAYOUT, SWATCHES, swatchRect, crosshairPoints } from "./layout.js";
 
 function rgb255(r: number, g: number, b: number) {
   return rgb(r / 255, g / 255, b / 255);
@@ -24,10 +24,7 @@ function drawCrosshair(page: PDFPage, x: number, y: number, size = 12): void {
 }
 
 function drawCornerMarks(page: PDFPage): void {
-  drawCrosshair(page, LAYOUT.margin, LAYOUT.pageHeight - LAYOUT.margin);
-  drawCrosshair(page, LAYOUT.pageWidth - LAYOUT.margin, LAYOUT.pageHeight - LAYOUT.margin);
-  drawCrosshair(page, LAYOUT.margin, LAYOUT.margin);
-  drawCrosshair(page, LAYOUT.pageWidth - LAYOUT.margin, LAYOUT.margin);
+  for (const p of crosshairPoints) drawCrosshair(page, p.x, p.y);
 }
 
 function drawHorizontalLines(page: PDFPage, baseY: number, count: number): void {

--- a/tools/test-page/generate.ts
+++ b/tools/test-page/generate.ts
@@ -2,33 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { PDFDocument, PDFPage, PDFFont, StandardFonts, rgb } from "pdf-lib";
-
-// A4 in pdf-lib points (1 pt = 1/72 inch).
-const PAGE_WIDTH = 595.28;
-const PAGE_HEIGHT = 841.89;
-const MARGIN = 40;
-
-interface Swatch {
-  r: number;
-  g: number;
-  b: number;
-  label: string;
-}
-
-const SWATCHES: Swatch[] = [
-  { r: 255, g: 0, b: 0, label: "FF0000" },
-  { r: 0, g: 255, b: 0, label: "00FF00" },
-  { r: 0, g: 0, b: 255, label: "0000FF" },
-  { r: 0, g: 255, b: 255, label: "00FFFF" },
-  { r: 255, g: 0, b: 255, label: "FF00FF" },
-  { r: 255, g: 255, b: 0, label: "FFFF00" },
-  { r: 192, g: 192, b: 192, label: "C0C0C0" },
-  { r: 128, g: 128, b: 128, label: "808080" },
-  { r: 64, g: 64, b: 64, label: "404040" },
-  { r: 255, g: 128, b: 0, label: "FF8000" },
-  { r: 128, g: 0, b: 255, label: "8000FF" },
-  { r: 0, g: 160, b: 160, label: "00A0A0" },
-];
+import { LAYOUT, SWATCHES, swatchRect } from "./layout.js";
 
 function rgb255(r: number, g: number, b: number) {
   return rgb(r / 255, g / 255, b / 255);
@@ -50,17 +24,17 @@ function drawCrosshair(page: PDFPage, x: number, y: number, size = 12): void {
 }
 
 function drawCornerMarks(page: PDFPage): void {
-  drawCrosshair(page, MARGIN, PAGE_HEIGHT - MARGIN);
-  drawCrosshair(page, PAGE_WIDTH - MARGIN, PAGE_HEIGHT - MARGIN);
-  drawCrosshair(page, MARGIN, MARGIN);
-  drawCrosshair(page, PAGE_WIDTH - MARGIN, MARGIN);
+  drawCrosshair(page, LAYOUT.margin, LAYOUT.pageHeight - LAYOUT.margin);
+  drawCrosshair(page, LAYOUT.pageWidth - LAYOUT.margin, LAYOUT.pageHeight - LAYOUT.margin);
+  drawCrosshair(page, LAYOUT.margin, LAYOUT.margin);
+  drawCrosshair(page, LAYOUT.pageWidth - LAYOUT.margin, LAYOUT.margin);
 }
 
 function drawHorizontalLines(page: PDFPage, baseY: number, count: number): void {
   for (let i = 0; i < count; i++) {
     page.drawLine({
-      start: { x: MARGIN + 20, y: baseY + i * 8 },
-      end: { x: PAGE_WIDTH - MARGIN - 20, y: baseY + i * 8 },
+      start: { x: LAYOUT.margin + 20, y: baseY + i * 8 },
+      end: { x: LAYOUT.pageWidth - LAYOUT.margin - 20, y: baseY + i * 8 },
       thickness: 0.3,
       color: rgb(0, 0, 0),
     });
@@ -76,7 +50,7 @@ function drawCenteredText(
 ): void {
   const width = font.widthOfTextAtSize(text, size);
   page.drawText(text, {
-    x: (PAGE_WIDTH - width) / 2,
+    x: (LAYOUT.pageWidth - width) / 2,
     y,
     size,
     font,
@@ -89,35 +63,25 @@ function drawFront(page: PDFPage, helv: PDFFont, helvBold: PDFFont): void {
 
   // Asymmetric corner marker — distinguishes a horizontal flip from rotation.
   page.drawText("F", {
-    x: MARGIN + 8,
-    y: PAGE_HEIGHT - MARGIN - 28,
+    x: LAYOUT.margin + 8,
+    y: LAYOUT.pageHeight - LAYOUT.margin - 28,
     size: 24,
     font: helvBold,
     color: rgb255(255, 0, 0),
   });
 
-  drawCenteredText(page, "FRONT — TOP", PAGE_HEIGHT - MARGIN - 55, 36, helvBold);
+  drawCenteredText(page, "FRONT — TOP", LAYOUT.pageHeight - LAYOUT.margin - 55, 36, helvBold);
 
   // 3 columns x 4 rows = 12 swatches with their declared RGB labels.
-  const swatchW = 120;
-  const swatchH = 70;
-  const colSpacing = 150;
-  const rowSpacing = 105;
-  const gridLeft = (PAGE_WIDTH - (3 * swatchW + 2 * (colSpacing - swatchW))) / 2;
-  const gridTop = PAGE_HEIGHT - 200;
-
   for (let i = 0; i < SWATCHES.length; i++) {
-    const col = i % 3;
-    const row = Math.floor(i / 3);
-    const x = gridLeft + col * colSpacing;
-    const y = gridTop - row * rowSpacing;
+    const { x, y } = swatchRect(i);
     const sw = SWATCHES[i];
 
     page.drawRectangle({
       x,
       y,
-      width: swatchW,
-      height: swatchH,
+      width: LAYOUT.swatchW,
+      height: LAYOUT.swatchH,
       color: rgb255(sw.r, sw.g, sw.b),
     });
     page.drawText(`#${sw.label}`, {
@@ -136,25 +100,25 @@ function drawFront(page: PDFPage, helv: PDFFont, helvBold: PDFFont): void {
     });
   }
 
-  drawHorizontalLines(page, MARGIN + 80, 5);
-  drawCenteredText(page, "FRONT — BOTTOM", MARGIN + 25, 24, helvBold);
+  drawHorizontalLines(page, LAYOUT.margin + 80, 5);
+  drawCenteredText(page, "FRONT — BOTTOM", LAYOUT.margin + 25, 24, helvBold);
 }
 
 function drawBack(page: PDFPage, helv: PDFFont, helvBold: PDFFont): void {
   drawCornerMarks(page);
 
   page.drawText("B", {
-    x: MARGIN + 8,
-    y: PAGE_HEIGHT - MARGIN - 28,
+    x: LAYOUT.margin + 8,
+    y: LAYOUT.pageHeight - LAYOUT.margin - 28,
     size: 24,
     font: helvBold,
     color: rgb255(0, 0, 255),
   });
 
-  drawCenteredText(page, "BACK — TOP", PAGE_HEIGHT - MARGIN - 55, 36, helvBold);
+  drawCenteredText(page, "BACK — TOP", LAYOUT.pageHeight - LAYOUT.margin - 55, 36, helvBold);
 
-  const textX = MARGIN + 50;
-  let y = PAGE_HEIGHT - 180;
+  const textX = LAYOUT.margin + 50;
+  let y = LAYOUT.pageHeight - 180;
   const lineGap = 32;
 
   page.drawText("Red text — anti-aliased coloured edges", {
@@ -192,13 +156,13 @@ function drawBack(page: PDFPage, helv: PDFFont, helvBold: PDFFont): void {
     size: 11,
     font: helv,
     color: rgb(0.15, 0.15, 0.15),
-    maxWidth: PAGE_WIDTH - 2 * textX,
+    maxWidth: LAYOUT.pageWidth - 2 * textX,
     lineHeight: 15,
   });
 
   // Thin horizontal lines for skew detection at scan time.
-  drawHorizontalLines(page, MARGIN + 80, 5);
-  drawCenteredText(page, "BACK — BOTTOM", MARGIN + 25, 24, helvBold);
+  drawHorizontalLines(page, LAYOUT.margin + 80, 5);
+  drawCenteredText(page, "BACK — BOTTOM", LAYOUT.margin + 25, 24, helvBold);
 }
 
 export async function generate(outputPath: string): Promise<void> {
@@ -206,8 +170,8 @@ export async function generate(outputPath: string): Promise<void> {
   const helv = await pdf.embedFont(StandardFonts.Helvetica);
   const helvBold = await pdf.embedFont(StandardFonts.HelveticaBold);
 
-  drawFront(pdf.addPage([PAGE_WIDTH, PAGE_HEIGHT]), helv, helvBold);
-  drawBack(pdf.addPage([PAGE_WIDTH, PAGE_HEIGHT]), helv, helvBold);
+  drawFront(pdf.addPage([LAYOUT.pageWidth, LAYOUT.pageHeight]), helv, helvBold);
+  drawBack(pdf.addPage([LAYOUT.pageWidth, LAYOUT.pageHeight]), helv, helvBold);
 
   const bytes = await pdf.save();
   fs.writeFileSync(outputPath, bytes);

--- a/tools/test-page/layout.test.ts
+++ b/tools/test-page/layout.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { LAYOUT, swatchRect, SWATCHES, greySwatchIndices, crosshairPoints } from "./layout.js";
+
+describe("test-page layout", () => {
+  it("mirrors the generator's page + margin constants", () => {
+    expect(LAYOUT.pageWidth).toBeCloseTo(595.28, 2);
+    expect(LAYOUT.pageHeight).toBeCloseTo(841.89, 2);
+    expect(LAYOUT.margin).toBe(40);
+  });
+
+  it("exposes 12 swatches with the declared RGB labels", () => {
+    expect(SWATCHES).toHaveLength(12);
+    expect(SWATCHES[0]).toEqual({ r: 255, g: 0, b: 0, label: "FF0000" });
+    expect(SWATCHES[6]).toEqual({ r: 192, g: 192, b: 192, label: "C0C0C0" });
+  });
+
+  it("identifies the three grey swatches", () => {
+    expect(greySwatchIndices).toEqual([6, 7, 8]);
+  });
+
+  it("computes swatch rects from the grid math (pdf bottom-left, points)", () => {
+    const r0 = swatchRect(0);
+    const colSpacing = 150;
+    const swatchW = 120;
+    const gridLeft = (595.28 - (3 * swatchW + 2 * (colSpacing - swatchW))) / 2;
+    const gridTop = 841.89 - 200;
+    expect(r0).toEqual({ x: gridLeft, y: gridTop, w: 120, h: 70 });
+    expect(swatchRect(3).y).toBeCloseTo(gridTop - 105, 5);
+  });
+
+  it("places 4 crosshairs at the margins (pdf bottom-left)", () => {
+    expect(crosshairPoints).toEqual([
+      { x: 40, y: 841.89 - 40 }, // TL
+      { x: 595.28 - 40, y: 841.89 - 40 }, // TR
+      { x: 40, y: 40 }, // BL
+      { x: 595.28 - 40, y: 40 }, // BR
+    ]);
+  });
+});

--- a/tools/test-page/layout.ts
+++ b/tools/test-page/layout.ts
@@ -1,0 +1,85 @@
+// Single source of truth for the compatibility test-page geometry.
+// Coordinates are PDF POINT space with pdf-lib's BOTTOM-LEFT origin (y up),
+// identical to generate.ts. The oracle maps these into raster (top-left,
+// y down) space via the crosshair-fit transform — see src/test-oracle.
+
+export interface Swatch {
+  r: number;
+  g: number;
+  b: number;
+  label: string;
+}
+
+export interface PointRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export const LAYOUT = {
+  pageWidth: 595.28,
+  pageHeight: 841.89,
+  margin: 40,
+  swatchW: 120,
+  swatchH: 70,
+  colSpacing: 150,
+  rowSpacing: 105,
+} as const;
+
+export const SWATCHES: Swatch[] = [
+  { r: 255, g: 0, b: 0, label: "FF0000" },
+  { r: 0, g: 255, b: 0, label: "00FF00" },
+  { r: 0, g: 0, b: 255, label: "0000FF" },
+  { r: 0, g: 255, b: 255, label: "00FFFF" },
+  { r: 255, g: 0, b: 255, label: "FF00FF" },
+  { r: 255, g: 255, b: 0, label: "FFFF00" },
+  { r: 192, g: 192, b: 192, label: "C0C0C0" },
+  { r: 128, g: 128, b: 128, label: "808080" },
+  { r: 64, g: 64, b: 64, label: "404040" },
+  { r: 255, g: 128, b: 0, label: "FF8000" },
+  { r: 128, g: 0, b: 255, label: "8000FF" },
+  { r: 0, g: 160, b: 160, label: "00A0A0" },
+];
+
+export const greySwatchIndices = [6, 7, 8];
+
+const gridLeft =
+  (LAYOUT.pageWidth - (3 * LAYOUT.swatchW + 2 * (LAYOUT.colSpacing - LAYOUT.swatchW))) / 2;
+const gridTop = LAYOUT.pageHeight - 200;
+
+/** Swatch i's filled rectangle in PDF point space (bottom-left origin). */
+export function swatchRect(i: number): PointRect {
+  const col = i % 3;
+  const row = Math.floor(i / 3);
+  return {
+    x: gridLeft + col * LAYOUT.colSpacing,
+    y: gridTop - row * LAYOUT.rowSpacing,
+    w: LAYOUT.swatchW,
+    h: LAYOUT.swatchH,
+  };
+}
+
+/** The 4 corner registration marks, order [TL, TR, BL, BR] in PDF point space. */
+export const crosshairPoints = [
+  { x: LAYOUT.margin, y: LAYOUT.pageHeight - LAYOUT.margin },
+  { x: LAYOUT.pageWidth - LAYOUT.margin, y: LAYOUT.pageHeight - LAYOUT.margin },
+  { x: LAYOUT.margin, y: LAYOUT.margin },
+  { x: LAYOUT.pageWidth - LAYOUT.margin, y: LAYOUT.margin },
+];
+
+/** Bottom horizontal-rule band (stripe/smear target), front + back identical. */
+export const ruleLineBand: PointRect = {
+  x: LAYOUT.margin + 20,
+  y: LAYOUT.margin + 80,
+  w: LAYOUT.pageWidth - 2 * (LAYOUT.margin + 20),
+  h: 5 * 8,
+};
+
+/** Asymmetric corner marker region (F front / B back), near the TL crosshair. */
+export const markerRegion: PointRect = {
+  x: LAYOUT.margin,
+  y: LAYOUT.pageHeight - LAYOUT.margin - 32,
+  w: 28,
+  h: 28,
+};

--- a/tools/test-page/layout.ts
+++ b/tools/test-page/layout.ts
@@ -42,7 +42,7 @@ export const SWATCHES: Swatch[] = [
   { r: 0, g: 160, b: 160, label: "00A0A0" },
 ];
 
-export const greySwatchIndices = [6, 7, 8];
+export const greySwatchIndices = [6, 7, 8] as const;
 
 const gridLeft =
   (LAYOUT.pageWidth - (3 * LAYOUT.swatchW + 2 * (LAYOUT.colSpacing - LAYOUT.swatchW))) / 2;
@@ -68,7 +68,12 @@ export const crosshairPoints = [
   { x: LAYOUT.pageWidth - LAYOUT.margin, y: LAYOUT.margin },
 ];
 
-/** Bottom horizontal-rule band (stripe/smear target), front + back identical. */
+/**
+ * Bottom horizontal-rule band (stripe/smear target), front + back identical.
+ * The 5 rules sit at `baseY + i*8` for i=0..4 (spanning 32pt); `h: 5 * 8` (40pt)
+ * is a deliberately generous bounding box with slack so the sampling region
+ * fully contains them.
+ */
 export const ruleLineBand: PointRect = {
   x: LAYOUT.margin + 20,
   y: LAYOUT.margin + 80,

--- a/tools/test-page/layout.ts
+++ b/tools/test-page/layout.ts
@@ -68,19 +68,6 @@ export const crosshairPoints = [
   { x: LAYOUT.pageWidth - LAYOUT.margin, y: LAYOUT.margin },
 ];
 
-/**
- * Bottom horizontal-rule band (stripe/smear target), front + back identical.
- * The 5 rules sit at `baseY + i*8` for i=0..4 (spanning 32pt); `h: 5 * 8` (40pt)
- * is a deliberately generous bounding box with slack so the sampling region
- * fully contains them.
- */
-export const ruleLineBand: PointRect = {
-  x: LAYOUT.margin + 20,
-  y: LAYOUT.margin + 80,
-  w: LAYOUT.pageWidth - 2 * (LAYOUT.margin + 20),
-  h: 5 * 8,
-};
-
 /** Asymmetric corner marker region (F front / B back), near the TL crosshair. */
 export const markerRegion: PointRect = {
   x: LAYOUT.margin,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,11 @@
     "types": ["node"]
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/test-support/**", "src/test-oracle/**"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts",
+    "src/**/test-support/**",
+    "src/test-oracle/**"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "types": ["node"]
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/test-support/**"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/test-support/**", "src/test-oracle/**"]
 }


### PR DESCRIPTION
## Summary

Adds the **scan-output patch-sampling regression oracle** from #27 — Phases 1–2 (engine + tooling). The oracle replays a captured compatibility-page scan, decodes the JPEG output, and asserts colour / geometry / stripe / greyscale / duplex-orientation against a committed per-fixture baseline. It exists because the wire-protocol replay shields verify framing but never assert real pixel content, so pixel-corrupting edits (channel order, stride, gamma, dropped chunks — cf. the GBR→RGB bug #24/#25 and the trailing-chunk drop #79) sail through.

The engine is transport/dialect-agnostic (operates on a decoded raster + layout + baseline). This PR lands it on the ESC/I-2-over-TLS path (ET-4956 / ET-4950 family) first.

### What's included
- **Shared test-page layout** (`tools/test-page/layout.ts`) — single source of truth for swatch/crosshair/grey/rule geometry; `generate.ts` refactored to consume it (behaviour-preserving).
- **Engine** (`src/test-oracle/`): `decode`, `crosshairs` (expected-position windows + all-channel near-black threshold), `transform` (crosshair-fit, y-flip aware), `metrics`, `color` (CIE76), `oracle` (`measure` / `assertAgainst`), `baseline` (Zod schema). Plus `readJpegOrientation` in `src/exif.ts`.
- **Tooling**: `npm run oracle:baseline` self-baselining CLI + annotated overlay PNG, and a globbing regression suite.
- The Frida replay helpers were lifted from `scanner.test.ts` into `src/esci2/test-support/frida-replay.ts`; the byte-for-byte replay shield is preserved (re-asserted explicitly in both replay blocks).
- The oracle is excluded from the production `tsc` build (`tsconfig.json`) — it's test-only infra; type-checked via `eslint`.

### Deferred (not this PR)
- **Phase 3 (hardware):** capturing the ET-4956 compatibility-page fixtures and committing baselines. The regression suite **no-ops (1 skip)** until a baseline lands, so this PR is safe to merge now; the baseline PR follows once the scan is captured with this released tooling.
- **Phase 4:** plain-TCP (ET-2750/XP-7100/ET-4800/ET-15000) and legacy WF-3620 oracle targets (tracked follow-ups).

## Test plan
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm run build` succeeds; `dist/` contains no `test-oracle/`
- [x] Oracle suites green (43 passed + 1 skipped), incl. injected-failure tests (shifted swatch, displaced crosshair, page-size mismatch, marker-rejection, empty-region throw, malformed-EXIF)
- [x] esci2 byte-for-byte replay shield intact
- [ ] CI green on Linux

> Note: on a **Windows** dev box `npm test` shows 6 failures in `src/esci2/scanner.test.ts`'s `runEsci2Scan failure-mode matrix` — these are **pre-existing** (hardcoded `tempDir: "/tmp"` → `D:\tmp` ENOENT), present on `main`, unrelated to this PR, and do not occur on Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)