### PR TITLE
ci(docker): add workflow_dispatch to build a branch image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  # Manual trigger for building a branch into a throwaway GHCR image
+  # (e.g. ghcr.io/<repo>:<branch>) so a compatibility reporter can test an
+  # unmerged speculative-printer PR without polluting main or cutting a release.
+  # The merge job's `type=ref,event=branch` tag names the image after the ref;
+  # `latest` stays gated to v* tags, so a branch build never moves it.
+  workflow_dispatch:
 
 concurrency:
   group: docker-${{ github.ref }}


### PR DESCRIPTION
## What

Adds `workflow_dispatch` to the Docker workflow so any branch can be manually built into a throwaway GHCR image.

## Why

Compatibility PRs for printers we don't own (e.g. #121, ET-8500) are speculative until a reporter validates them on real hardware. Today the only ways to hand a reporter a testable image are merging to `main` or cutting a `v*` release — both undesirable for unverified code.

With this, `gh workflow run docker.yml --ref <branch>` publishes an image tagged after the ref (the merge job already emits `type=ref,event=branch`), e.g. `ghcr.io/mtheuma/epson2paperless:feat-et-8500-compat`. `latest` stays gated to `v*` tags, so a branch build never moves it.

Infra-only; no application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)