### PR TITLE
[codex] docs: join compatibility report intro sentence

### DIFF
--- a/.github/ISSUE_TEMPLATE/compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility.yml
@@ -6,8 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for sharing a compatibility report — both successes and failures
-        help the [Compatible printers](https://github.com/mtheuma/epson2paperless#compatible-printers) table grow.
+        Thanks for sharing a compatibility report — both successes and failures help the [Compatible printers](https://github.com/mtheuma/epson2paperless#compatible-printers) table grow.
 
   - type: input
     id: model


### PR DESCRIPTION
## What

Joins the opening compatibility issue-template sentence so `help the Compatible printers...` does not start on a new rendered line.

## Why

The issue form renders the Markdown block with the physical line break intact, which made the intro read awkwardly after the previous link fix.

## Impact

Compatibility reporters see the intro as a single sentence.

## Verification

- Focused text check confirming `help the [Compatible printers]` is no longer on a new line
- `npx prettier --check .github/ISSUE_TEMPLATE/compatibility.yml`
- Pre-push hook ran `npm run lint` and `npm run format:check` successfully during push
