### PR TITLE
chore(deps): bump js-yaml to 4.2.0 (GHSA-h67p-54hq-rp68)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2833,10 +2833,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
Resolves the one open Dependabot alert ([#4](https://github.com/mtheuma/epson2paperless/security/dependabot/4) / CVE-2026-53550, GHSA-h67p-54hq-rp68).

## What
- Bumps transitive dep `js-yaml` `4.1.1 → 4.2.0`.
- Pulled in **dev-only** via `eslint → @eslint/eslintrc` (range `^4.1.1`, so 4.2.0 satisfies it). No runtime impact.
- Lockfile-only change.

## Why
Medium-severity advisory: quadratic-complexity DoS in merge-key handling via repeated aliases. Real-world exposure here is negligible (dev tooling parsing trusted ESLint config, not attacker-controlled YAML), but the fix is clean.

## Verification
- `npm audit` → 0 vulnerabilities
- `npm run lint` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)