### PR TITLE
chore(deps): bump dev-only brace-expansion to 5.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1869,9 +1869,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

Clears the remaining Dependabot alert surfaced during the esbuild bump (#116):

- **[GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2)** (moderate) — `brace-expansion`'s documented `max` DoS protection is defeated by a large numeric range. Vulnerable `5.0.2 – 5.0.5`; fixed in **5.0.6**.

## How

The vulnerable copy is **dev-only and pulled transitively**:

```
typescript-eslint
  └─ @typescript-eslint/typescript-estree
       └─ minimatch@10.2.5
            └─ brace-expansion@5.0.5   ← vulnerable
```

`minimatch@10.2.5` already declares `brace-expansion: ^5.0.5`, which permits the patched 5.0.6, so this is a **lockfile-only** bump (`5.0.5 → 5.0.6`) via `npm audit fix` — no `package.json` change. The eslint chain uses the separate, non-vulnerable `brace-expansion@1.x` line and is unaffected.

```
$ npm audit
found 0 vulnerabilities
```

## Runtime impact

None. `brace-expansion` is dev-scope only (lint tooling); runtime deps (`pdf-lib`, `sharp`, `zod`) are untouched.

## Verification

- `npm audit` → 0 vulnerabilities
- `npm test` → green (740 passed, 2 skipped)
- `npm run lint` → clean
- `npm run format:check` → clean
- `npm run build` (tsc) → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
