### PR TITLE
[codex] docs: fix compatibility issue template links

### DIFF
--- a/.github/ISSUE_TEMPLATE/compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         Thanks for sharing a compatibility report — both successes and failures
-        help the [Compatible printers](../../#compatible-printers) table grow.
+        help the [Compatible printers](https://github.com/mtheuma/epson2paperless#compatible-printers) table grow.
 
   - type: input
     id: model
@@ -54,7 +54,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        📎 **Captured a scan?** Don't attach the pcap here; it includes your printer's MAC and other identifying bytes. See [CONTRIBUTING.md → Contributing a scan capture](../../blob/main/CONTRIBUTING.md#contributing-a-scan-capture) to send it privately. A scan of [compatibility-test-page.pdf](https://github.com/mtheuma/epson2paperless/blob/main/tools/test-page/compatibility-test-page.pdf) is most useful.
+        📎 **Captured a scan?** Don't attach the pcap here; it includes your printer's MAC and other identifying bytes. See [CONTRIBUTING.md → Contributing a scan capture](https://github.com/mtheuma/epson2paperless/blob/main/CONTRIBUTING.md#contributing-a-scan-capture) to send it privately. A scan of [compatibility-test-page.pdf](https://github.com/mtheuma/epson2paperless/blob/main/tools/test-page/compatibility-test-page.pdf) is most useful.
 
   - type: textarea
     id: notes


### PR DESCRIPTION
## What

Fixes broken links in the compatibility issue template by replacing parent-relative links with absolute repository URLs.

## Why

GitHub renders the issue form from `/issues/new`, so links like `../../blob/main/CONTRIBUTING.md#contributing-a-scan-capture` resolve to `https://github.com/mtheuma/blob/main/CONTRIBUTING.md...` instead of this repository.

## Impact

Compatibility reporters can now reach the scan-capture instructions and the compatible-printers section directly from the issue form.

## Verification

- `npx prettier --check .github/ISSUE_TEMPLATE/compatibility.yml`
- Focused URL check confirming the expected absolute links are present and no `../../` parent-relative links remain
- Pre-push hook ran `npm run lint` and `npm run format:check` successfully during push
