### PR TITLE
feat(esci2): add speculative ET-8500 dialect (flatbed-only, TLS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ What you get:
 | **WF-3620**           | ✅ Verified     | Plain TCP scanner, no TLS pinning                     |
 | **ET-2750**           | ✅ Verified     | Flatbed-only hardware; ESC/I-2 over plain TCP, no TLS |
 | **ET-2950**           | 🟡 Experimental | Flatbed-only hardware                                 |
-| **ET-8500**           | 🟡 Experimental | Flatbed-only hardware; awaiting hardware confirmation |
+| **ET-8500**           | 🟡 Experimental | Flatbed-only hardware                                 |
 | **ET-4800**           | ✅ Verified     | ADF simplex; ESC/I-2 over plain TCP, no TLS           |
 | **ET-15000**          | 🟡 Experimental | Flatbed verified; ADF simplex untested                |
 | **XP-7100**           | ✅ Verified     |                                                       |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ What you get:
 | **WF-3620**           | ✅ Verified     | Plain TCP scanner, no TLS pinning                     |
 | **ET-2750**           | ✅ Verified     | Flatbed-only hardware; ESC/I-2 over plain TCP, no TLS |
 | **ET-2950**           | 🟡 Experimental | Flatbed-only hardware                                 |
+| **ET-8500**           | 🟡 Experimental | Flatbed-only hardware; awaiting hardware confirmation |
 | **ET-4800**           | ✅ Verified     | ADF simplex; ESC/I-2 over plain TCP, no TLS           |
 | **ET-15000**          | 🟡 Experimental | Flatbed verified; ADF simplex untested                |
 | **XP-7100**           | ✅ Verified     |                                                       |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epson2paperless",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "epson2paperless",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "pdf-lib": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epson2paperless",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Epson Scan to Computer protocol emulator — delivers scans to Paperless-ngx",
   "main": "dist/index.js",
   "scripts": {

--- a/src/esci2/dialects/et-8500.test.ts
+++ b/src/esci2/dialects/et-8500.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { REGISTRY } from "./registry.js";
+import { composePara } from "../para-composer.js";
+import { makeParaSpec } from "./dispatch.js";
+
+const ET8500_FP = "05b5c7eaad217e9538883f3fffe9796464689a5d9006c5b3e3c3fd2c24e21467";
+const entry = REGISTRY.get(ET8500_FP)!;
+
+// The registry entry's static fields are asserted in registry.test.ts alongside
+// the other dialects. This file covers only what's specific to the ET-8500's
+// composed PARA. The ET-8500 is an A4 EcoTank Photo (flatbed-only, ESC/I-2 over
+// TLS). Its PARA reuses the ET-4800's gamma/CMX class bytes but, unlike the
+// ET-4800, carries the optional #QITOFF segment — so its flatbed PARA is the
+// ET-4800's 936 bytes plus 8 (944 total).
+
+describe("ET-8500 composed PARA size", () => {
+  it("flatbed is 944 bytes (ET-4800's 936 + 8 for the #QITOFF segment)", () => {
+    expect(composePara(makeParaSpec(entry, "flatbed", "jpg")).length).toBe(944);
+  });
+});
+
+describe("ET-8500 action invariance", () => {
+  it("flatbed JPG equals flatbed PDF byte-for-byte", () => {
+    const jpg = composePara(makeParaSpec(entry, "flatbed", "jpg"));
+    const pdf = composePara(makeParaSpec(entry, "flatbed", "pdf"));
+    expect(jpg.equals(pdf)).toBe(true);
+  });
+});

--- a/src/esci2/dialects/et-8500.test.ts
+++ b/src/esci2/dialects/et-8500.test.ts
@@ -9,9 +9,10 @@ const entry = REGISTRY.get(ET8500_FP)!;
 // The registry entry's static fields are asserted in registry.test.ts alongside
 // the other dialects. This file covers only what's specific to the ET-8500's
 // composed PARA. The ET-8500 is an A4 EcoTank Photo (flatbed-only, ESC/I-2 over
-// TLS). Its PARA reuses the ET-4800's gamma/CMX class bytes but, unlike the
-// ET-4800, carries the optional #QITOFF segment — so its flatbed PARA is the
-// ET-4800's 936 bytes plus 8 (944 total).
+// TLS). It pairs the TLS-sibling et4950-stock gamma with the ET-4800's
+// et4800-um08 CMX, and (unlike the ET-4800) carries the optional #QITOFF
+// segment — every gamma triplet is 804 bytes, so its flatbed PARA is still the
+// ET-4800's 936 bytes plus 8 for #QITOFF (944 total).
 
 describe("ET-8500 composed PARA size", () => {
   it("flatbed is 944 bytes (ET-4800's 936 + 8 for the #QITOFF segment)", () => {

--- a/src/esci2/dialects/et-8500.test.ts
+++ b/src/esci2/dialects/et-8500.test.ts
@@ -9,7 +9,8 @@ const entry = REGISTRY.get(ET8500_FP)!;
 // The registry entry's static fields are asserted in registry.test.ts alongside
 // the other dialects. This file covers only what's specific to the ET-8500's
 // composed PARA. The ET-8500 is an A4 EcoTank Photo (flatbed-only, ESC/I-2 over
-// TLS). It pairs the TLS-sibling et4950-stock gamma with the ET-4800's
+// both TLS and plain TCP across reporters). It pairs the TLS-sibling
+// et4950-stock gamma with the ET-4800's
 // et4800-um08 CMX, and (unlike the ET-4800) carries the optional #QITOFF
 // segment — every gamma triplet is 804 bytes, so its flatbed PARA is still the
 // ET-4800's 936 bytes plus 8 for #QITOFF (944 total).

--- a/src/esci2/dialects/registry.test.ts
+++ b/src/esci2/dialects/registry.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect } from "vitest";
 import { REGISTRY } from "./registry.js";
 
 describe("REGISTRY", () => {
-  it("contains exactly seven known fingerprints", () => {
-    expect(REGISTRY.size).toBe(7);
+  it("contains exactly eight known fingerprints", () => {
+    expect(REGISTRY.size).toBe(8);
   });
 
   it("includes ET-4950 family entry", () => {
@@ -74,6 +74,19 @@ describe("REGISTRY", () => {
     expect(e!.optionalSegments).toEqual({ qit: false, cct: false });
     expect(e!.fbExtents).toEqual({ x0: 0, y0: 0, w: 2481, h: 3506 });
     expect(e!.adfExtents).toEqual({ x0: 69, y0: 0, w: 2481, h: 3506 });
+  });
+
+  it("includes ET-8500 entry (flatbed-only, TLS, reuses ET-4800 class bytes)", () => {
+    const e = REGISTRY.get("05b5c7eaad217e9538883f3fffe9796464689a5d9006c5b3e3c3fd2c24e21467");
+    expect(e).toBeDefined();
+    expect(e!.sourceDetection).toBe("fixed-flatbed");
+    expect(e!.initPollIterations).toBe(3);
+    expect(e!.gmm).toBe("UG18");
+    expect(e!.gammaClass).toEqual({ jpg: "et4800-stock", pdf: "et4800-stock" });
+    expect(e!.cmxClass).toEqual({ jpg: "et4800-um08", pdf: "et4800-um08" });
+    expect(e!.optionalSegments).toEqual({ qit: true, cct: false });
+    expect(e!.fbExtents).toEqual({ x0: 0, y0: 0, w: 2481, h: 3506 });
+    expect(e!.adfExtents).toBeNull();
   });
 
   it("includes FF-680W entry (ADF-only, plain TCP)", () => {

--- a/src/esci2/dialects/registry.test.ts
+++ b/src/esci2/dialects/registry.test.ts
@@ -76,13 +76,13 @@ describe("REGISTRY", () => {
     expect(e!.adfExtents).toEqual({ x0: 69, y0: 0, w: 2481, h: 3506 });
   });
 
-  it("includes ET-8500 entry (flatbed-only, TLS, reuses ET-4800 class bytes)", () => {
+  it("includes ET-8500 entry (flatbed-only, TLS; TLS-sibling gamma + ET-4800 CMX)", () => {
     const e = REGISTRY.get("05b5c7eaad217e9538883f3fffe9796464689a5d9006c5b3e3c3fd2c24e21467");
     expect(e).toBeDefined();
     expect(e!.sourceDetection).toBe("fixed-flatbed");
     expect(e!.initPollIterations).toBe(3);
     expect(e!.gmm).toBe("UG18");
-    expect(e!.gammaClass).toEqual({ jpg: "et4800-stock", pdf: "et4800-stock" });
+    expect(e!.gammaClass).toEqual({ jpg: "et4950-stock", pdf: "et4950-stock" });
     expect(e!.cmxClass).toEqual({ jpg: "et4800-um08", pdf: "et4800-um08" });
     expect(e!.optionalSegments).toEqual({ qit: true, cct: false });
     expect(e!.fbExtents).toEqual({ x0: 0, y0: 0, w: 2481, h: 3506 });

--- a/src/esci2/dialects/registry.ts
+++ b/src/esci2/dialects/registry.ts
@@ -128,26 +128,28 @@ export const REGISTRY: ReadonlyMap<string, RegistryEntry> = new Map([
     },
   ],
   [
-    // ET-8500: A4 EcoTank Photo. Flatbed-only (CAPA reports ADF: N / duplex: N),
-    // ESC/I-2 over TLS. Mechanically an ET-2950 (TLS, flatbed-only, fixed-flatbed
-    // source detection, 3-cycle init poll) but its PARA-segment shape matches the
-    // ET-15000/ET-4800 family: CAPA advertises GMM "UG10UG18" and CMX "UNITUM08"
-    // with QIT present (PREFON OFF) and CCT absent. Its #FB AREA value
-    // "d850i0001170" is byte-identical to the ET-4800/ET-2750, so the A4 flatbed
-    // extents are reused from the ET-4800, and the CMX class bytes from the
-    // ET-4800's matching UNITUM08 variant (et4800-um08).
+    // ET-8500: A4 EcoTank Photo. Flatbed-only (CAPA reports ADF: N / duplex: N).
+    // Presents over ESC/I-2 on both TLS (issue #120, Peter-Maguire) and plain TCP
+    // (issue #123, anaxci) across reporters — identical CAPA fingerprint either
+    // way, so this one transport-agnostic entry serves both. Source detection and
+    // init poll mirror the ET-2950 (flatbed-only, fixed-flatbed, 3-cycle), but its
+    // PARA-segment shape matches the ET-15000/ET-4800 family: CAPA advertises GMM
+    // "UG10UG18" and CMX "UNITUM08" with QIT present (PREFON OFF) and CCT absent.
+    // Its #FB AREA value "d850i0001170" is byte-identical to the ET-4800/ET-2750,
+    // so the A4 flatbed extents are reused from the ET-4800, and the CMX class
+    // bytes from the ET-4800's matching UNITUM08 variant (et4800-um08).
     //
     // The gamma curve is NOT advertised in CAPA, so it can't be pinned from the
     // diagnostic the way extents/CMX/GMM can. We default it to the near-identity
-    // et4950-stock used by the actual TLS sibling (ET-4950/ET-2950) rather than
-    // the ET-4800's contrast-boosting curve: for an unknown photo scanner a flat
-    // curve is the lower-risk guess (if wrong it degrades mildly, vs crushing
-    // shadows). Speculative entry from the issue #120 diagnostic block (PID 1193,
-    // FW FB 2.00); the gamma especially wants live validation by the reporter,
-    // and a Frida capture would pin both the gamma and CMX bytes exactly.
+    // et4950-stock used by the TLS sibling (ET-4950/ET-2950) rather than the
+    // ET-4800's contrast-boosting curve: for an unknown photo scanner a flat curve
+    // is the lower-risk guess (if wrong it degrades mildly, vs crushing shadows).
+    // Originally speculative from the issue #120 diagnostic (PID 1193, FW FB 2.00);
+    // since confirmed working by the reporter (flatbed JPG + PDF, colours accurate,
+    // nothing washed out). A Frida capture would still pin the gamma/CMX exactly.
     "05b5c7eaad217e9538883f3fffe9796464689a5d9006c5b3e3c3fd2c24e21467",
     {
-      displayName: "ET-8500 (ESC/I-2 over TLS)",
+      displayName: "ET-8500 (ESC/I-2)",
       sourceDetection: "fixed-flatbed",
       initPollIterations: 3,
       fbExtents: { x0: 0, y0: 0, w: 2481, h: 3506 },

--- a/src/esci2/dialects/registry.ts
+++ b/src/esci2/dialects/registry.ts
@@ -134,10 +134,17 @@ export const REGISTRY: ReadonlyMap<string, RegistryEntry> = new Map([
     // ET-15000/ET-4800 family: CAPA advertises GMM "UG10UG18" and CMX "UNITUM08"
     // with QIT present (PREFON OFF) and CCT absent. Its #FB AREA value
     // "d850i0001170" is byte-identical to the ET-4800/ET-2750, so the A4 flatbed
-    // extents are reused from the ET-4800. The gamma/CMX class bytes are reused
-    // from the ET-4800 (closest UG10UG18/UNITUM08 sibling) pending a Frida capture
-    // of the ET-8500's own PARA. Speculative entry from the issue #120 diagnostic
-    // block (PID 1193, FW FB 2.00); awaiting live validation by the reporter.
+    // extents are reused from the ET-4800, and the CMX class bytes from the
+    // ET-4800's matching UNITUM08 variant (et4800-um08).
+    //
+    // The gamma curve is NOT advertised in CAPA, so it can't be pinned from the
+    // diagnostic the way extents/CMX/GMM can. We default it to the near-identity
+    // et4950-stock used by the actual TLS sibling (ET-4950/ET-2950) rather than
+    // the ET-4800's contrast-boosting curve: for an unknown photo scanner a flat
+    // curve is the lower-risk guess (if wrong it degrades mildly, vs crushing
+    // shadows). Speculative entry from the issue #120 diagnostic block (PID 1193,
+    // FW FB 2.00); the gamma especially wants live validation by the reporter,
+    // and a Frida capture would pin both the gamma and CMX bytes exactly.
     "05b5c7eaad217e9538883f3fffe9796464689a5d9006c5b3e3c3fd2c24e21467",
     {
       displayName: "ET-8500 (ESC/I-2 over TLS)",
@@ -146,7 +153,7 @@ export const REGISTRY: ReadonlyMap<string, RegistryEntry> = new Map([
       fbExtents: { x0: 0, y0: 0, w: 2481, h: 3506 },
       adfExtents: null,
       gmm: "UG18",
-      gammaClass: { jpg: "et4800-stock", pdf: "et4800-stock" },
+      gammaClass: { jpg: "et4950-stock", pdf: "et4950-stock" },
       cmxClass: { jpg: "et4800-um08", pdf: "et4800-um08" },
       optionalSegments: { qit: true, cct: false },
     },

--- a/src/esci2/dialects/registry.ts
+++ b/src/esci2/dialects/registry.ts
@@ -127,4 +127,28 @@ export const REGISTRY: ReadonlyMap<string, RegistryEntry> = new Map([
       paraProfile: "ff680w-adf",
     },
   ],
+  [
+    // ET-8500: A4 EcoTank Photo. Flatbed-only (CAPA reports ADF: N / duplex: N),
+    // ESC/I-2 over TLS. Mechanically an ET-2950 (TLS, flatbed-only, fixed-flatbed
+    // source detection, 3-cycle init poll) but its PARA-segment shape matches the
+    // ET-15000/ET-4800 family: CAPA advertises GMM "UG10UG18" and CMX "UNITUM08"
+    // with QIT present (PREFON OFF) and CCT absent. Its #FB AREA value
+    // "d850i0001170" is byte-identical to the ET-4800/ET-2750, so the A4 flatbed
+    // extents are reused from the ET-4800. The gamma/CMX class bytes are reused
+    // from the ET-4800 (closest UG10UG18/UNITUM08 sibling) pending a Frida capture
+    // of the ET-8500's own PARA. Speculative entry from the issue #120 diagnostic
+    // block (PID 1193, FW FB 2.00); awaiting live validation by the reporter.
+    "05b5c7eaad217e9538883f3fffe9796464689a5d9006c5b3e3c3fd2c24e21467",
+    {
+      displayName: "ET-8500 (ESC/I-2 over TLS)",
+      sourceDetection: "fixed-flatbed",
+      initPollIterations: 3,
+      fbExtents: { x0: 0, y0: 0, w: 2481, h: 3506 },
+      adfExtents: null,
+      gmm: "UG18",
+      gammaClass: { jpg: "et4800-stock", pdf: "et4800-stock" },
+      cmxClass: { jpg: "et4800-um08", pdf: "et4800-um08" },
+      optionalSegments: { qit: true, cct: false },
+    },
+  ],
 ]);


### PR DESCRIPTION
Closes #120 once validated.

## What

Adds a dialect registry entry for the **ET-8500** (A4 EcoTank Photo), which reaches the ESC/I-2-over-TLS path but had an unregistered CAPA fingerprint and so failed fast with `UnsupportedDialectError`.

## How it was derived

From the reporter's diagnostic block (PID 1193, FW FB 2.00, fingerprint `05b5c7ea…21467`):

- **Mechanics** mirror the **ET-2950** — TLS transport, flatbed-only (`ADF: N` / `duplex: N`), `fixed-flatbed` source detection, 3-cycle init poll.
- **PARA-segment shape** matches the **ET-15000/ET-4800** family — GMM `UG10UG18`, CMX `UNITUM08` present, QIT present (`PREFON OFF`), CCT absent.
- The reported `#FB AREA` value `d850i0001170` is **byte-identical** to the ET-4800/ET-2750, so the A4 flatbed extents (`2481×3506`) are reused from the ET-4800 — not a guess.
- **CMX** reuses the ET-4800's `et4800-um08` — the matching `UNITUM08` variant (its bytes differ from the `et2750`/`xp7100` variants).
- **Gamma** is the one field CAPA does *not* advertise, so it can't be pinned from the diagnostic. It defaults to the near-identity `et4950-stock` used by the actual **TLS sibling** (ET-4950/ET-2950) rather than the ET-4800's contrast-boosting curve — the lower-risk guess for an unknown photo scanner (a flat curve degrades mildly if wrong, where the contrast-boost curve crushes shadows).

Composed flatbed PARA is **944 bytes** (the ET-4800's 936 + 8 for the `#QITOFF` segment the ET-8500 advertises). Every gamma triplet is 804 bytes, so the gamma choice doesn't affect framing.

## Validation status

🟡 **Experimental — not yet confirmed on hardware.** Awaiting flatbed JPG/PDF validation from the issue reporter, with the **gamma curve** as the thing most worth eyeballing (overall brightness / shadow detail). A Frida capture would pin both the gamma and CMX bytes exactly.

## Tests

- `registry.test.ts`: count 7→8 + ET-8500 static-field assertions.
- `et-8500.test.ts`: 944-byte flatbed PARA size + JPG≡PDF byte-equivalence.
- Full suite green locally (743 passed, 2 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)