### PR TITLE
chore: release v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epson2paperless",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "epson2paperless",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "pdf-lib": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epson2paperless",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Epson Scan to Computer protocol emulator — delivers scans to Paperless-ngx",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Version bump to **v0.5.0** ahead of tagging. Bundles FF-680W (#110) and ET-15000 (#106) support, the scan-output regression oracle (#27), and the new `SCAN_FORMAT`/`SCAN_SIDES`/`SCAN_RESOLUTION` config surface. Full notes go on the GitHub Release once tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)